### PR TITLE
support for marking point-of-interest in migration

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -606,6 +606,8 @@ func (this *Migrator) printStatus() {
 		shouldPrintStatus = (elapsedSeconds%5 == 0)
 	} else if elapsedSeconds <= 180 {
 		shouldPrintStatus = (elapsedSeconds%5 == 0)
+	} else if this.migrationContext.TimeSincePointOfInterest() <= 60 {
+		shouldPrintStatus = (elapsedSeconds%5 == 0)
 	} else {
 		shouldPrintStatus = (elapsedSeconds%30 == 0)
 	}


### PR DESCRIPTION
This allows us to mark points of interest during migration process; `gh-ost` will print status more aggressively immediately after such points.

Except for just after beginning and shortly before end of migration, status is printed twice a minute, which allows reasonable control yet not too spammy on logs.
In some cases we might wish to have spiked status frequency. One such case is when the `gh-ost` replica disconnects (timeout?) and reconnects. We want to see better what happens at such time.
