### PR TITLE
[go cmd] Correct spelling for main() comment

### DIFF
--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -39,7 +39,7 @@ func acceptSignals(migrationContext *base.MigrationContext) {
 	}()
 }
 
-// main is the application's entry point. It will either spawn a CLI or HTTP itnerfaces.
+// main is the application's entry point. It will either spawn a CLI or HTTP interfaces.
 func main() {
 	migrationContext := base.GetMigrationContext()
 


### PR DESCRIPTION
### Corrects typo in `go/cmd/gh-ost/main.go`


This simply corrects the spelling of `itnerfaces` to `interfaces` for the `main` function's comment.

