### PR TITLE
capped streamer retries

### DIFF
--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -63,15 +63,6 @@ func (this *GoMySQLReader) ConnectBinlogStreamer(coordinates mysql.BinlogCoordin
 	return err
 }
 
-func (this *GoMySQLReader) Reconnect() error {
-	this.binlogSyncer.Close()
-	connectCoordinates := &mysql.BinlogCoordinates{LogFile: this.currentCoordinates.LogFile, LogPos: 4}
-	if err := this.ConnectBinlogStreamer(*connectCoordinates); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (this *GoMySQLReader) GetCurrentBinlogCoordinates() *mysql.BinlogCoordinates {
 	this.currentCoordinatesMutex.Lock()
 	defer this.currentCoordinatesMutex.Unlock()


### PR DESCRIPTION
Streamer had infinite amount of retries. We happened on a couple cases where for some reasons the binary logs were no longer available, at which case `gh-ost` would never bail out.

`gh-ost` would now bail out after `n` successive failure to reconnect the streamer (and the count resets per successful connect which is able to process data)
