### PR TITLE
safe access to applier/inspector hostnames for hooks

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -236,6 +236,28 @@ func (this *MigrationContext) RequiresBinlogFormatChange() bool {
 	return this.OriginalBinlogFormat != "ROW"
 }
 
+// GetApplierHostname is a safe access method to the applier hostname
+func (this *MigrationContext) GetApplierHostname() string {
+	if this.ApplierConnectionConfig == nil {
+		return ""
+	}
+	if this.ApplierConnectionConfig.ImpliedKey == nil {
+		return ""
+	}
+	return this.ApplierConnectionConfig.ImpliedKey.Hostname
+}
+
+// GetInspectorHostname is a safe access method to the inspector hostname
+func (this *MigrationContext) GetInspectorHostname() string {
+	if this.InspectorConnectionConfig == nil {
+		return ""
+	}
+	if this.InspectorConnectionConfig.ImpliedKey == nil {
+		return ""
+	}
+	return this.InspectorConnectionConfig.ImpliedKey.Hostname
+}
+
 // InspectorIsAlsoApplier is `true` when the both inspector and applier are the
 // same database instance. This would be true when running directly on master or when
 // testing on replica.

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -59,8 +59,8 @@ func (this *HooksExecutor) applyEnvironmentVairables(extraVariables ...string) [
 	env = append(env, fmt.Sprintf("GH_OST_ESTIMATED_ROWS=%d", estimatedRows))
 	totalRowsCopied := this.migrationContext.GetTotalRowsCopied()
 	env = append(env, fmt.Sprintf("GH_OST_COPIED_ROWS=%d", totalRowsCopied))
-	env = append(env, fmt.Sprintf("GH_OST_MIGRATED_HOST=%s", this.migrationContext.ApplierConnectionConfig.ImpliedKey.Hostname))
-	env = append(env, fmt.Sprintf("GH_OST_INSPECTED_HOST=%s", this.migrationContext.InspectorConnectionConfig.ImpliedKey.Hostname))
+	env = append(env, fmt.Sprintf("GH_OST_MIGRATED_HOST=%s", this.migrationContext.GetApplierHostname()))
+	env = append(env, fmt.Sprintf("GH_OST_INSPECTED_HOST=%s", this.migrationContext.GetInspectorHostname()))
 	env = append(env, fmt.Sprintf("GH_OST_EXECUTING_HOST=%s", this.migrationContext.Hostname))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT=%s", this.migrationContext.HooksHintMessage))
 


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/256

this PR provides safe access to applier/inspector hostnames, such that `nil` references are silenced.