### PR TITLE
dynamic replication-lag-query

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="1.0.5"
+RELEASE_VERSION="1.0.6"
 
 buildpath=/tmp/gh-ost
 target=gh-ost


### PR DESCRIPTION
`replication-lag-query` can now be dynamically set via interactive command:

```
echo "replication-lag-query=select 1" | nc -U /tmp/gh-ost.test.sample_data_0.sock
```

Also, when configured, the query shows up on `status` output
