### PR TITLE
assume-master-host now applies ImpliedKey

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.20"
+RELEASE_VERSION="1.0.21"
 
 function build {
     osname=$1

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -624,6 +624,7 @@ func (this *Migrator) initiateInspector() (err error) {
 			return err
 		} else {
 			this.migrationContext.ApplierConnectionConfig.Key = *key
+			this.migrationContext.ApplierConnectionConfig.ImpliedKey = key
 		}
 	}
 	if this.migrationContext.TestOnReplica || this.migrationContext.MigrateOnReplica {

--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -26,17 +26,19 @@ func NewConnectionConfig() *ConnectionConfig {
 	return config
 }
 
-func (this *ConnectionConfig) Duplicate() *ConnectionConfig {
+// DuplicateCredentials creates a new connection config with given key and with same credentials as this config
+func (this *ConnectionConfig) DuplicateCredentials(key InstanceKey) *ConnectionConfig {
 	config := &ConnectionConfig{
-		Key: InstanceKey{
-			Hostname: this.Key.Hostname,
-			Port:     this.Key.Port,
-		},
+		Key:      key,
 		User:     this.User,
 		Password: this.Password,
 	}
 	config.ImpliedKey = &config.Key
 	return config
+}
+
+func (this *ConnectionConfig) Duplicate() *ConnectionConfig {
+	return this.DuplicateCredentials(this.Key)
 }
 
 func (this *ConnectionConfig) String() string {

--- a/go/mysql/connection_test.go
+++ b/go/mysql/connection_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright 2016 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestNewConnectionConfig(t *testing.T) {
+	c := NewConnectionConfig()
+	test.S(t).ExpectEquals(c.Key.Hostname, "")
+	test.S(t).ExpectEquals(c.Key.Port, 0)
+	test.S(t).ExpectEquals(c.ImpliedKey.Hostname, "")
+	test.S(t).ExpectEquals(c.ImpliedKey.Port, 0)
+	test.S(t).ExpectEquals(c.User, "")
+	test.S(t).ExpectEquals(c.Password, "")
+}
+
+func TestDuplicateCredentials(t *testing.T) {
+	c := NewConnectionConfig()
+	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
+	c.User = "gromit"
+	c.Password = "penguin"
+
+	dup := c.DuplicateCredentials(InstanceKey{Hostname: "otherhost", Port: 3310})
+	test.S(t).ExpectEquals(dup.Key.Hostname, "otherhost")
+	test.S(t).ExpectEquals(dup.Key.Port, 3310)
+	test.S(t).ExpectEquals(dup.ImpliedKey.Hostname, "otherhost")
+	test.S(t).ExpectEquals(dup.ImpliedKey.Port, 3310)
+	test.S(t).ExpectEquals(dup.User, "gromit")
+	test.S(t).ExpectEquals(dup.Password, "penguin")
+}
+
+func TestDuplicate(t *testing.T) {
+	c := NewConnectionConfig()
+	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
+	c.User = "gromit"
+	c.Password = "penguin"
+
+	dup := c.Duplicate()
+	test.S(t).ExpectEquals(dup.Key.Hostname, "myhost")
+	test.S(t).ExpectEquals(dup.Key.Port, 3306)
+	test.S(t).ExpectEquals(dup.ImpliedKey.Hostname, "myhost")
+	test.S(t).ExpectEquals(dup.ImpliedKey.Port, 3306)
+	test.S(t).ExpectEquals(dup.User, "gromit")
+	test.S(t).ExpectEquals(dup.Password, "penguin")
+}


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/212#issuecomment-251907157

The `--allow-on-master` flag shouldn't be required when specifying `--host=some.replica --assume-master-host=identity.of.master`.