### PR TITLE
elaborate output on error in apply dml

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -860,5 +860,8 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 	if this.migrationContext.CountTableRows {
 		atomic.AddInt64(&this.migrationContext.RowsEstimate, rowDelta)
 	}
+	if err != nil {
+		err = fmt.Errorf("%s; query=%s; args=%+v", err.Error(), query, args)
+	}
 	return err
 }


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/157

This PR outputs more detail in the case where `ApplyDMLEventQuery` fails to apply a query. 
Reminder: this function gets a DML event from the binary log, constructs a query and arguments from that event, and applies the query with given arguments.

In the case of failure (and after retry count), this function will return the original SQL error, plus query, plus argument values.