### PR TITLE
fixed 5.5 binlog_row_image default value

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -298,7 +298,7 @@ func (this *Inspector) validateBinlogs() error {
 	query = `select @@global.binlog_row_image`
 	if err := this.db.QueryRow(query).Scan(&this.migrationContext.OriginalBinlogRowImage); err != nil {
 		// Only as of 5.6. We wish to support 5.5 as well
-		this.migrationContext.OriginalBinlogRowImage = ""
+		this.migrationContext.OriginalBinlogRowImage = "FULL"
 	}
 	this.migrationContext.OriginalBinlogRowImage = strings.ToUpper(this.migrationContext.OriginalBinlogRowImage)
 


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/184

While the code did make sure not to fail on `5.5`, it didn't set a reasonable default, namely `FULL`.
It does so now.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

