### PR TITLE
avoiding writing rows when rowcopy complete

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.13"
+RELEASE_VERSION="1.0.14"
 
 function build {
     osname=$1

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1146,6 +1146,10 @@ func (this *Migrator) iterateChunks() error {
 			return nil
 		}
 		copyRowsFunc := func() error {
+			if atomic.LoadInt64(&this.rowCopyCompleteFlag) == 1 {
+				// Done
+				return nil
+			}
 			hasFurtherRange, err := this.applier.CalculateNextIterationRangeEndValues()
 			if err != nil {
 				return terminateRowIteration(err)


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/180

This should address the problem of rows still attempted to copy after completion flag is set.
This should solve the thread synchronization problem because rowcopy executes sequentially.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

