### PR TITLE
Cleanup socket file

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -399,6 +399,8 @@ func (this *Migrator) Migrate() (err error) {
 	if err := this.initiateServer(); err != nil {
 		return err
 	}
+	defer this.server.RemoveSocketFile()
+
 	if this.migrationContext.CountTableRows {
 		if this.migrationContext.Noop {
 			log.Debugf("Noop operation; not really counting table rows")

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -47,6 +47,10 @@ func (this *Server) BindSocketFile() (err error) {
 	return nil
 }
 
+func (this *Server) RemoveSocketFile() (err error) {
+	return os.Remove(this.migrationContext.ServeSocketFile)
+}
+
 func (this *Server) BindTCPPort() (err error) {
 	if this.migrationContext.ServeTCPPort == 0 {
 		return nil

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -48,6 +48,7 @@ func (this *Server) BindSocketFile() (err error) {
 }
 
 func (this *Server) RemoveSocketFile() (err error) {
+	log.Infof("Removing socket file: %s", this.migrationContext.ServeSocketFile)
 	return os.Remove(this.migrationContext.ServeSocketFile)
 }
 


### PR DESCRIPTION
This PR makes sure the socket file is removed upon normal termination. 

Related issue: #95 
Suggested in place of https://github.com/github/gh-ost/pull/134

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`

cc @dveeden 