### PR TITLE
adding interactive user commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="0.8.3"
+RELEASE_VERSION="0.8.4"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -1,0 +1,59 @@
+# Interactive commands
+
+`gh-ost` is designed to be operations friendly. To that effect, it allows the user to control its behavior even while it is running.
+
+### Interactive interfaces
+
+`gh-ost` listens on:
+
+- Unix socket file: either provided via `--serve-socket-file` or determined by `gh-ost`, this interface is always up.
+  When self-determined, `gh-ost` will advertise the identify of socket file upon start up and throughout the migration.
+- TCP: if `--serve-tcp-port` is provided
+
+Both interfaces may serve at the same time. Both respond to simple text command, which makes it easy to interact via shell.
+
+### Known commands
+
+- `help`: shows a brief list of available commands
+- `status`: returns a status summary of migration progress and configuration
+- `throttle`: force migration suspend
+- `no-throttle`: cancel forced suspension (though other throttling reasons may still apply)
+- `chunk-size=<newsize>`: modify the `chunk-size`; applies on next running copy-iteration
+
+### Examples
+
+While migration is running:
+
+```shell
+$ echo status | nc -U /tmp/gh-ost.test.sample_data_0.sock
+# Migrating `test`.`sample_data_0`; Ghost table is `test`.`_sample_data_0_gst`
+# Migration started at Tue Jun 07 11:45:16 +0200 2016
+# chunk-size: 200; max lag: 1500ms; max-load: map[Threads_connected:20]
+# Throttle additional flag file: /tmp/gh-ost.throttle
+# Serving on unix socket: /tmp/gh-ost.test.sample_data_0.sock
+# Serving on TCP port: 10001
+Copy: 0/2915 0.0%; Applied: 0; Backlog: 0/100; Elapsed: 40s(copy), 41s(total); streamer: mysql-bin.000550:49942; ETA: throttled, flag-file
+```
+
+```shell
+$ echo "chunk-size=250" | nc -U /tmp/gh-ost.test.sample_data_0.sock
+# Migrating `test`.`sample_data_0`; Ghost table is `test`.`_sample_data_0_gst`
+# Migration started at Tue Jun 07 11:56:03 +0200 2016
+# chunk-size: 250; max lag: 1500ms; max-load: map[Threads_connected:20]
+# Throttle additional flag file: /tmp/gh-ost.throttle
+# Serving on unix socket: /tmp/gh-ost.test.sample_data_0.sock
+# Serving on TCP port: 10001
+```
+
+```shell
+$ echo throttle | nc -U /tmp/gh-ost.test.sample_data_0.sock
+
+$ echo status | nc -U /tmp/gh-ost.test.sample_data_0.sock
+# Migrating `test`.`sample_data_0`; Ghost table is `test`.`_sample_data_0_gst`
+# Migration started at Tue Jun 07 11:56:03 +0200 2016
+# chunk-size: 250; max lag: 1500ms; max-load: map[Threads_connected:20]
+# Throttle additional flag file: /tmp/gh-ost.throttle
+# Serving on unix socket: /tmp/gh-ost.test.sample_data_0.sock
+# Serving on TCP port: 10001
+Copy: 0/2915 0.0%; Applied: 0; Backlog: 0/100; Elapsed: 59s(copy), 59s(total); streamer: mysql-bin.000551:68067; ETA: throttled, commanded by user
+```

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -64,9 +64,13 @@ type MigrationContext struct {
 	ThrottleControlReplicaKeys          *mysql.InstanceKeyMap
 	ThrottleFlagFile                    string
 	ThrottleAdditionalFlagFile          string
+	ThrottleCommandedByUser             int64
 	MaxLoad                             map[string]int64
 	PostponeSwapTablesFlagFile          string
 	SwapTablesTimeoutSeconds            int64
+
+	ServeSocketFile string
+	ServeTCPPort    int64
 
 	Noop                    bool
 	TestOnReplica           bool
@@ -240,6 +244,16 @@ func (this *MigrationContext) TimeSincePointOfInterest() time.Duration {
 	defer this.pointOfInterestTimeMutex.Unlock()
 
 	return time.Now().Sub(this.pointOfInterestTime)
+}
+
+func (this *MigrationContext) SetChunkSize(chunkSize int64) {
+	if chunkSize < 100 {
+		chunkSize = 100
+	}
+	if chunkSize > 100000 {
+		chunkSize = 100000
+	}
+	atomic.StoreInt64(&this.ChunkSize, chunkSize)
 }
 
 func (this *MigrationContext) SetThrottled(throttle bool, reason string) {

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -373,7 +373,7 @@ func (this *Applier) CalculateNextIterationRangeEndValues() (hasFurtherRange boo
 		this.migrationContext.UniqueKey.Columns.Names,
 		this.migrationContext.MigrationIterationRangeMinValues.AbstractValues(),
 		this.migrationContext.MigrationRangeMaxValues.AbstractValues(),
-		this.migrationContext.ChunkSize,
+		atomic.LoadInt64(&this.migrationContext.ChunkSize),
 		this.migrationContext.GetIteration() == 0,
 		fmt.Sprintf("iteration:%d", this.migrationContext.GetIteration()),
 	)

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -1,0 +1,89 @@
+/*
+   Copyright 2016 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package logic
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/github/gh-ost/go/base"
+	"github.com/outbrain/golib/log"
+)
+
+type onCommandFunc func(command string, writer *bufio.Writer) error
+
+// Server listens for requests on a socket file or via TCP
+type Server struct {
+	migrationContext *base.MigrationContext
+	unixListener     net.Listener
+	tcpListener      net.Listener
+	onCommand        onCommandFunc
+}
+
+func NewServer(onCommand onCommandFunc) *Server {
+	return &Server{
+		migrationContext: base.GetMigrationContext(),
+		onCommand:        onCommand,
+	}
+}
+
+func (this *Server) BindSocketFile() (err error) {
+	if this.migrationContext.ServeSocketFile == "" {
+		return nil
+	}
+	if base.FileExists(this.migrationContext.ServeSocketFile) {
+		os.Remove(this.migrationContext.ServeSocketFile)
+	}
+	this.unixListener, err = net.Listen("unix", this.migrationContext.ServeSocketFile)
+	if err != nil {
+		return err
+	}
+	log.Infof("Listening on unix socket file: %s", this.migrationContext.ServeSocketFile)
+	return nil
+}
+
+func (this *Server) BindTCPPort() (err error) {
+	if this.migrationContext.ServeTCPPort == 0 {
+		return nil
+	}
+	this.tcpListener, err = net.Listen("tcp", fmt.Sprintf(":%d", this.migrationContext.ServeTCPPort))
+	if err != nil {
+		return err
+	}
+	log.Infof("Listening on tcp port: %d", this.migrationContext.ServeTCPPort)
+	return nil
+}
+
+func (this *Server) Serve() (err error) {
+	go func() {
+		for {
+			conn, err := this.unixListener.Accept()
+			if err != nil {
+				log.Errore(err)
+			}
+			go this.handleConnection(conn)
+		}
+	}()
+	go func() {
+		for {
+			conn, err := this.tcpListener.Accept()
+			if err != nil {
+				log.Errore(err)
+			}
+			go this.handleConnection(conn)
+		}
+	}()
+
+	return nil
+}
+
+func (this *Server) handleConnection(conn net.Conn) (err error) {
+	defer conn.Close()
+	command, _, err := bufio.NewReader(conn).ReadLine()
+	return this.onCommand(string(command), bufio.NewWriter(conn))
+}


### PR DESCRIPTION
`gh-ost` listens on:
- Unix socket file: either provided via `--serve-socket-file` or determined by `gh-ost`, this interface is always up.
  When self-determined, `gh-ost` will advertise the identify of socket file upon start up and throughout the migration.
- TCP: if `--serve-tcp-port` is provided
### Known commands
- `help`: shows a brief list of available commands
- `status`: returns a status summary of migration progress and configuration
- `throttle`: force migration suspend
- `no-throttle`: cancel forced suspension (though other throttling reasons may still apply)
- `chunk-size=<newsize>`: modify the `chunk-size`; applies on next running copy-iteration
