### PR TITLE
validating table structure on applier and migrator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 #
 #
 
-RELEASE_VERSION="1.0.23"
+RELEASE_VERSION="1.0.26"
 
 function build {
     osname=$1

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -147,6 +147,7 @@ type MigrationContext struct {
 	UserCommandedUnpostponeFlag            int64
 	PanicAbort                             chan error
 
+	OriginalTableColumnsOnApplier    *sql.ColumnList
 	OriginalTableColumns             *sql.ColumnList
 	OriginalTableUniqueKeys          [](*sql.UniqueKey)
 	GhostTableColumns                *sql.ColumnList

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -67,6 +67,9 @@ func (this *Applier) InitDBConnections() (err error) {
 	} else {
 		this.connectionConfig.ImpliedKey = impliedKey
 	}
+	if err := this.readTableColumns(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -92,6 +95,16 @@ func (this *Applier) validateAndReadTimeZone() error {
 	}
 
 	log.Infof("will use time_zone='%s' on applier", this.migrationContext.ApplierTimeZone)
+	return nil
+}
+
+// readTableColumns reads table columns on applier
+func (this *Applier) readTableColumns() (err error) {
+	log.Infof("Examining table structure on applier")
+	this.migrationContext.OriginalTableColumnsOnApplier, err = mysql.GetTableColumns(this.db, this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/github/gh-ost/issues/276

This compares table structure on applier and on migrator (i.e. master & replica on replica-based migration) and expects identical columns.

- indexes not verified