### PR TITLE
some messagages are now Info instead of Debug

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -568,15 +568,15 @@ func (this *Applier) StopSlaveNicely() error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("Replication stopped at %+v. Will wait for SQL thread to apply", *binlogCoordinates)
+	log.Infof("Replication stopped at %+v. Will wait for SQL thread to apply", *binlogCoordinates)
 	if err := this.MasterPosWait(binlogCoordinates); err != nil {
 		return err
 	}
-	log.Debugf("Replication SQL thread applied all events")
+	log.Infof("Replication SQL thread applied all events")
 	if selfBinlogCoordinates, err := mysql.GetSelfBinlogCoordinates(this.db); err != nil {
 		return err
 	} else {
-		log.Debugf("Self binlog coordinates: %+v", *selfBinlogCoordinates)
+		log.Infof("Self binlog coordinates: %+v", *selfBinlogCoordinates)
 	}
 	return nil
 }


### PR DESCRIPTION
I was getting a particular run fail on `Timeout waiting on master_pos_wait()`. While this is a potentially valid failure, I'm unsure the case was indeed a failure case. Moreover, with `--verbose` there's no details on this.
While still investigating the cause of this event, I'm adding more visibility into the case.
