### PR TITLE
indicating 100% when rowcopy is complete

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1026,7 +1026,9 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	} else {
 		progressPct = 100.0 * float64(totalRowsCopied) / float64(rowsEstimate)
 	}
-
+	if atomic.LoadInt64(&this.rowCopyCompleteFlag) == 1 {
+		progressPct = 100.0
+	}
 	// Before status, let's see if we should print a nice reminder for what exactly we're doing here.
 	shouldPrintMigrationStatusHint := (elapsedSeconds%600 == 0)
 	if rule == ForcePrintStatusAndHintRule {


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/209

in this PR the progress pct is set to `100.0%` when row-copy is known to be complete, regardless of computation.
The rowcount is always an inaccurate estimate. However `gh-ost` knows when it is complete, and at that time, `100.0%` is the correct progress.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

