### PR TITLE
row_event converts timestamps to UTC

### DIFF
--- a/vendor/github.com/siddontang/go-mysql/replication/row_event.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/row_event.go
@@ -609,7 +609,7 @@ func decodeTimestamp2(data []byte, dec uint16) (string, int, error) {
 		return "0000-00-00 00:00:00", n, nil
 	}
 
-	t := time.Unix(sec, usec*1000)
+	t := time.Unix(sec, usec*1000).UTC()
 	return t.Format(TimeFormat), n, nil
 }
 


### PR DESCRIPTION
Continued discussion on https://github.com/github/gh-ost/issues/161

This explicitly sets UTC for timestamps read by the `go-mysql` library.
Unfortunately when returning timestamp, it is returned as a `string`, just so that it is able to support `0000-00-00 00:00:00`.
But then it uses the local machine's timezone, converting a real time into string, losing context. Because this is a string, it is not converted back to number when applied as DML event.
This is an attempt to fix that, with local tests already proving well.

cc @dveeden 

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

