### PR TITLE
test-on-replica to invoke cut-over swap

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="0.8.8"
+RELEASE_VERSION="0.8.9"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -31,9 +31,9 @@ const (
 type CutOver int
 
 const (
-	CutOverTwoStep CutOver = 1
-	CutOverVoluntaryLock
-	CutOverUdfWait
+	CutOverTwoStep       CutOver = iota
+	CutOverVoluntaryLock         = iota
+	CutOverUdfWait               = iota
 )
 
 const (

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -389,14 +389,25 @@ func (this *Migrator) stopWritesAndCompleteMigration() (err error) {
 	)
 
 	if this.migrationContext.TestOnReplica {
-		return this.stopWritesAndCompleteMigrationOnReplica()
+		// return this.stopWritesAndCompleteMigrationOnReplica()
+
+		// With `--test-on-replica` we stop replication thread, and then proceed to use
+		// the same cut-over phase as the master would use. That means we take locks
+		// and swap the tables.
+		// The difference is that we will later swap the tables back.
+		log.Debugf("testing on replica. Stopping replication IO thread")
+		if err := this.retryOperation(this.applier.StopSlaveNicely); err != nil {
+			return err
+		}
+		// We're merly testing, we don't want to keep this state. Rollback the renames as possible
+		defer this.applier.RenameTablesRollback()
 	}
-	// Running on master
+
 	if this.migrationContext.CutOverType == base.CutOverTwoStep {
 		return this.stopWritesAndCompleteMigrationOnMasterQuickAndBumpy()
 	}
 
-	{
+	if this.migrationContext.CutOverType == base.CutOverVoluntaryLock {
 		// Lock-based solution: we use low timeout and multiple attempts. But for
 		// each failed attempt, we throttle until replication lag is back to normal
 		if err := this.retryOperation(


### PR DESCRIPTION
With this PR, the `--test-on-replica` flow includes a normal cut-over indicated by `--cut-over`. This means the tets-on-replica flows uses complete same flow as in on master, with the addition of:
- Stopping the replication IO thread prior to cut-over
- Rolling back the table rename at the end (we want to restore to original state)
