### PR TITLE
Hooks: more environment variables

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.16"
+RELEASE_VERSION="1.0.17"
 
 function build {
     osname=$1

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -58,13 +58,16 @@ The following variables are available on all hooks:
 - `GH_OST_DATABASE_NAME`
 - `GH_OST_TABLE_NAME`
 - `GH_OST_GHOST_TABLE_NAME`
-- `GH_OST_OLD_TABLE_NAME`
+- `GH_OST_OLD_TABLE_NAME` - the name the original table will be renamed to at the end of operation
 - `GH_OST_DDL`
-- `GH_OST_ELAPSED_SECONDS`
+- `GH_OST_ELAPSED_SECONDS` - total runtime
+- `GH_OST_ELAPSED_COPY_SECONDS` - row-copy time (excluding startup, row-count and postpone time)
+- `GH_OST_ESTIMATED_ROWS` - estimated total rows in table
+- `GH_OST_COPIED_ROWS` - number of rows copied by `gh-ost`
 - `GH_OST_MIGRATED_HOST`
 - `GH_OST_INSPECTED_HOST`
 - `GH_OST_EXECUTING_HOST`
-- `GH_OST_HOOKS_HINT`
+- `GH_OST_HOOKS_HINT` - copy of `--hooks-hint` value
 
 The following variable are available on particular hooks:
 

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 
 	"github.com/github/gh-ost/go/base"
 	"github.com/outbrain/golib/log"
@@ -53,6 +54,11 @@ func (this *HooksExecutor) applyEnvironmentVairables(extraVariables ...string) [
 	env = append(env, fmt.Sprintf("GH_OST_OLD_TABLE_NAME=%s", this.migrationContext.GetOldTableName()))
 	env = append(env, fmt.Sprintf("GH_OST_DDL=%s", this.migrationContext.AlterStatement))
 	env = append(env, fmt.Sprintf("GH_OST_ELAPSED_SECONDS=%f", this.migrationContext.ElapsedTime().Seconds()))
+	env = append(env, fmt.Sprintf("GH_OST_ELAPSED_COPY_SECONDS=%f", this.migrationContext.ElapsedRowCopyTime().Seconds()))
+	estimatedRows := atomic.LoadInt64(&this.migrationContext.RowsEstimate) + atomic.LoadInt64(&this.migrationContext.RowsDeltaEstimate)
+	env = append(env, fmt.Sprintf("GH_OST_ESTIMATED_ROWS=%d", estimatedRows))
+	totalRowsCopied := this.migrationContext.GetTotalRowsCopied()
+	env = append(env, fmt.Sprintf("GH_OST_COPIED_ROWS=%d", totalRowsCopied))
 	env = append(env, fmt.Sprintf("GH_OST_MIGRATED_HOST=%s", this.migrationContext.ApplierConnectionConfig.ImpliedKey.Hostname))
 	env = append(env, fmt.Sprintf("GH_OST_INSPECTED_HOST=%s", this.migrationContext.InspectorConnectionConfig.ImpliedKey.Hostname))
 	env = append(env, fmt.Sprintf("GH_OST_EXECUTING_HOST=%s", this.migrationContext.Hostname))

--- a/resources/hooks-sample/gh-ost-on-success-hook-2
+++ b/resources/hooks-sample/gh-ost-on-success-hook-2
@@ -3,3 +3,4 @@
 # Sample hook file for gh-ost-on-success
 
 echo "$(date) gh-ost-on-success $GH_OST_DATABASE_NAME.$GH_OST_TABLE_NAME -- this message should show on the gh-ost log"
+echo "$(date) gh-ost-on-success copied $GH_OST_COPIED_ROWS rows in $GH_OST_ELAPSED_COPY_SECONDS seconds. Total runtime was $GH_OST_ELAPSED_SECONDS seconds"


### PR DESCRIPTION
Adding a few more env variables to hooks, this gives better visibility into the migration state.

Storyline: #62, #190 

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`
