### PR TITLE
Modified definition of `critical-load`

### DIFF
--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -20,9 +20,17 @@ Both interfaces may serve at the same time. Both respond to simple text command,
 - `chunk-size=<newsize>`: modify the `chunk-size`; applies on next running copy-iteration
 - `max-lag-millis=<max-lag>`: modify the maximum replication lag threshold (milliseconds, minimum value is `100`, i.e. `0.1` second)
 - `max-load=<max-load-thresholds>`: modify the `max-load` config; applies on next running copy-iteration
-  The `max-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`. For example: `Threads_running=50,threads_connected=1000`, and you would then write/echo `max-load=Threads_running=50,threads_connected=1000` to the socket.
-- `critical-load=<load>`: change critical load setting (exceeding given thresholds causes panic and abort)
-- `nice-ratio=<ratio>`: change _nice_ ratio: 0 for aggressive (not nice, not sleeping), positive integer `n`: for any `1ms` spent copying rows, spend `n*1ms` units of time sleeping. Examples: assume a single rows chunk copy takes `100ms` to complete. `nice-ratio=0.5` will cause `gh-ost` to sleep for `50ms` immediately following. `nice-ratio=1` will cause `gh-ost` to sleep for `100ms`, effectively doubling runtime; value of `2` will effectively triple the runtime; etc.
+  - The `max-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`'
+  - For example: `Threads_running=50,threads_connected=1000`, and you would then write/echo `max-load=Threads_running=50,threads_connected=1000` to the socket.
+- `critical-load=<critical-load-thresholds>`: modify the `critical-load` config (exceeding these thresholds aborts the operation)
+  - The `critical-load` format must be: `some_status=<numeric-threshold>[,some_status=<numeric-threshold>...]`'
+  - For example: `Threads_running=1000,threads_connected=5000`, and you would then write/echo `critical-load=Threads_running=1000,threads_connected=5000` to the socket.
+- `nice-ratio=<ratio>`: change _nice_ ratio: 0 for aggressive (not nice, not sleeping), positive integer `n`:
+  - For any `1ms` spent copying rows, spend `n*1ms` units of time sleeping. 
+  - Examples: assume a single rows chunk copy takes `100ms` to complete. 
+    - `nice-ratio=0.5` will cause `gh-ost` to sleep for `50ms` immediately following. 
+    - `nice-ratio=1` will cause `gh-ost` to sleep for `100ms`, effectively doubling runtime
+    - value of `2` will effectively triple the runtime; etc.
 - `throttle-query`: change throttle query
 - `throttle-control-replicas='replica1,replica2'`: change list of throttle-control replicas, these are replicas `gh-ost` will check. This takes a comma separated list of replica's to check and replaces the previous list.
 - `throttle`: force migration suspend


### PR DESCRIPTION
This PR is just to update the help docs to clarify `--critical-load`, because it didn't give the format for the option like it did for `--max-load`, and people who aren't used to running `pt-online-schema-change` won't necessarily recognize that they're related.

I mostly copied the `--max-load` definition and added some embedded list items to break lines, because I couldn't figure out from markdown how to do newlines within list items. 

/cc https://github.com/github/shell/pull/3842 as the use case for the option
/cc @github/database-infrastructure for feedback on docs change