### PR TITLE
cut-over flag and other stuff

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="0.8.2"
+RELEASE_VERSION="0.8.3"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -28,6 +28,14 @@ const (
 	CountRowsEstimate                          = "CountRowsEstimate"
 )
 
+type CutOver int
+
+const (
+	CutOverTwoStep CutOver = 1
+	CutOverVoluntaryLock
+	CutOverUdfWait
+)
+
 const (
 	maxRetries = 10
 )
@@ -63,9 +71,9 @@ type MigrationContext struct {
 	Noop                    bool
 	TestOnReplica           bool
 	OkToDropTable           bool
-	QuickAndBumpySwapTables bool
 	InitiallyDropOldTable   bool
 	InitiallyDropGhostTable bool
+	CutOverType             CutOver
 
 	TableEngine               string
 	RowsEstimate              int64

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -59,9 +59,9 @@ func main() {
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration tables are not swapped; gh-ost issues `STOP SLAVE` and you can compare the two tables for building trust")
 	flag.BoolVar(&migrationContext.OkToDropTable, "ok-to-drop-table", false, "Shall the tool drop the old table at end of operation. DROPping tables can be a long locking operation, which is why I'm not doing it by default. I'm an online tool, yes?")
-	flag.BoolVar(&migrationContext.QuickAndBumpySwapTables, "quick-and-bumpy-swap-tables", false, "Shall the tool issue a faster swapping of tables at end of operation, at the cost of causing a brief period of time when the table does not exist? This will cause queries on table to fail with error (as opposed to being locked for a longer duration of a swap)")
 	flag.BoolVar(&migrationContext.InitiallyDropOldTable, "initially-drop-old-table", false, "Drop a possibly existing OLD table (remains from a previous run?) before beginning operation. Default is to panic and abort if such table exists")
 	flag.BoolVar(&migrationContext.InitiallyDropGhostTable, "initially-drop-ghost-table", false, "Drop a possibly existing Ghost table (remains from a previous run?) before beginning operation. Default is to panic and abort if such table exists")
+	cutOver := flag.String("cut-over", "", "(mandatory) choose cut-over type (two-step, voluntary-lock)")
 
 	flag.BoolVar(&migrationContext.SwitchToRowBinlogFormat, "switch-to-rbr", false, "let this tool automatically switch binary log format to 'ROW' on the replica, if needed. The format will NOT be switched back. I'm too scared to do that, and wish to protect you if you happen to execute another migration while this one is running")
 	flag.Int64Var(&migrationContext.ChunkSize, "chunk-size", 1000, "amount of rows to handle in each iteration (allowed range: 100-100,000)")
@@ -129,8 +129,15 @@ func main() {
 	if migrationContext.AllowedRunningOnMaster && migrationContext.TestOnReplica {
 		log.Fatalf("--allow-on-master and --test-on-replica are mutually exclusive")
 	}
-	if migrationContext.QuickAndBumpySwapTables && migrationContext.TestOnReplica {
-		log.Fatalf("--quick-and-bumpy-swap-tables and --test-on-replica are mutually exclusive (the former implies migrating on master)")
+	switch *cutOver {
+	case "two-step":
+		migrationContext.CutOverType = base.CutOverTwoStep
+	case "voluntary-lock":
+		migrationContext.CutOverType = base.CutOverVoluntaryLock
+	case "":
+		log.Fatalf("--cut-over must be specified")
+	default:
+		log.Fatalf("Unknown cut-over: %s", *cutOver)
 	}
 	if err := migrationContext.ReadConfigFile(); err != nil {
 		log.Fatale(err)

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -63,14 +63,8 @@ func (this *Inspector) ValidateOriginalTable() (err error) {
 	if err := this.validateTableForeignKeys(); err != nil {
 		return err
 	}
-	if this.migrationContext.CountTableRows {
-		if err := this.countTableRows(); err != nil {
-			return err
-		}
-	} else {
-		if err := this.estimateTableRowsViaExplain(); err != nil {
-			return err
-		}
+	if err := this.estimateTableRowsViaExplain(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -99,6 +93,8 @@ func (this *Inspector) InspectOriginalTable() (err error) {
 	return nil
 }
 
+// InspectOriginalAndGhostTables compares original and ghost tables to see whether the migration
+// makes sense and is valid. It extracts the list of shared columns and the chosen migration unique key
 func (this *Inspector) InspectOriginalAndGhostTables() (err error) {
 	this.migrationContext.GhostTableColumns, this.migrationContext.GhostTableUniqueKeys, err = this.InspectTableColumnsAndUniqueKeys(this.migrationContext.GetGhostTableName())
 	if err != nil {
@@ -353,7 +349,7 @@ func (this *Inspector) estimateTableRowsViaExplain() error {
 	return nil
 }
 
-func (this *Inspector) countTableRows() error {
+func (this *Inspector) CountTableRows() error {
 	log.Infof("As instructed, I'm issuing a SELECT COUNT(*) on the table. This may take a while")
 	query := fmt.Sprintf(`select /* gh-ost */ count(*) as rows from %s.%s`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
 	if err := this.db.QueryRow(query).Scan(&this.migrationContext.RowsEstimate); err != nil {


### PR DESCRIPTION
- requiring `--cut-over` argument to be `two-step|voluntary-lock` (will add `udf-wait` once it is ready)
  The idea is that the user is forced to specify the cut-over type they wish to use, given that each type has some drawbacks.
- More data in status hint
- `select count(*)` is deferred till after we validate migration is valid. Also, it is skipped on `--noop`
