### PR TITLE
nice-ratio is now float64

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -63,7 +63,7 @@ type MigrationContext struct {
 
 	defaultNumRetries                   int64
 	ChunkSize                           int64
-	NiceRatio                           int64
+	niceRatio                           float64
 	MaxLagMillisecondsThrottleThreshold int64
 	replicationLagQuery                 string
 	throttleControlReplicaKeys          *mysql.InstanceKeyMap
@@ -380,6 +380,26 @@ func (this *MigrationContext) GetCriticalLoad() LoadMap {
 	defer this.throttleMutex.Unlock()
 
 	return this.criticalLoad.Duplicate()
+}
+
+func (this *MigrationContext) GetNiceRatio() float64 {
+	this.throttleMutex.Lock()
+	defer this.throttleMutex.Unlock()
+
+	return this.niceRatio
+}
+
+func (this *MigrationContext) SetNiceRatio(newRatio float64) {
+	if newRatio < 0.0 {
+		newRatio = 0.0
+	}
+	if newRatio > 100.0 {
+		newRatio = 100.0
+	}
+
+	this.throttleMutex.Lock()
+	defer this.throttleMutex.Unlock()
+	this.niceRatio = newRatio
 }
 
 // ReadMaxLoad parses the `--max-load` flag, which is in multiple key-value format,

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -72,7 +72,7 @@ func main() {
 	chunkSize := flag.Int64("chunk-size", 1000, "amount of rows to handle in each iteration (allowed range: 100-100,000)")
 	defaultRetries := flag.Int64("default-retries", 60, "Default number of retries for various operations before panicking")
 	cutOverLockTimeoutSeconds := flag.Int64("cut-over-lock-timeout-seconds", 3, "Max number of seconds to hold locks on tables while attempting to cut-over (retry attempted when lock exceeds timeout)")
-	flag.Int64Var(&migrationContext.NiceRatio, "nice-ratio", 0, "force being 'nice', imply sleep time per chunk time. Example values: 0 is aggressive. 3: for every ms spend in a rowcopy chunk, spend 3ms sleeping immediately after")
+	niceRatio := flag.Float64("nice-ratio", 0, "force being 'nice', imply sleep time per chunk time; range: [0.0..100.0]. Example values: 0 is aggressive. 1.5: for every ms spend in a rowcopy chunk, spend 1.5ms sleeping immediately after")
 
 	maxLagMillis := flag.Int64("max-lag-millis", 1500, "replication lag at which to throttle operation")
 	replicationLagQuery := flag.String("replication-lag-query", "", "Query that detects replication lag in seconds. Result can be a floating point (by default gh-ost issues SHOW SLAVE STATUS and reads Seconds_behind_master). If you're using pt-heartbeat, query would be something like: SELECT ROUND(UNIX_TIMESTAMP() - MAX(UNIX_TIMESTAMP(ts))) AS delay FROM my_schema.heartbeat")
@@ -169,6 +169,7 @@ func main() {
 	if migrationContext.ServeSocketFile == "" {
 		migrationContext.ServeSocketFile = fmt.Sprintf("/tmp/gh-ost.%s.%s.sock", migrationContext.DatabaseName, migrationContext.OriginalTableName)
 	}
+	migrationContext.SetNiceRatio(*niceRatio)
 	migrationContext.SetChunkSize(*chunkSize)
 	migrationContext.SetMaxLagMillisecondsThrottleThreshold(*maxLagMillis)
 	migrationContext.SetReplicationLagQuery(*replicationLagQuery)


### PR DESCRIPTION
storyline: https://github.com/github/gh-ost/issues/114

`--nice-ratio` (also dynamically controlled) is now a floating point value. Allowed range is `[0.0..100.0]`. Anything outside this range is set to meet range.

To elaborate, value of:
- `0.0` means not being nice. Aggressive (of course, still checking for replication lag, which is the de-factor rate limiting factor we use in production)
- `0.5` means for every `1ms` spent copying rows, we spend `0.5ms` sleeping
- `1.0` means for every `1ms` spent copying rows, we spend `1ms` sleeping

etc.
