### PR TITLE
relaxed check for log_slave_updates

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -243,16 +243,13 @@ func (this *Inspector) applyBinlogFormat() error {
 
 // validateBinlogs checks that binary log configuration is good to go
 func (this *Inspector) validateBinlogs() error {
-	query := `select @@global.log_bin, @@global.log_slave_updates, @@global.binlog_format`
-	var hasBinaryLogs, logSlaveUpdates bool
-	if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &logSlaveUpdates, &this.migrationContext.OriginalBinlogFormat); err != nil {
+	query := `select @@global.log_bin, @@global.binlog_format`
+	var hasBinaryLogs bool
+	if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat); err != nil {
 		return err
 	}
 	if !hasBinaryLogs {
 		return fmt.Errorf("%s:%d must have binary logs enabled", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
-	}
-	if !logSlaveUpdates {
-		return fmt.Errorf("%s:%d must have log_slave_updates enabled", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
 	}
 	if this.migrationContext.RequiresBinlogFormatChange() {
 		if !this.migrationContext.SwitchToRowBinlogFormat {
@@ -280,6 +277,21 @@ func (this *Inspector) validateBinlogs() error {
 	this.migrationContext.OriginalBinlogRowImage = strings.ToUpper(this.migrationContext.OriginalBinlogRowImage)
 
 	log.Infof("binary logs validated on %s:%d", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
+	return nil
+}
+
+// ValidateLogSlaveUpdates checks that binary log log_slave_updates is set. This test is not required when migrating on replica or when migrating directly on master
+func (this *Inspector) ValidateLogSlaveUpdates() error {
+	query := `select @@global.log_slave_updates`
+	var logSlaveUpdates bool
+	if err := this.db.QueryRow(query).Scan(&logSlaveUpdates); err != nil {
+		return err
+	}
+	if !logSlaveUpdates && !this.migrationContext.InspectorIsAlsoApplier() {
+		return fmt.Errorf("%s:%d must have log_slave_updates enabled", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
+	}
+
+	log.Infof("binary logs updates validated on %s:%d", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
 	return nil
 }
 

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -280,8 +280,8 @@ func (this *Inspector) validateBinlogs() error {
 	return nil
 }
 
-// ValidateLogSlaveUpdates checks that binary log log_slave_updates is set. This test is not required when migrating on replica or when migrating directly on master
-func (this *Inspector) ValidateLogSlaveUpdates() error {
+// validateLogSlaveUpdates checks that binary log log_slave_updates is set. This test is not required when migrating on replica or when migrating directly on master
+func (this *Inspector) validateLogSlaveUpdates() error {
 	query := `select @@global.log_slave_updates`
 	var logSlaveUpdates bool
 	if err := this.db.QueryRow(query).Scan(&logSlaveUpdates); err != nil {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -828,6 +828,9 @@ func (this *Migrator) initiateInspector() (err error) {
 	} else if this.migrationContext.InspectorIsAlsoApplier() && !this.migrationContext.AllowedRunningOnMaster {
 		return fmt.Errorf("It seems like this migration attempt to run directly on master. Preferably it would be executed on a replica (and this reduces load from the master). To proceed please provide --allow-on-master")
 	}
+	if err := this.inspector.ValidateLogSlaveUpdates(); err != nil {
+		return err
+	}
 
 	log.Infof("Master found to be %+v", *this.migrationContext.ApplierConnectionConfig.ImpliedKey)
 	return nil

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -828,7 +828,7 @@ func (this *Migrator) initiateInspector() (err error) {
 	} else if this.migrationContext.InspectorIsAlsoApplier() && !this.migrationContext.AllowedRunningOnMaster {
 		return fmt.Errorf("It seems like this migration attempt to run directly on master. Preferably it would be executed on a replica (and this reduces load from the master). To proceed please provide --allow-on-master")
 	}
-	if err := this.inspector.ValidateLogSlaveUpdates(); err != nil {
+	if err := this.inspector.validateLogSlaveUpdates(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Related issue: #135 

`log_slave_updates` doesn't have to be set if we're directly:

- migrating on master
- migrating the replica

`log_slave_updates` _is_ required when doing normal read-from-replica-write-on-master or when `--test-on-replica`

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`

