### PR TITLE
status hint parameters using normalized names

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -874,7 +874,7 @@ func (this *Migrator) printMigrationStatusHint(writers ...io.Writer) {
 		this.migrationContext.GetNiceRatio(),
 	))
 	if replicationLagQuery := this.migrationContext.GetReplicationLagQuery(); replicationLagQuery != "" {
-		fmt.Fprintln(w, fmt.Sprintf("# Replication lag query: %+v",
+		fmt.Fprintln(w, fmt.Sprintf("# replication-lag-query: %+v",
 			replicationLagQuery,
 		))
 	}
@@ -883,7 +883,7 @@ func (this *Migrator) printMigrationStatusHint(writers ...io.Writer) {
 		if base.FileExists(this.migrationContext.ThrottleFlagFile) {
 			setIndicator = "[set]"
 		}
-		fmt.Fprintln(w, fmt.Sprintf("# Throttle flag file: %+v %+v",
+		fmt.Fprintln(w, fmt.Sprintf("# throttle-flag-file: %+v %+v",
 			this.migrationContext.ThrottleFlagFile, setIndicator,
 		))
 	}
@@ -892,12 +892,12 @@ func (this *Migrator) printMigrationStatusHint(writers ...io.Writer) {
 		if base.FileExists(this.migrationContext.ThrottleAdditionalFlagFile) {
 			setIndicator = "[set]"
 		}
-		fmt.Fprintln(w, fmt.Sprintf("# Throttle additional flag file: %+v %+v",
+		fmt.Fprintln(w, fmt.Sprintf("# throttle-additional-flag-file: %+v %+v",
 			this.migrationContext.ThrottleAdditionalFlagFile, setIndicator,
 		))
 	}
 	if throttleQuery := this.migrationContext.GetThrottleQuery(); throttleQuery != "" {
-		fmt.Fprintln(w, fmt.Sprintf("# Throttle query: %+v",
+		fmt.Fprintln(w, fmt.Sprintf("# throttle-query: %+v",
 			throttleQuery,
 		))
 	}
@@ -906,12 +906,12 @@ func (this *Migrator) printMigrationStatusHint(writers ...io.Writer) {
 		if base.FileExists(this.migrationContext.PostponeCutOverFlagFile) {
 			setIndicator = "[set]"
 		}
-		fmt.Fprintln(w, fmt.Sprintf("# Postpone cut-over flag file: %+v %+v",
+		fmt.Fprintln(w, fmt.Sprintf("# postpone-cut-over-flag-file: %+v %+v",
 			this.migrationContext.PostponeCutOverFlagFile, setIndicator,
 		))
 	}
 	if this.migrationContext.PanicFlagFile != "" {
-		fmt.Fprintln(w, fmt.Sprintf("# Panic flag file: %+v",
+		fmt.Fprintln(w, fmt.Sprintf("# panic-flag-file: %+v",
 			this.migrationContext.PanicFlagFile,
 		))
 	}


### PR DESCRIPTION
status hint show variables using same notation as used in command line arguments. For example, `replication-lag-query` (as opposed to "Replication lag query")

See example output:

```
# Migrating `test`.`sample_data_0`; Ghost table is `test`.`_sample_data_0_gho`
# Migrating shlomi-gh:22293; inspecting shlomi-gh:22297; executing on shlomi-gh
# Migration started at Fri Jul 29 09:19:04 +0200 2016
# chunk-size: 200; max-lag-millis: 1500ms; max-load: Threads_connected=20; critical-load: ; nice-ratio: 0.000000
# replication-lag-query: select 1
# throttle-additional-flag-file: /tmp/gh-ost.throttle
# postpone-cut-over-flag-file: /tmp/ghost-postpone.flag
# Serving on unix socket: /tmp/gh-ost.test.sample_data_0.sock
```

compare with previous format:

```
# Migrating `test`.`sample_data_0`; Ghost table is `test`.`_sample_data_0_gho`
# Migrating shlomi-gh:22293; inspecting shlomi-gh:22297; executing on shlomi-gh
# Migration started at Thu Jul 28 13:23:28 +0200 2016
# chunk-size: 200; max-lag-millis: 1500ms; max-load: Threads_connected=20; critical-load: ; nice-ratio: 0.200000
# Replication lag query: select 1
# Throttle additional flag file: /tmp/gh-ost.throttle
# Postpone cut-over flag file: /tmp/ghost-postpone.flag
# Serving on unix socket: /tmp/gh-ost.test.sample_data_0.sock
```
