### PR TITLE
suuporting dynamic reconfiguration of max-load

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="0.8.7"
+RELEASE_VERSION="0.8.8"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -19,6 +19,8 @@ Both interfaces may serve at the same time. Both respond to simple text command,
 - `throttle`: force migration suspend
 - `no-throttle`: cancel forced suspension (though other throttling reasons may still apply)
 - `chunk-size=<newsize>`: modify the `chunk-size`; applies on next running copy-iteration
+- `max-load=<max-load-thresholds>`: modify the `max-load` config; applies on next running copy-iteration
+  The `max-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`. For example: `Threads_running=50,threads_connected=1000`, and you would then write/echo `max-load=Threads_running=50,threads_connected=1000` to the socket.
 
 ### Examples
 

--- a/doc/perks.md
+++ b/doc/perks.md
@@ -12,13 +12,22 @@ You started with a `chunk-size=5000` but you find out it's too much. You want to
 $ echo "chunk-size=250" | nc -U /tmp/gh-ost.test.sample_data_0.sock
 ```
 
+Likewise, you can change the `max-load` configuration:
+
+```shell
+$ echo "max-load=Threads_running=50,threads_connected=1000" | nc -U /tmp/gh-ost.test.sample_data_0.sock
+```
+
+The `max-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`.
+In case of parsing error the command is ignored.
+
 Read more about [interactive commands](interactive-commands.md)
 
 ### What's the status?
 
 You do not have to have access to the `screen` where the migration is issued. You have two ways to get current status:
 
-0. Use [interactive commands](interactive-commands.md). Via unix socket file or via `TCP` you can get current status:
+1. Use [interactive commands](interactive-commands.md). Via unix socket file or via `TCP` you can get current status:
 
 ```shell
 $ echo status | nc -U /tmp/gh-ost.test.sample_data_0.sock
@@ -31,7 +40,7 @@ $ echo status | nc -U /tmp/gh-ost.test.sample_data_0.sock
 Copy: 0/2915 0.0%; Applied: 0; Backlog: 0/100; Elapsed: 40s(copy), 41s(total); streamer: mysql-bin.000550:49942; ETA: throttled, flag-file
 ```
 
-0. `gh-ost` creates and uses a changelog table for internal bookkeeping. This table has the `_osc` suffix (the tool creates and announces this table upon startup) If you like, you can SQL your status:
+2. `gh-ost` creates and uses a changelog table for internal bookkeeping. This table has the `_osc` suffix (the tool creates and announces this table upon startup) If you like, you can SQL your status:
 
 ```
 > select * from _sample_data_0_osc order by id desc limit 1 \G

--- a/doc/why-triggerless.md
+++ b/doc/why-triggerless.md
@@ -45,6 +45,10 @@ Thus, triggers must keep operating. On busy servers, we have seen that even as t
 
 Read more about [`gh-ost` throttling](throttle.md)
 
+### Triggers, multiple migrations
+
+We are interested in being able to run multiple concurrent migrations (not on the same table, of course). Given all the above, we do not have trust that running multiple trigger-based migrations is a safe operation. In our current, past and shared experiences we have never done so; we are unaware of anyone who is doing so.
+
 ### Trigger based migration, no reliable production test
 
 We sometimes wish to experiment with a migration, or know in advance how much time it would take. A trigger-based solution allows us to run a migration on a replica, provided it uses Statement Based Replication.


### PR DESCRIPTION
via interactive commands (TCP/unix socket)

``` shell
$ echo "max-load=Threads_running=50,threads_connected=1000" | nc -U /tmp/gh-ost.test.sample_data_0.sock
```

The `max-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`.
In case of parsing error the command is ignored.
