### PR TITLE
initial, simple solution to our-of-order applying of DML events

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -121,17 +121,17 @@ func GetMigrationContext() *MigrationContext {
 
 // GetGhostTableName generates the name of ghost table, based on original table name
 func (this *MigrationContext) GetGhostTableName() string {
-	return fmt.Sprintf("_%s_New", this.OriginalTableName)
+	return fmt.Sprintf("_%s_gst", this.OriginalTableName)
 }
 
 // GetOldTableName generates the name of the "old" table, into which the original table is renamed.
 func (this *MigrationContext) GetOldTableName() string {
-	return fmt.Sprintf("_%s_Old", this.OriginalTableName)
+	return fmt.Sprintf("_%s_old", this.OriginalTableName)
 }
 
 // GetChangelogTableName generates the name of changelog table, based on original table name
 func (this *MigrationContext) GetChangelogTableName() string {
-	return fmt.Sprintf("_%s_OSC", this.OriginalTableName)
+	return fmt.Sprintf("_%s_osc", this.OriginalTableName)
 }
 
 // GetVoluntaryLockName returns a name of a voluntary lock to be used throughout

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -107,3 +107,25 @@ func GetMasterConnectionConfigSafe(connectionConfig *ConnectionConfig, visitedKe
 	visitedKeys.AddKey(masterConfig.Key)
 	return GetMasterConnectionConfigSafe(masterConfig, visitedKeys)
 }
+
+func GetReadBinlogCoordinates(db *gosql.DB) (readBinlogCoordinates *BinlogCoordinates, err error) {
+	err = sqlutils.QueryRowsMap(db, `show slave status`, func(m sqlutils.RowMap) error {
+		readBinlogCoordinates = &BinlogCoordinates{
+			LogFile: m.GetString("Master_Log_File"),
+			LogPos:  m.GetInt64("Read_Master_Log_Pos"),
+		}
+		return nil
+	})
+	return readBinlogCoordinates, err
+}
+
+func GetSelfBinlogCoordinates(db *gosql.DB) (selfBinlogCoordinates *BinlogCoordinates, err error) {
+	err = sqlutils.QueryRowsMap(db, `show master status`, func(m sqlutils.RowMap) error {
+		selfBinlogCoordinates = &BinlogCoordinates{
+			LogFile: m.GetString("File"),
+			LogPos:  m.GetInt64("Position"),
+		}
+		return nil
+	})
+	return selfBinlogCoordinates, err
+}


### PR DESCRIPTION
Storyline: https://github.com/github/gh-osc/issues/30

This is the first and potentially last change so as to solve the out-of-order issue.
The change is to not have the DML event func run asynchronously. They were originally introduced to run synchronously when the heartbeat mechanism was using binlog events as well. That turned out to be a wrong implementation, and heartbeat now uses plain old table queries.

There is a buffer of `100` event entries that will allow for a queue buildup of DML events. See https://github.com/github/gh-osc/blob/master/go/logic/migrator.go#L34 and https://github.com/github/gh-osc/blob/master/go/logic/migrator.go#L69

So up to `100` unhandled events can still build up without further blocking DML events such as `status` entries. I'm not at all sure at this point we should care about the DML events blocking other events. Running with this small change.
