### PR TITLE
Full cycle works!

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -37,30 +37,37 @@ type MigrationContext struct {
 	OriginalTableName string
 	AlterStatement    string
 
-	Noop          bool
-	TestOnReplica bool
+	CountTableRows          bool
+	AllowedRunningOnMaster  bool
+	SwitchToRowBinlogFormat bool
 
-	TableEngine                         string
-	CountTableRows                      bool
-	RowsEstimate                        int64
-	UsedRowsEstimateMethod              RowsEstimateMethod
 	ChunkSize                           int64
-	OriginalBinlogFormat                string
-	OriginalBinlogRowImage              string
-	AllowedRunningOnMaster              bool
-	InspectorConnectionConfig           *mysql.ConnectionConfig
-	ApplierConnectionConfig             *mysql.ConnectionConfig
-	StartTime                           time.Time
-	RowCopyStartTime                    time.Time
-	CurrentLag                          int64
 	MaxLagMillisecondsThrottleThreshold int64
 	ThrottleFlagFile                    string
 	ThrottleAdditionalFlagFile          string
-	TotalRowsCopied                     int64
-	isThrottled                         bool
-	throttleReason                      string
-	throttleMutex                       *sync.Mutex
 	MaxLoad                             map[string]int64
+
+	Noop          bool
+	TestOnReplica bool
+	OkToDropTable bool
+
+	TableEngine               string
+	RowsEstimate              int64
+	UsedRowsEstimateMethod    RowsEstimateMethod
+	OriginalBinlogFormat      string
+	OriginalBinlogRowImage    string
+	InspectorConnectionConfig *mysql.ConnectionConfig
+	ApplierConnectionConfig   *mysql.ConnectionConfig
+	StartTime                 time.Time
+	RowCopyStartTime          time.Time
+	LockTablesStartTime       time.Time
+	RenameTablesStartTime     time.Time
+	RenameTablesEndTime       time.Time
+	CurrentLag                int64
+	TotalRowsCopied           int64
+	isThrottled               bool
+	throttleReason            string
+	throttleMutex             *sync.Mutex
 
 	OriginalTableColumns             *sql.ColumnList
 	OriginalTableUniqueKeys          [](*sql.UniqueKey)

--- a/go/cmd/gh-osc/main.go
+++ b/go/cmd/gh-osc/main.go
@@ -32,7 +32,9 @@ func main() {
 
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration tables are not swapped; gh-osc issues `STOP SLAVE` and you can compare the two tables for building trust")
+	flag.BoolVar(&migrationContext.OkToDropTable, "ok-to-drop-table", false, "Shall the tool drop the old table at end of operation. DROPping tables can be a long locking operation, which is why I'm not doing it by default. I'm an online tool, yes?")
 
+	flag.BoolVar(&migrationContext.SwitchToRowBinlogFormat, "switch-to-rbr", false, "let this tool automatically switch binary log format to 'ROW' on the replica, if needed. The format will NOT be switched back. I'm too scared to do that, and wish to protect you if you happen to execute another migration while this one is running")
 	flag.Int64Var(&migrationContext.ChunkSize, "chunk-size", 1000, "amount of rows to handle in each iteration (allowed range: 100-100,000)")
 	if migrationContext.ChunkSize < 100 {
 		migrationContext.ChunkSize = 100

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -71,9 +71,10 @@ func (this *ColumnList) Len() int {
 
 // UniqueKey is the combination of a key's name and columns
 type UniqueKey struct {
-	Name        string
-	Columns     ColumnList
-	HasNullable bool
+	Name            string
+	Columns         ColumnList
+	HasNullable     bool
+	IsAutoIncrement bool
 }
 
 // IsPrimary checks if this unique key is primary
@@ -86,7 +87,11 @@ func (this *UniqueKey) Len() int {
 }
 
 func (this *UniqueKey) String() string {
-	return fmt.Sprintf("%s: %s; has nullable: %+v", this.Name, this.Columns, this.HasNullable)
+	description := this.Name
+	if this.IsAutoIncrement {
+		description = fmt.Sprintf("%s (auto_incrmenet)", description)
+	}
+	return fmt.Sprintf("%s: %s; has nullable: %+v", description, this.Columns.Names, this.HasNullable)
 }
 
 type ColumnValues struct {


### PR DESCRIPTION
At this point we have a complete cycle. The tool works.
- Added `ok-to-drop-table` flag
- Added `switch-to-rbr` flag; applying binlog format change if needed
- Using dedicated db instance for locking & renaming on applier (must be used from within same connection)
- Heartbeat now uses `time.RFC3339Nano`
- Swap tables works! Caveat: short table outage
- `--test-on-replica` works!
- retries: using `panicAbort`: from any goroutine, regardless of context, it is possible to terminate the operation
- Reintroduced changelog events listener on streamer. This is the correct implementation.
