### PR TITLE
Handling gh-ost replication timeouts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="0.7.16"
+RELEASE_VERSION="0.7.17"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/go/binlog/binlog_reader.go
+++ b/go/binlog/binlog_reader.go
@@ -5,14 +5,11 @@
 
 package binlog
 
-import (
-	"github.com/github/gh-ost/go/mysql"
-)
+import ()
 
 // BinlogReader is a general interface whose implementations can choose their methods of reading
 // a binary log file and parsing it into binlog entries
 type BinlogReader interface {
 	StreamEvents(canStopStreaming func() bool, entriesChannel chan<- *BinlogEntry) error
-	GetCurrentBinlogCoordinates() *mysql.BinlogCoordinates
 	Reconnect() error
 }


### PR DESCRIPTION
`gh-ost` uses https://github.com/siddontang/go-mysql/ to impose as a replica. When this replica connection times out, `gh-ost` initiates a brand new replica (destroying and forgetting about the old connection), starting at same binlog file, pos `4`, and skipping queries up to the point where they were executed.

With RBR once can't just point back into the exact same coordinates one left off at at time of breakage. The events are not atomic. A `Rows_Event` is preceded by a `Table_map` event, which is preceded by a `Begin` event. You can't issue the `Rows_event` without having the associated `Table_map`. I'm still unsure about the `Begin` event but am not willing to take chances on other dependencies.

So the solution is: whenever we apply a `Row_event`, we remember take note of a unique identifier of the event: its coordinates.

> Actually, these are the "next coordinates" of the event, but this does not matter; we merely pick a unique identifier of the event, and this happens to be the "next coordinates"

When replica disconnects, we reconnect at `same-binlog.XXXXX:4`. We then process all the events as normal, but skip applying row events that are known to have been processed (their coordinates are smaller than the one we have). We resume from an event we have not processed before.

This means wasting cycles getting to our previous positions, but with the benefit of properly processing `table_map` events and whatever else is out there in the RBR.
