### PR TITLE
setting time_zone on DML apply

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.10"
+RELEASE_VERSION="1.0.11"
 
 function build {
     osname=$1

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -871,6 +871,9 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 		if err != nil {
 			return err
 		}
+		if _, err := tx.Exec("SET SESSION time_zone = '+00:00'"); err != nil {
+			return err
+		}
 		if _, err := tx.Exec(query, args...); err != nil {
 			return err
 		}


### PR DESCRIPTION
Storyline: #161 

This addresses the `time_zone` setting by applying a session`time_zone` for each and every DML applied, within same transaction

cc @dveeden 

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

