### PR TITLE
all: use time.Since() instead of time.Now().Sub

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -259,7 +259,7 @@ func (this *MigrationContext) IsTransactionalTable() bool {
 
 // ElapsedTime returns time since very beginning of the process
 func (this *MigrationContext) ElapsedTime() time.Duration {
-	return time.Now().Sub(this.StartTime)
+	return time.Since(this.StartTime)
 }
 
 // MarkRowCopyStartTime
@@ -280,7 +280,7 @@ func (this *MigrationContext) ElapsedRowCopyTime() time.Duration {
 	}
 
 	if this.RowCopyEndTime.IsZero() {
-		return time.Now().Sub(this.RowCopyStartTime)
+		return time.Since(this.RowCopyStartTime)
 	}
 	return this.RowCopyEndTime.Sub(this.RowCopyStartTime)
 }
@@ -314,7 +314,7 @@ func (this *MigrationContext) TimeSincePointOfInterest() time.Duration {
 	this.pointOfInterestTimeMutex.Lock()
 	defer this.pointOfInterestTimeMutex.Unlock()
 
-	return time.Now().Sub(this.pointOfInterestTime)
+	return time.Since(this.pointOfInterestTime)
 }
 
 func (this *MigrationContext) SetMaxLagMillisecondsThrottleThreshold(maxLagMillisecondsThrottleThreshold int64) {

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -419,7 +419,7 @@ func (this *Applier) ApplyIterationInsertQuery() (chunkSize int64, rowsAffected 
 		return chunkSize, rowsAffected, duration, err
 	}
 	rowsAffected, _ = sqlResult.RowsAffected()
-	duration = time.Now().Sub(startTime)
+	duration = time.Since(startTime)
 	log.Debugf(
 		"Issued INSERT on range: [%s]..[%s]; iteration: %d; chunk-size: %d",
 		this.migrationContext.MigrationIterationRangeMinValues,

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -333,7 +333,7 @@ func (this *Migrator) onChangelogHeartbeat(heartbeatValue string) (err error) {
 	if err != nil {
 		return log.Errore(err)
 	}
-	lag := time.Now().Sub(heartbeatTime)
+	lag := time.Since(heartbeatTime)
 
 	atomic.StoreInt64(&this.migrationContext.CurrentLag, int64(lag))
 
@@ -517,7 +517,7 @@ func (this *Migrator) waitForEventsUpToLock() (err error) {
 	log.Infof("Waiting for events up to lock")
 	atomic.StoreInt64(&this.allEventsUpToLockProcessedInjectedFlag, 1)
 	<-this.allEventsUpToLockProcessed
-	waitForEventsUpToLockDuration := time.Now().Sub(waitForEventsUpToLockStartTime)
+	waitForEventsUpToLockDuration := time.Since(waitForEventsUpToLockStartTime)
 
 	log.Infof("Done waiting for events up to lock; duration=%+v", waitForEventsUpToLockDuration)
 	this.printStatus(ForcePrintStatusAndHint)
@@ -1193,7 +1193,7 @@ func (this *Migrator) executeWriteFuncs() error {
 							return log.Errore(err)
 						}
 						if niceRatio := this.migrationContext.GetNiceRatio(); niceRatio > 0 {
-							copyRowsDuration := time.Now().Sub(copyRowsStartTime)
+							copyRowsDuration := time.Since(copyRowsStartTime)
 							sleepTimeNanosecondFloat64 := niceRatio * float64(copyRowsDuration.Nanoseconds())
 							sleepTime := time.Duration(time.Duration(int64(sleepTimeNanosecondFloat64)) * time.Nanosecond)
 							time.Sleep(sleepTime)


### PR DESCRIPTION
Patch created with:
    gofmt -w -r 'time.Now().Sub(a) -> time.Since(a)' .