### PR TITLE
Solving credentials issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="0.7.2"
+RELEASE_VERSION="0.7.3"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -23,8 +23,8 @@ func main() {
 
 	flag.StringVar(&migrationContext.InspectorConnectionConfig.Key.Hostname, "host", "127.0.0.1", "MySQL hostname (preferably a replica, not the master)")
 	flag.IntVar(&migrationContext.InspectorConnectionConfig.Key.Port, "port", 3306, "MySQL port (preferably a replica, not the master)")
-	flag.StringVar(&migrationContext.InspectorConnectionConfig.User, "user", "root", "MySQL user")
-	flag.StringVar(&migrationContext.InspectorConnectionConfig.Password, "password", "", "MySQL password")
+	flag.StringVar(&migrationContext.CliUser, "user", "", "MySQL user")
+	flag.StringVar(&migrationContext.CliPassword, "password", "", "MySQL password")
 	flag.StringVar(&migrationContext.ConfigFile, "conf", "", "Config file")
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
@@ -118,6 +118,7 @@ func main() {
 	if err := migrationContext.ReadMaxLoad(*maxLoad); err != nil {
 		log.Fatale(err)
 	}
+	migrationContext.ApplyCredentials()
 
 	log.Infof("starting gh-ost %+v", AppVersion)
 


### PR DESCRIPTION
Storyline: #25 
- user/password provided in CLI override those in config file
- user no longer defaults to .
- config is now part of Context, and is protected by mutex
