### PR TITLE
serving socket before counting table rows

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -396,6 +396,9 @@ func (this *Migrator) Migrate() (err error) {
 	if err := this.inspector.InspectOriginalAndGhostTables(); err != nil {
 		return err
 	}
+	if err := this.initiateServer(); err != nil {
+		return err
+	}
 	if this.migrationContext.CountTableRows {
 		if this.migrationContext.Noop {
 			log.Debugf("Noop operation; not really counting table rows")
@@ -404,9 +407,6 @@ func (this *Migrator) Migrate() (err error) {
 		}
 	}
 
-	if err := this.initiateServer(); err != nil {
-		return err
-	}
 	if err := this.addDMLEventsListener(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/113

start serving before issuing the exhaustive `select count(*)` when `--exact-rowcount` is given
