### PR TITLE
DML write wrapped in transaction

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -880,15 +880,14 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 		return nil
 	}()
 
-	if err == nil {
-		atomic.AddInt64(&this.migrationContext.TotalDMLEventsApplied, 1)
+	if err != nil {
+		err = fmt.Errorf("%s; query=%s; args=%+v", err.Error(), query, args)
+		return log.Errore(err)
 	}
+	// no error
+	atomic.AddInt64(&this.migrationContext.TotalDMLEventsApplied, 1)
 	if this.migrationContext.CountTableRows {
 		atomic.AddInt64(&this.migrationContext.RowsEstimate, rowDelta)
 	}
-	if err != nil {
-		err = fmt.Errorf("%s; query=%s; args=%+v", err.Error(), query, args)
-		log.Errore(err)
-	}
-	return err
+	return nil
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -854,31 +854,32 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 		return err
 	}
 
-	// TODO The below is commented, and is in preparation for transactional writes on the ghost tables.
+	// TODO The below is in preparation for transactional writes on the ghost tables.
 	// Such writes would be, for example:
 	// - prepended with sql_mode setup
+	// - prepended with time zone setup
 	// - prepended with SET SQL_LOG_BIN=0
 	// - prepended with SET FK_CHECKS=0
 	// etc.
 	//
-	// Current known problem: https://github.com/golang/go/issues/9373 -- bitint unsigned values, not supported in database/sql
+	// a known problem: https://github.com/golang/go/issues/9373 -- bitint unsigned values, not supported in database/sql
+	// is solved by silently converting unsigned bigints to string values.
 	//
 
-	// err = func() error {
-	// 	tx, err := this.db.Begin()
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	if _, err := tx.Exec(query, args...); err != nil {
-	// 		return err
-	// 	}
-	// 	if err := tx.Commit(); err != nil {
-	// 		return err
-	// 	}
-	// 	return nil
-	// }()
+	err = func() error {
+		tx, err := this.db.Begin()
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(query, args...); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		return nil
+	}()
 
-	_, err = sqlutils.Exec(this.db, query, args...)
 	if err == nil {
 		atomic.AddInt64(&this.migrationContext.TotalDMLEventsApplied, 1)
 	}

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -47,7 +47,7 @@ func fixArgType(arg interface{}, isUnsigned bool) interface{} {
 		return uint32(i)
 	}
 	if i, ok := arg.(int64); ok {
-		return uint64(i)
+		return strconv.FormatUint(uint64(i), 10)
 	}
 	if i, ok := arg.(int); ok {
 		return uint(i)


### PR DESCRIPTION
Required for:

- https://github.com/github/gh-ost/issues/164
- https://github.com/github/gh-ost/issues/149
- https://github.com/github/gh-ost/issues/161

also solving the `golang` limitation: 

```
sql: converting Exec argument #2's type: uint64 values with high bit set are not supported
```
by converting `uint64` silently to strings when applying DML changes.
Related: https://github.com/github/gh-ost/issues/157

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`
