### PR TITLE
DML write sets sql_mode to STRICT ALL TABLES

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -870,7 +870,10 @@ func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
 		if err != nil {
 			return err
 		}
-		if _, err := tx.Exec("SET SESSION time_zone = '+00:00'"); err != nil {
+		if _, err := tx.Exec(`SET
+			SESSION time_zone = '+00:00',
+			sql_mode = CONCAT(@@session.sql_mode, ',STRICT_ALL_TABLES')
+			`); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(query, args...); err != nil {


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/164

Each DML write forces session `sql_mode` to `STRICT_ALL_TABLES`.

This serves as a safety net in case the server's `sql_mode` is not strict. `gh-ost`'s mode _should_ be strict because it just copies values around, so there should not be any case where data is truncated.

On interesting potential case is if the user reduces `BIGINT` to `INT`, or `VARCHAR(128)` to `VARCHAR(64)`, for example, and some existing values do not fit in reduced column size.
This PR will assist the user in avoiding shooting herself in the foot.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

