### PR TITLE
Add -override-applier-host for use with -allow-master-master

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -109,6 +109,7 @@ type MigrationContext struct {
 	CutOverType                  CutOver
 
 	Hostname                               string
+	OverrideApplierHostname                string
 	TableEngine                            string
 	RowsEstimate                           int64
 	RowsDeltaEstimate                      int64

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -44,6 +44,7 @@ func main() {
 	migrationContext := base.GetMigrationContext()
 
 	flag.StringVar(&migrationContext.InspectorConnectionConfig.Key.Hostname, "host", "127.0.0.1", "MySQL hostname (preferably a replica, not the master)")
+	flag.StringVar(&migrationContext.OverrideApplierHostname, "override-applier-host", "", "(with -allow-master-master), optionally specify which host should have changes applied to it")
 	flag.IntVar(&migrationContext.InspectorConnectionConfig.Key.Port, "port", 3306, "MySQL port (preferably a replica, not the master)")
 	flag.StringVar(&migrationContext.CliUser, "user", "", "MySQL user")
 	flag.StringVar(&migrationContext.CliPassword, "password", "", "MySQL password")
@@ -160,6 +161,9 @@ func main() {
 			log.Fatalf("--test-on-replica-skip-replica-stop requires --test-on-replica to be enabled")
 		}
 		log.Warning("--test-on-replica-skip-replica-stop enabled. We will not stop replication before cut-over. Ensure you have a plugin that does this.")
+	}
+	if migrationContext.OverrideApplierHostname != "" && !migrationContext.AllowedMasterMaster {
+		log.Fatalf("--override-applier-host is only for use with --allow-master-amster")
 	}
 
 	switch *cutOver {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -759,6 +759,9 @@ func (this *Migrator) initiateInspector() (err error) {
 	if this.migrationContext.ApplierConnectionConfig, err = this.inspector.getMasterConnectionConfig(); err != nil {
 		return err
 	}
+	if this.migrationContext.OverrideApplierHostname != "" {
+		this.migrationContext.ApplierConnectionConfig.Key.Hostname = this.migrationContext.OverrideApplierHostname
+	}
 	if this.migrationContext.TestOnReplica || this.migrationContext.MigrateOnReplica {
 		if this.migrationContext.InspectorIsAlsoApplier() {
 			return fmt.Errorf("Instructed to --test-on-replica or --migrate-on-replica, but the server we connect to doesn't seem to be a replica")


### PR DESCRIPTION
This is for configurations where writes are meant to go to one master, but gh-ost can't automatically determine which.

Related discussion on https://github.com/github/gh-ost/issues/212 -- it looks like there are a couple use cases where this comes in handy, and we've done a migration using the flag on our cluster.

I could rename it something like -active-master since that's closer to how the user thinks of it. It could be required when master-master is allowed and there are at least three nodes. I should get an idea what you think before going down any of those paths.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`