### PR TITLE
progress is 100% when 0/0 rows copied

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -941,7 +941,9 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	totalRowsCopied := this.migrationContext.GetTotalRowsCopied()
 	rowsEstimate := atomic.LoadInt64(&this.migrationContext.RowsEstimate)
 	var progressPct float64
-	if rowsEstimate > 0 {
+	if rowsEstimate == 0 {
+		progressPct = 100.0
+	} else {
 		progressPct = 100.0 * float64(totalRowsCopied) / float64(rowsEstimate)
 	}
 


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/159

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

