### PR TITLE
testing for trigger existence

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-RELEASE_VERSION="1.0.8"
+RELEASE_VERSION="1.0.9"
 
 buildpath=/tmp/gh-ost
 target=gh-ost


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/141

### Description

This PR checks for existence of triggers on the migrated table; if any trigger exists, `gh-ost` bails out with error.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`

