### PR TITLE
config file supports environment variables

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="1.0.3"
+RELEASE_VERSION="1.0.4"
 
 buildpath=/tmp/gh-ost
 target=gh-ost

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -7,6 +7,8 @@ package base
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,6 +35,10 @@ const (
 	CutOverAtomic  CutOver = iota
 	CutOverSafe            = iota
 	CutOverTwoStep         = iota
+)
+
+var (
+	envVariableRegexp = regexp.MustCompile("[$][{](.*)[}]")
 )
 
 // MigrationContext has the general, global state of migration. It is used by
@@ -441,8 +447,19 @@ func (this *MigrationContext) ReadConfigFile() error {
 	if this.ConfigFile == "" {
 		return nil
 	}
+	gcfg.RelaxedParserMode = true
 	if err := gcfg.ReadFileInto(&this.config, this.ConfigFile); err != nil {
 		return err
 	}
+
+	// We accept user & password in the form "${SOME_ENV_VARIABLE}" in which case we pull
+	// the given variable from os env
+	if submatch := envVariableRegexp.FindStringSubmatch(this.config.Client.User); len(submatch) > 1 {
+		this.config.Client.User = os.Getenv(submatch[1])
+	}
+	if submatch := envVariableRegexp.FindStringSubmatch(this.config.Client.Password); len(submatch) > 1 {
+		this.config.Client.Password = os.Getenv(submatch[1])
+	}
+
 	return nil
 }

--- a/vendor/gopkg.in/gcfg.v1/set.go
+++ b/vendor/gopkg.in/gcfg.v1/set.go
@@ -16,6 +16,8 @@ type tag struct {
 	intMode string
 }
 
+var RelaxedParserMode = false
+
 func newTag(ts string) tag {
 	t := tag{}
 	s := strings.Split(ts, ",")
@@ -197,6 +199,9 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 	vCfg := vPCfg.Elem()
 	vSect, _ := fieldFold(vCfg, sect)
 	if !vSect.IsValid() {
+		if RelaxedParserMode {
+			return nil
+		}
 		return fmt.Errorf("invalid section: section %q", sect)
 	}
 	if vSect.Kind() == reflect.Map {
@@ -232,6 +237,9 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 	}
 	vVar, t := fieldFold(vSect, name)
 	if !vVar.IsValid() {
+		if RelaxedParserMode {
+			return nil
+		}
 		return fmt.Errorf("invalid variable: "+
 			"section %q subsection %q variable %q", sect, sub, name)
 	}


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/102

This supports environment variables in the `.cnf` config file, such as:

```
[client]
user=${GHOST_USER}
password=${GHOST_PASSWORD}
```

Note: env variable must be in `${NAME}` notation and not in `$NAME` notation.

Also, similarly to `ccql`, as per https://github.com/github/ccql/pull/33/files, config file reading is _relaxed_ and allows for extra variables and scopes.

This closes #102 
