### PR TITLE
Message about waiting should be INFO not DEBUG

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -387,7 +387,7 @@ func (this *Migrator) Migrate() (err error) {
 		return err
 	}
 
-	log.Debugf("Waiting for tables to be in place")
+	log.Infof("Waiting for tables to be in place")
 	<-this.tablesInPlace
 	log.Debugf("Tables are in place")
 	// Yay! We now know the Ghost and Changelog tables are good to examine!


### PR DESCRIPTION
Give some feedback about what is happening when running with 'just' `-verbose`.

For me this happened:
```
2016-08-23 06:32:45 INFO Ghost table altered
2016-08-23 06:37:24 INFO Chosen shared unique key is PRIMARY
```
This is because I had to restart the slave before starting gh-ost so it was still catching up.