### PR TITLE
config file allows underscore variables

### DIFF
--- a/vendor/gopkg.in/gcfg.v1/scanner/scanner.go
+++ b/vendor/gopkg.in/gcfg.v1/scanner/scanner.go
@@ -148,7 +148,7 @@ func (s *Scanner) scanComment() string {
 }
 
 func isLetter(ch rune) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch >= 0x80 && unicode.IsLetter(ch)
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' || ch >= 0x80 && unicode.IsLetter(ch)
 }
 
 func isDigit(ch rune) bool {


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/198

`gh-ost` supports underscore (`_`) in variable name, in config file (just so as to be able to ignore without error MySQL variables ; we don't really parse those for `gh-ost` itself)

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

