### PR TITLE
Add --test-on-replica-manual-replication-control flag

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -82,14 +82,14 @@ type MigrationContext struct {
 	ServeSocketFile string
 	ServeTCPPort    int64
 
-	Noop                     bool
-	TestOnReplica            bool
-	MigrateOnReplica         bool
-	ManualReplicationControl bool
-	OkToDropTable            bool
-	InitiallyDropOldTable    bool
-	InitiallyDropGhostTable  bool
-	CutOverType              CutOver
+	Noop                         bool
+	TestOnReplica                bool
+	MigrateOnReplica             bool
+	TestOnReplicaSkipReplicaStop bool
+	OkToDropTable                bool
+	InitiallyDropOldTable        bool
+	InitiallyDropGhostTable      bool
+	CutOverType                  CutOver
 
 	TableEngine               string
 	RowsEstimate              int64

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -82,13 +82,14 @@ type MigrationContext struct {
 	ServeSocketFile string
 	ServeTCPPort    int64
 
-	Noop                    bool
-	TestOnReplica           bool
-	MigrateOnReplica        bool
-	OkToDropTable           bool
-	InitiallyDropOldTable   bool
-	InitiallyDropGhostTable bool
-	CutOverType             CutOver
+	Noop                     bool
+	TestOnReplica            bool
+	MigrateOnReplica         bool
+	ManualReplicationControl bool
+	OkToDropTable            bool
+	InitiallyDropOldTable    bool
+	InitiallyDropGhostTable  bool
+	CutOverType              CutOver
 
 	TableEngine               string
 	RowsEstimate              int64

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -568,15 +568,11 @@ func (this *Applier) StartSlaveSQLThread() error {
 
 // StopReplication is used by `--test-on-replica` and stops replication.
 func (this *Applier) StopReplication() error {
-	if this.migrationContext.TestOnReplicaSkipReplicaStop {
-		log.Warningf("--test-on-replica-skip-replica-stop enabled, we are not stopping replication.")
-	} else {
-		if err := this.StopSlaveIOThread(); err != nil {
-			return err
-		}
-		if err := this.StopSlaveSQLThread(); err != nil {
-			return err
-		}
+	if err := this.StopSlaveIOThread(); err != nil {
+		return err
+	}
+	if err := this.StopSlaveSQLThread(); err != nil {
+		return err
 	}
 
 	readBinlogCoordinates, executeBinlogCoordinates, err := mysql.GetReplicationBinlogCoordinates(this.db)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -477,9 +477,14 @@ func (this *Migrator) cutOver() (err error) {
 		// the same cut-over phase as the master would use. That means we take locks
 		// and swap the tables.
 		// The difference is that we will later swap the tables back.
-		log.Debugf("testing on replica. Stopping replication IO thread")
-		if err := this.retryOperation(this.applier.StopReplication); err != nil {
-			return err
+
+		if this.migrationContext.TestOnReplicaSkipReplicaStop {
+			log.Warningf("--test-on-replica-skip-replica-stop enabled, we are not stopping replication.")
+		} else {
+			log.Debugf("testing on replica. Stopping replication IO thread")
+			if err := this.retryOperation(this.applier.StopReplication); err != nil {
+				return err
+			}
 		}
 		// We're merly testing, we don't want to keep this state. Rollback the renames as possible
 		defer this.applier.RenameTablesRollback()


### PR DESCRIPTION
This will wait indefinitely for the replication status to change.
This allows us to run test schema changes in RDS without needing
custom RDS commands in gh-ost.

Closes #162