### PR TITLE
Eta status

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.15"
+RELEASE_VERSION="1.0.16"
 
 function build {
     osname=$1


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/197

This splits `ETA` into `State` & `ETA`.

- `State` indicates progress state (migrating? throttled? postponed?)
- `ETA` indicates time to complete, if such info is available

The direct result of this change is that `ETA` presents time to complete even when the migration is throttled.

- [ ] contributed code is using same conventions as original code
- [ ] code is formatted via `gofmt` (please avoid `goimports`)
- [ ] code is built via `./build.sh`
- [ ] code is tested via `./test.sh`
