### PR TITLE
detect IPv6 literals and wrap them in square brackets in GetDBUri

### DIFF
--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -7,6 +7,7 @@ package mysql
 
 import (
 	"fmt"
+	"net"
 )
 
 // ConnectionConfig is the minimal configuration required to connect to a MySQL server
@@ -47,5 +48,11 @@ func (this *ConnectionConfig) Equals(other *ConnectionConfig) bool {
 }
 
 func (this *ConnectionConfig) GetDBUri(databaseName string) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", this.User, this.Password, this.Key.Hostname, this.Key.Port, databaseName)
+	var ip = net.ParseIP(this.Key.Hostname)
+	if (ip != nil) && (ip.To4() == nil) {
+		// Wrap IPv6 literals in square brackets
+		return fmt.Sprintf("%s:%s@tcp([%s]:%d)/%s", this.User, this.Password, this.Key.Hostname, this.Key.Port, databaseName)
+	} else {
+		return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", this.User, this.Password, this.Key.Hostname, this.Key.Port, databaseName)
+	}
 }


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/142

### Description

This PR detects IPv6 address literals (using `net.ParseIP`) and wraps them in square brackets for the dburi so that we can actually use IPv6 replication configurations.

I don't typically write go, so I'm not sure if this is the idiomatic way to detect IP address families. It appears that `net.IP` sometimes packs an IPv4 address into a 16-byte char slice, so we can't just compare the length of the slice with `net.IPv4len`, but maybe there's some better function out there somewhere. This seems to work in limited testing.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `bash build.sh`

