### PR TITLE
Fix unsigned columns

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.9"
+RELEASE_VERSION="1.0.10"
 
 function build {
     osname=$1

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -128,33 +128,23 @@ func (this *GoMySQLReader) StreamEvents(canStopStreaming func() bool, entriesCha
 		if err != nil {
 			return err
 		}
-		// if rand.Intn(1000) == 0 {
-		// 	this.binlogSyncer.Close()
-		// 	log.Debugf("current: %+v, hint: %+v", this.currentCoordinates, this.LastAppliedRowsEventHint)
-		// 	return log.Errorf(".............haha got random error")
-		// }
-		//		log.Debugf("0001 ........ currentCoordinates: %+v", this.currentCoordinates) //TODO
 		func() {
 			this.currentCoordinatesMutex.Lock()
 			defer this.currentCoordinatesMutex.Unlock()
 			this.currentCoordinates.LogPos = int64(ev.Header.LogPos)
 		}()
 		if rotateEvent, ok := ev.Event.(*replication.RotateEvent); ok {
-			// log.Debugf("0008 ........ currentCoordinates: %+v", this.currentCoordinates) //TODO
-			// ev.Dump(os.Stdout)
 			func() {
 				this.currentCoordinatesMutex.Lock()
 				defer this.currentCoordinatesMutex.Unlock()
 				this.currentCoordinates.LogFile = string(rotateEvent.NextLogName)
 			}()
-			// log.Debugf("0001 ........ currentCoordinates: %+v", this.currentCoordinates) //TODO
 			log.Infof("rotate to next log name: %s", rotateEvent.NextLogName)
 		} else if rowsEvent, ok := ev.Event.(*replication.RowsEvent); ok {
 			if err := this.handleRowsEvent(ev, rowsEvent, entriesChannel); err != nil {
 				return err
 			}
 		}
-		// log.Debugf("TODO ........ currentCoordinates: %+v", this.currentCoordinates) //TODO
 	}
 	log.Debugf("done streaming events")
 

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -860,5 +860,8 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 	if this.migrationContext.CountTableRows {
 		atomic.AddInt64(&this.migrationContext.RowsEstimate, rowDelta)
 	}
+	if err != nil {
+		err = fmt.Errorf("%s; query=%s; args=%+v", err.Error(), query, args)
+	}
 	return err
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -862,6 +862,7 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 	}
 	if err != nil {
 		err = fmt.Errorf("%s; query=%s; args=%+v", err.Error(), query, args)
+		log.Errore(err)
 	}
 	return err
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -853,6 +853,31 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 	if err != nil {
 		return err
 	}
+
+	// TODO The below is commented, and is in preparation for transactional writes on the ghost tables.
+	// Such writes would be, for example:
+	// - prepended with sql_mode setup
+	// - prepended with SET SQL_LOG_BIN=0
+	// - prepended with SET FK_CHECKS=0
+	// etc.
+	//
+	// Current known problem: https://github.com/golang/go/issues/9373 -- bitint unsigned values, not supported in database/sql
+	//
+
+	// err = func() error {
+	// 	tx, err := this.db.Begin()
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	if _, err := tx.Exec(query, args...); err != nil {
+	// 		return err
+	// 	}
+	// 	if err := tx.Commit(); err != nil {
+	// 		return err
+	// 	}
+	// 	return nil
+	// }()
+
 	_, err = sqlutils.Exec(this.db, query, args...)
 	if err == nil {
 		atomic.AddInt64(&this.migrationContext.TotalDMLEventsApplied, 1)

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -14,24 +14,31 @@ import (
 // ColumnsMap maps a column onto its ordinal position
 type ColumnsMap map[string]int
 
-func NewColumnsMap(orderedNames []string) ColumnsMap {
+func NewEmptyColumnsMap() ColumnsMap {
 	columnsMap := make(map[string]int)
+	return ColumnsMap(columnsMap)
+}
+
+func NewColumnsMap(orderedNames []string) ColumnsMap {
+	columnsMap := NewEmptyColumnsMap()
 	for i, column := range orderedNames {
 		columnsMap[column] = i
 	}
-	return ColumnsMap(columnsMap)
+	return columnsMap
 }
 
 // ColumnList makes for a named list of columns
 type ColumnList struct {
-	Names    []string
-	Ordinals ColumnsMap
+	Names         []string
+	Ordinals      ColumnsMap
+	UnsignedFlags ColumnsMap
 }
 
 // NewColumnList creates an object given ordered list of column names
 func NewColumnList(names []string) *ColumnList {
 	result := &ColumnList{
-		Names: names,
+		Names:         names,
+		UnsignedFlags: NewEmptyColumnsMap(),
 	}
 	result.Ordinals = NewColumnsMap(result.Names)
 	return result
@@ -40,10 +47,19 @@ func NewColumnList(names []string) *ColumnList {
 // ParseColumnList parses a comma delimited list of column names
 func ParseColumnList(columns string) *ColumnList {
 	result := &ColumnList{
-		Names: strings.Split(columns, ","),
+		Names:         strings.Split(columns, ","),
+		UnsignedFlags: NewEmptyColumnsMap(),
 	}
 	result.Ordinals = NewColumnsMap(result.Names)
 	return result
+}
+
+func (this *ColumnList) SetUnsigned(columnName string) {
+	this.UnsignedFlags[columnName] = 1
+}
+
+func (this *ColumnList) IsUnsigned(columnName string) bool {
+	return this.UnsignedFlags[columnName] == 1
 }
 
 func (this *ColumnList) String() string {


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/157

This PR checks and fixes unsigned datatypes. 
It seems the binary log does not tell us whether int values are signed or unsigned. The `go-mysql` library assumes signed.

`gh-ost` uses its own understanding of migrated table structure to modify column type (on app side) on the fly from `int` to `uint` on all variations (8, 16, 32, 64).

This fixes a data-corruption problem which can go undetected without `STRICT_ALL_TABLES`.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`
