### PR TITLE
postpone-swap-tables-flag-file

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -52,6 +52,7 @@ type MigrationContext struct {
 	ThrottleFlagFile                    string
 	ThrottleAdditionalFlagFile          string
 	MaxLoad                             map[string]int64
+	PostponeSwapTablesFlagFile          string
 	SwapTablesTimeoutSeconds            int64
 
 	Noop                    bool

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -7,6 +7,7 @@ package base
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"time"
 )
@@ -22,4 +23,11 @@ func PrettifyDurationOutput(d time.Duration) string {
 	result := fmt.Sprintf("%s", d)
 	result = prettifyDurationRegexp.ReplaceAllString(result, "")
 	return result
+}
+
+func FileExists(fileName string) bool {
+	if _, err := os.Stat(fileName); err == nil {
+		return true
+	}
+	return false
 }

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -53,6 +53,8 @@ func main() {
 	throttleControlReplicas := flag.String("throttle-control-replicas", "", "List of replicas on which to check for lag; comma delimited. Example: myhost1.com:3306,myhost2.com,myhost3.com:3307")
 	flag.StringVar(&migrationContext.ThrottleFlagFile, "throttle-flag-file", "", "operation pauses when this file exists; hint: use a file that is specific to the table being altered")
 	flag.StringVar(&migrationContext.ThrottleAdditionalFlagFile, "throttle-additional-flag-file", "/tmp/gh-ost.throttle", "operation pauses when this file exists; hint: keep default, use for throttling multiple gh-ost operations")
+	flag.StringVar(&migrationContext.PostponeSwapTablesFlagFile, "postpone-swap-tables-flag-file", "", "while this file exists, migration will postpone the final stage of swapping tables, and will keep on syncing the ghost table. Swapping would be ready to perform the moment the file is deleted.")
+
 	maxLoad := flag.String("max-load", "", "Comma delimited status-name=threshold. e.g: 'Threads_running=100,Threads_connected=500'")
 	quiet := flag.Bool("quiet", false, "quiet")
 	verbose := flag.Bool("verbose", false, "verbose")
@@ -117,7 +119,7 @@ func main() {
 		log.Fatale(err)
 	}
 
-	log.Info("starting gh-ost %+v", AppVersion)
+	log.Infof("starting gh-ost %+v", AppVersion)
 
 	migrator := logic.NewMigrator()
 	err := migrator.Migrate()


### PR DESCRIPTION
- Support for `--postpone-swap-tables-flag-file`: while this file exists, final table swap does not take place, and the ghost table keeps being synchronized
- Fixed version printing
- `rowCopyCompleteFlag` is a hint that allows us to escape the infinite loop of rowcopy once we are sure we have reached the end
