### PR TITLE
Set session timezone to UTC to prevent data drift for timestamp columns

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -878,6 +878,13 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 	// 	return nil
 	// }()
 
+	// Use UTC to prevent timestamp columns from drifting
+	// https://github.com/github/gh-ost/issues/161
+	_, err = sqlutils.Exec(this.db, "SET SESSION time_zone = '+00:00'")
+	if err != nil {
+		err = fmt.Errorf("Failed to set session time zone to +00:00")
+		log.Errore(err)
+	}
 	_, err = sqlutils.Exec(this.db, query, args...)
 	if err == nil {
 		atomic.AddInt64(&this.migrationContext.TotalDMLEventsApplied, 1)


### PR DESCRIPTION
Related Issue: https://github.com/github/gh-ost/issues/161

Do we need to do the SET SESSION and apply statement in a transaction?
Could this introduce issues with date columns?

