### PR TITLE
exact-rowcount implices updating number of rows as we make progress

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -528,7 +528,7 @@ func (this *Migrator) printStatus() {
 	elapsedTime := this.migrationContext.ElapsedTime()
 	elapsedSeconds := int64(elapsedTime.Seconds())
 	totalRowsCopied := this.migrationContext.GetTotalRowsCopied()
-	rowsEstimate := this.migrationContext.RowsEstimate
+	rowsEstimate := atomic.LoadInt64(&this.migrationContext.RowsEstimate)
 	progressPct := 100.0 * float64(totalRowsCopied) / float64(rowsEstimate)
 
 	shouldPrintStatus := false


### PR DESCRIPTION
This keeps the status message up to date with actual number of rows in table.
