### PR TITLE
relaxed config scanner mode

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -18,6 +18,7 @@ import (
 	"github.com/github/gh-ost/go/sql"
 
 	"gopkg.in/gcfg.v1"
+	gcfgscanner "gopkg.in/gcfg.v1/scanner"
 )
 
 // RowsEstimateMethod is the type of row number estimation
@@ -507,6 +508,7 @@ func (this *MigrationContext) ReadConfigFile() error {
 		return nil
 	}
 	gcfg.RelaxedParserMode = true
+	gcfgscanner.RelaxedScannerMode = true
 	if err := gcfg.ReadFileInto(&this.config, this.ConfigFile); err != nil {
 		return err
 	}

--- a/vendor/gopkg.in/gcfg.v1/scanner/scanner.go
+++ b/vendor/gopkg.in/gcfg.v1/scanner/scanner.go
@@ -16,11 +16,11 @@ import (
 	"path/filepath"
 	"unicode"
 	"unicode/utf8"
-)
 
-import (
 	"gopkg.in/gcfg.v1/token"
 )
+
+var RelaxedScannerMode = false
 
 // An ErrorHandler may be provided to Scanner.Init. If a syntax error is
 // encountered and a handler was installed, the handler is called with a
@@ -231,7 +231,7 @@ loop:
 				hasCR = true
 				s.next()
 			}
-			if s.ch != '\n' {
+			if s.ch != '\n' && !RelaxedScannerMode {
 				s.error(offs, "unquoted '\\' must be followed by new line")
 				break loop
 			}


### PR DESCRIPTION
- does not fail on MySQL 'prompt' config

Storyline: https://github.com/github/gh-ost/issues/168#issuecomment-240691797

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

