### PR TITLE
Updating template to request markdown and test case

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,13 @@
-> This is the place to report a bug, ask a question, suggest an enhancement.
+> This is the place to report a bug, ask a question, or suggest an enhancement.
 
-> This is the place to make a discussion before creating a PR.
+> This is also the place to make a discussion before creating a PR.
 
-> Please label your Issue
+> If this is a bug report, please provide a test case (e.g., your table definition and gh-ost command) and the error output.
 
-> Please understand if this Issue is not addressed immediately or in a timeframe you were expecting.
+> Please use markdown to format code or SQL: https://guides.github.com/features/mastering-markdown/
+
+> Please label the issue on the right (bug, enhancement, question, etc.).
+
+> And please understand if this issue is not addressed immediately or in a timeframe you were expecting.
 
 > Thank you!


### PR DESCRIPTION
This PR edits the issue template for this repository. It adds a request for a test case and error output, and gives the link to the markdown help docs.

I keep seeing @shlomi-noach asking people to provide test cases and output and to use markdown to format their SQL and output in existing issues, so I thought that could just be put in the issue template to save time.

/cc @github/database-infrastructure 