### PR TITLE
Reduce minimum maxLagMillisecondsThrottleThreshold to 100ms

### DIFF
--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -18,7 +18,7 @@ Both interfaces may serve at the same time. Both respond to simple text command,
 - `status`: returns a detailed status summary of migration progress and configuration
 - `sup`: returns a brief status summary of migration progress
 - `chunk-size=<newsize>`: modify the `chunk-size`; applies on next running copy-iteration
-- `max-lag-millis=<max-lag>`: modify the maximum replication lag threshold (milliseconds, minimum value is `1000`, i.e. 1 second)
+- `max-lag-millis=<max-lag>`: modify the maximum replication lag threshold (milliseconds, minimum value is `100`, i.e. `0.1` second)
 - `max-load=<max-load-thresholds>`: modify the `max-load` config; applies on next running copy-iteration
   The `max-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`. For example: `Threads_running=50,threads_connected=1000`, and you would then write/echo `max-load=Threads_running=50,threads_connected=1000` to the socket.
 - `critical-load=<load>`: change critical load setting (exceeding given thresholds causes panic and abort)

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -108,34 +108,36 @@ type MigrationContext struct {
 	InitiallyDropGhostTable      bool
 	CutOverType                  CutOver
 
-	Hostname                   string
-	TableEngine                string
-	RowsEstimate               int64
-	RowsDeltaEstimate          int64
-	UsedRowsEstimateMethod     RowsEstimateMethod
-	HasSuperPrivilege          bool
-	OriginalBinlogFormat       string
-	OriginalBinlogRowImage     string
-	InspectorConnectionConfig  *mysql.ConnectionConfig
-	ApplierConnectionConfig    *mysql.ConnectionConfig
-	StartTime                  time.Time
-	RowCopyStartTime           time.Time
-	RowCopyEndTime             time.Time
-	LockTablesStartTime        time.Time
-	RenameTablesStartTime      time.Time
-	RenameTablesEndTime        time.Time
-	pointOfInterestTime        time.Time
-	pointOfInterestTimeMutex   *sync.Mutex
-	CurrentLag                 int64
-	controlReplicasLagResult   mysql.ReplicationLagResult
-	TotalRowsCopied            int64
-	TotalDMLEventsApplied      int64
-	isThrottled                bool
-	throttleReason             string
-	throttleGeneralCheckResult ThrottleCheckResult
-	throttleMutex              *sync.Mutex
-	IsPostponingCutOver        int64
-	CountingRowsFlag           int64
+	Hostname                               string
+	TableEngine                            string
+	RowsEstimate                           int64
+	RowsDeltaEstimate                      int64
+	UsedRowsEstimateMethod                 RowsEstimateMethod
+	HasSuperPrivilege                      bool
+	OriginalBinlogFormat                   string
+	OriginalBinlogRowImage                 string
+	InspectorConnectionConfig              *mysql.ConnectionConfig
+	ApplierConnectionConfig                *mysql.ConnectionConfig
+	StartTime                              time.Time
+	RowCopyStartTime                       time.Time
+	RowCopyEndTime                         time.Time
+	LockTablesStartTime                    time.Time
+	RenameTablesStartTime                  time.Time
+	RenameTablesEndTime                    time.Time
+	pointOfInterestTime                    time.Time
+	pointOfInterestTimeMutex               *sync.Mutex
+	CurrentLag                             int64
+	controlReplicasLagResult               mysql.ReplicationLagResult
+	TotalRowsCopied                        int64
+	TotalDMLEventsApplied                  int64
+	isThrottled                            bool
+	throttleReason                         string
+	throttleGeneralCheckResult             ThrottleCheckResult
+	throttleMutex                          *sync.Mutex
+	IsPostponingCutOver                    int64
+	CountingRowsFlag                       int64
+	AllEventsUpToLockProcessedInjectedFlag int64
+	CleanupImminentFlag                    int64
 
 	OriginalTableColumns             *sql.ColumnList
 	OriginalTableUniqueKeys          [](*sql.UniqueKey)

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -324,8 +324,8 @@ func (this *MigrationContext) TimeSincePointOfInterest() time.Duration {
 }
 
 func (this *MigrationContext) SetMaxLagMillisecondsThrottleThreshold(maxLagMillisecondsThrottleThreshold int64) {
-	if maxLagMillisecondsThrottleThreshold < 1000 {
-		maxLagMillisecondsThrottleThreshold = 1000
+	if maxLagMillisecondsThrottleThreshold < 100 {
+		maxLagMillisecondsThrottleThreshold = 100
 	}
 	atomic.StoreInt64(&this.MaxLagMillisecondsThrottleThreshold, maxLagMillisecondsThrottleThreshold)
 }

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -81,6 +81,7 @@ func main() {
 	replicationLagQuery := flag.String("replication-lag-query", "", "Query that detects replication lag in seconds. Result can be a floating point (by default gh-ost issues SHOW SLAVE STATUS and reads Seconds_behind_master). If you're using pt-heartbeat, query would be something like: SELECT ROUND(UNIX_TIMESTAMP() - MAX(UNIX_TIMESTAMP(ts))) AS delay FROM my_schema.heartbeat")
 	throttleControlReplicas := flag.String("throttle-control-replicas", "", "List of replicas on which to check for lag; comma delimited. Example: myhost1.com:3306,myhost2.com,myhost3.com:3307")
 	throttleQuery := flag.String("throttle-query", "", "when given, issued (every second) to check if operation should throttle. Expecting to return zero for no-throttle, >0 for throttle. Query is issued on the migrated server. Make sure this query is lightweight")
+	heartbeatIntervalMillis := flag.Int64("heartbeat-interval-millis", 500, "how frequently would gh-ost inject a heartbeat value")
 	flag.StringVar(&migrationContext.ThrottleFlagFile, "throttle-flag-file", "", "operation pauses when this file exists; hint: use a file that is specific to the table being altered")
 	flag.StringVar(&migrationContext.ThrottleAdditionalFlagFile, "throttle-additional-flag-file", "/tmp/gh-ost.throttle", "operation pauses when this file exists; hint: keep default, use for throttling multiple gh-ost operations")
 	flag.StringVar(&migrationContext.PostponeCutOverFlagFile, "postpone-cut-over-flag-file", "", "while this file exists, migration will postpone the final stage of swapping tables, and will keep on syncing the ghost table. Cut-over/swapping would be ready to perform the moment the file is deleted.")
@@ -181,6 +182,7 @@ func main() {
 	if migrationContext.ServeSocketFile == "" {
 		migrationContext.ServeSocketFile = fmt.Sprintf("/tmp/gh-ost.%s.%s.sock", migrationContext.DatabaseName, migrationContext.OriginalTableName)
 	}
+	migrationContext.SetHeartbeatIntervalMilliseconds(*heartbeatIntervalMillis)
 	migrationContext.SetNiceRatio(*niceRatio)
 	migrationContext.SetChunkSize(*chunkSize)
 	migrationContext.SetMaxLagMillisecondsThrottleThreshold(*maxLagMillis)

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -258,7 +258,7 @@ func (this *Applier) WriteChangelogState(value string) (string, error) {
 
 // InitiateHeartbeat creates a heartbeat cycle, writing to the changelog table.
 // This is done asynchronously
-func (this *Applier) InitiateHeartbeat(heartbeatIntervalMilliseconds int64) {
+func (this *Applier) InitiateHeartbeat() {
 	var numSuccessiveFailures int64
 	injectHeartbeat := func() error {
 		if _, err := this.WriteChangelog("heartbeat", time.Now().Format(time.RFC3339Nano)); err != nil {
@@ -273,10 +273,10 @@ func (this *Applier) InitiateHeartbeat(heartbeatIntervalMilliseconds int64) {
 	}
 	injectHeartbeat()
 
-	heartbeatTick := time.Tick(time.Duration(heartbeatIntervalMilliseconds) * time.Millisecond)
+	heartbeatTick := time.Tick(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
 	for range heartbeatTick {
 		// Generally speaking, we would issue a goroutine, but I'd actually rather
-		// have this blocked rather than spam the master in the event something
+		// have this block the loop rather than spam the master in the event something
 		// goes wrong
 		if err := injectHeartbeat(); err != nil {
 			return

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -1,0 +1,256 @@
+/*
+   Copyright 2016 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package logic
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/github/gh-ost/go/base"
+	"github.com/github/gh-ost/go/mysql"
+	"github.com/outbrain/golib/log"
+)
+
+// Throttler collects metrics related to throttling and makes informed decisison
+// whether throttling should take place.
+type Throttler struct {
+	migrationContext *base.MigrationContext
+	applier          *Applier
+	inspector        *Inspector
+	panicAbort       chan error
+}
+
+func NewThrottler(applier *Applier, inspector *Inspector, panicAbort chan error) *Throttler {
+	return &Throttler{
+		migrationContext: base.GetMigrationContext(),
+		applier:          applier,
+		inspector:        inspector,
+		panicAbort:       panicAbort,
+	}
+}
+
+// shouldThrottle performs checks to see whether we should currently be throttling.
+// It merely observes the metrics collected by other components, it does not issue
+// its own metric collection.
+func (this *Throttler) shouldThrottle() (result bool, reason string) {
+	generalCheckResult := this.migrationContext.GetThrottleGeneralCheckResult()
+	if generalCheckResult.ShouldThrottle {
+		return generalCheckResult.ShouldThrottle, generalCheckResult.Reason
+	}
+	// Replication lag throttle
+	maxLagMillisecondsThrottleThreshold := atomic.LoadInt64(&this.migrationContext.MaxLagMillisecondsThrottleThreshold)
+	lag := atomic.LoadInt64(&this.migrationContext.CurrentLag)
+	if time.Duration(lag) > time.Duration(maxLagMillisecondsThrottleThreshold)*time.Millisecond {
+		return true, fmt.Sprintf("lag=%fs", time.Duration(lag).Seconds())
+	}
+	checkThrottleControlReplicas := true
+	if (this.migrationContext.TestOnReplica || this.migrationContext.MigrateOnReplica) && (atomic.LoadInt64(&this.migrationContext.AllEventsUpToLockProcessedInjectedFlag) > 0) {
+		checkThrottleControlReplicas = false
+	}
+	if checkThrottleControlReplicas {
+		lagResult := this.migrationContext.GetControlReplicasLagResult()
+		if lagResult.Err != nil {
+			return true, fmt.Sprintf("%+v %+v", lagResult.Key, lagResult.Err)
+		}
+		if lagResult.Lag > time.Duration(maxLagMillisecondsThrottleThreshold)*time.Millisecond {
+			return true, fmt.Sprintf("%+v replica-lag=%fs", lagResult.Key, lagResult.Lag.Seconds())
+		}
+	}
+	// Got here? No metrics indicates we need throttling.
+	return false, ""
+}
+
+// parseChangelogHeartbeat is called when a heartbeat event is intercepted
+func (this *Throttler) parseChangelogHeartbeat(heartbeatValue string) (err error) {
+	heartbeatTime, err := time.Parse(time.RFC3339Nano, heartbeatValue)
+	if err != nil {
+		return log.Errore(err)
+	}
+	lag := time.Since(heartbeatTime)
+	atomic.StoreInt64(&this.migrationContext.CurrentLag, int64(lag))
+	return nil
+}
+
+// collectHeartbeat reads the latest changelog heartbeat value
+func (this *Throttler) collectHeartbeat() {
+	ticker := time.Tick(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
+	for range ticker {
+		go func() error {
+			if atomic.LoadInt64(&this.migrationContext.CleanupImminentFlag) > 0 {
+				return nil
+			}
+			changelogState, err := this.inspector.readChangelogState()
+			if err != nil {
+				return log.Errore(err)
+			}
+			if heartbeatValue, ok := changelogState["heartbeat"]; ok {
+				this.parseChangelogHeartbeat(heartbeatValue)
+			}
+			return nil
+		}()
+	}
+}
+
+// collectControlReplicasLag polls all the control replicas to get maximum lag value
+func (this *Throttler) collectControlReplicasLag() {
+	readControlReplicasLag := func(replicationLagQuery string) error {
+		if (this.migrationContext.TestOnReplica || this.migrationContext.MigrateOnReplica) && (atomic.LoadInt64(&this.migrationContext.AllEventsUpToLockProcessedInjectedFlag) > 0) {
+			return nil
+		}
+		lagResult := mysql.GetMaxReplicationLag(
+			this.migrationContext.InspectorConnectionConfig,
+			this.migrationContext.GetThrottleControlReplicaKeys(),
+			replicationLagQuery,
+		)
+		this.migrationContext.SetControlReplicasLagResult(lagResult)
+		return nil
+	}
+	aggressiveTicker := time.Tick(100 * time.Millisecond)
+	relaxedFactor := 10
+	counter := 0
+	shouldReadLagAggressively := false
+	replicationLagQuery := ""
+
+	for range aggressiveTicker {
+		if counter%relaxedFactor == 0 {
+			// we only check if we wish to be aggressive once per second. The parameters for being aggressive
+			// do not typically change at all throughout the migration, but nonetheless we check them.
+			counter = 0
+			maxLagMillisecondsThrottleThreshold := atomic.LoadInt64(&this.migrationContext.MaxLagMillisecondsThrottleThreshold)
+			replicationLagQuery = this.migrationContext.GetReplicationLagQuery()
+			shouldReadLagAggressively = (replicationLagQuery != "" && maxLagMillisecondsThrottleThreshold < 1000)
+		}
+		if counter == 0 || shouldReadLagAggressively {
+			// We check replication lag every so often, or if we wish to be aggressive
+			readControlReplicasLag(replicationLagQuery)
+		}
+		counter++
+	}
+}
+
+// collectGeneralThrottleMetrics reads the once-per-sec metrics, and stores them onto this.migrationContext
+func (this *Throttler) collectGeneralThrottleMetrics() error {
+
+	setThrottle := func(throttle bool, reason string) error {
+		this.migrationContext.SetThrottleGeneralCheckResult(base.NewThrottleCheckResult(throttle, reason))
+		return nil
+	}
+
+	// Regardless of throttle, we take opportunity to check for panic-abort
+	if this.migrationContext.PanicFlagFile != "" {
+		if base.FileExists(this.migrationContext.PanicFlagFile) {
+			this.panicAbort <- fmt.Errorf("Found panic-file %s. Aborting without cleanup", this.migrationContext.PanicFlagFile)
+		}
+	}
+	criticalLoad := this.migrationContext.GetCriticalLoad()
+	for variableName, threshold := range criticalLoad {
+		value, err := this.applier.ShowStatusVariable(variableName)
+		if err != nil {
+			return setThrottle(true, fmt.Sprintf("%s %s", variableName, err))
+		}
+		if value >= threshold {
+			this.panicAbort <- fmt.Errorf("critical-load met: %s=%d, >=%d", variableName, value, threshold)
+		}
+	}
+
+	// Back to throttle considerations
+
+	// User-based throttle
+	if atomic.LoadInt64(&this.migrationContext.ThrottleCommandedByUser) > 0 {
+		return setThrottle(true, "commanded by user")
+	}
+	if this.migrationContext.ThrottleFlagFile != "" {
+		if base.FileExists(this.migrationContext.ThrottleFlagFile) {
+			// Throttle file defined and exists!
+			return setThrottle(true, "flag-file")
+		}
+	}
+	if this.migrationContext.ThrottleAdditionalFlagFile != "" {
+		if base.FileExists(this.migrationContext.ThrottleAdditionalFlagFile) {
+			// 2nd Throttle file defined and exists!
+			return setThrottle(true, "flag-file")
+		}
+	}
+
+	maxLoad := this.migrationContext.GetMaxLoad()
+	for variableName, threshold := range maxLoad {
+		value, err := this.applier.ShowStatusVariable(variableName)
+		if err != nil {
+			return setThrottle(true, fmt.Sprintf("%s %s", variableName, err))
+		}
+		if value >= threshold {
+			return setThrottle(true, fmt.Sprintf("max-load %s=%d >= %d", variableName, value, threshold))
+		}
+	}
+	if this.migrationContext.GetThrottleQuery() != "" {
+		if res, _ := this.applier.ExecuteThrottleQuery(); res > 0 {
+			return setThrottle(true, "throttle-query")
+		}
+	}
+
+	return setThrottle(false, "")
+}
+
+// initiateThrottlerMetrics initiates the various processes that collect measurements
+// that may affect throttling. There are several components, all running independently,
+// that collect such metrics.
+func (this *Throttler) initiateThrottlerCollection(firstThrottlingCollected chan<- bool) {
+	go this.collectHeartbeat()
+	go this.collectControlReplicasLag()
+
+	go func() {
+		throttlerMetricsTick := time.Tick(1 * time.Second)
+		this.collectGeneralThrottleMetrics()
+		firstThrottlingCollected <- true
+		for range throttlerMetricsTick {
+			this.collectGeneralThrottleMetrics()
+		}
+	}()
+}
+
+// initiateThrottlerChecks initiates the throttle ticker and sets the basic behavior of throttling.
+func (this *Throttler) initiateThrottlerChecks() error {
+	throttlerTick := time.Tick(100 * time.Millisecond)
+
+	throttlerFunction := func() {
+		alreadyThrottling, currentReason := this.migrationContext.IsThrottled()
+		shouldThrottle, throttleReason := this.shouldThrottle()
+		if shouldThrottle && !alreadyThrottling {
+			// New throttling
+			this.applier.WriteAndLogChangelog("throttle", throttleReason)
+		} else if shouldThrottle && alreadyThrottling && (currentReason != throttleReason) {
+			// Change of reason
+			this.applier.WriteAndLogChangelog("throttle", throttleReason)
+		} else if alreadyThrottling && !shouldThrottle {
+			// End of throttling
+			this.applier.WriteAndLogChangelog("throttle", "done throttling")
+		}
+		this.migrationContext.SetThrottled(shouldThrottle, throttleReason)
+	}
+	throttlerFunction()
+	for range throttlerTick {
+		throttlerFunction()
+	}
+
+	return nil
+}
+
+// throttle sees if throttling needs take place, and if so, continuously sleeps (blocks)
+// until throttling reasons are gone
+func (this *Throttler) throttle(onThrottled func()) {
+	for {
+		// IsThrottled() is non-blocking; the throttling decision making takes place asynchronously.
+		// Therefore calling IsThrottled() is cheap
+		if shouldThrottle, _ := this.migrationContext.IsThrottled(); !shouldThrottle {
+			return
+		}
+		if onThrottled != nil {
+			onThrottled()
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
This PR reduces the minimum value for maxLagMillisecondsThrottleThreshold from 1000ms to 100ms per https://github.com/github/gh-ost/issues/203.


> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] code is formatted via `gofmt` (please avoid `goimports`)
- [ ] code is built via `./build.sh`
- [ ] code is tested via `./test.sh`

