### PR TITLE
status hint shows [set] next to existing flag files

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -654,6 +654,8 @@ func (this *Migrator) onServerCommand(command string, writer *bufio.Writer) (err
 		arg = strings.TrimSpace(tokens[1])
 	}
 
+	throttleHint := "# Note: you may only throttle for as long as your binary logs are not purged\n"
+
 	switch command {
 	case "help":
 		{
@@ -730,6 +732,7 @@ help                                 # This message
 	case "throttle-query":
 		{
 			this.migrationContext.SetThrottleQuery(arg)
+			fmt.Fprintf(writer, throttleHint)
 			this.printStatus(ForcePrintStatusAndHint, writer)
 		}
 	case "throttle-control-replicas":
@@ -744,6 +747,8 @@ help                                 # This message
 	case "throttle", "pause", "suspend":
 		{
 			atomic.StoreInt64(&this.migrationContext.ThrottleCommandedByUser, 1)
+			fmt.Fprintf(writer, throttleHint)
+			this.printStatus(ForcePrintStatusAndHint, writer)
 		}
 	case "no-throttle", "unthrottle", "resume", "continue":
 		{


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/110
`gh-ost` shows a human friendly `[set]` indicator next to flag files (throttle; additional throttle; postpone) in status-info

Sample output:

```
# Migrating `test`.`sample_data_0`; Ghost table is `test`.`_sample_data_0_gho`
# Migrating shlomi-gh:22293; inspecting shlomi-gh:22297; executing on shlomi-gh
# Migration started at Wed Jul 27 10:24:12 +0200 2016
# chunk-size: 200; max-lag-millis: 1500ms; max-load: Threads_connected=20; critical-load: ; nice-ratio: 0
# Replication lag query: select 1
# Throttle additional flag file: /tmp/gh-ost.throttle
# Postpone cut-over flag file: /tmp/ghost-postpone.flag [set]
# Serving on unix socket: /tmp/gh-ost.test.sample_data_0.sock
Copy: 0/2915 0.0%; Applied: 0; Backlog: 0/100; Time: 1m35s(total), 1m34s(copy); streamer: mysql-bin.000902:103882; ETA: throttled, 127.0.0.1:22295 replica-lag=3.000000s
```

panic flag file does not get a `[set]` indicator because such file panics the app anyhow.

this closes https://github.com/github/gh-ost/issues/110
