### PR TITLE
reading and reporting replication lag before waiting on initial repli…

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/mysql"
@@ -689,4 +690,13 @@ func (this *Inspector) readChangelogState() (map[string]string, error) {
 func (this *Inspector) getMasterConnectionConfig() (applierConfig *mysql.ConnectionConfig, err error) {
 	visitedKeys := mysql.NewInstanceKeyMap()
 	return mysql.GetMasterConnectionConfigSafe(this.connectionConfig, visitedKeys, this.migrationContext.AllowedMasterMaster)
+}
+
+func (this *Inspector) getReplicationLag() (replicationLag time.Duration, err error) {
+	replicationLagQuery := this.migrationContext.GetReplicationLagQuery()
+	lag, err := mysql.GetReplicationLag(
+		this.migrationContext.InspectorConnectionConfig,
+		replicationLagQuery,
+	)
+	return lag, err
 }

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -694,9 +694,9 @@ func (this *Inspector) getMasterConnectionConfig() (applierConfig *mysql.Connect
 
 func (this *Inspector) getReplicationLag() (replicationLag time.Duration, err error) {
 	replicationLagQuery := this.migrationContext.GetReplicationLagQuery()
-	lag, err := mysql.GetReplicationLag(
+	replicationLag, err = mysql.GetReplicationLag(
 		this.migrationContext.InspectorConnectionConfig,
 		replicationLagQuery,
 	)
-	return lag, err
+	return replicationLag, err
 }

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -291,7 +291,8 @@ func (this *Migrator) Migrate() (err error) {
 		return err
 	}
 
-	log.Infof("Waiting for ghost table to be migrated")
+	initialLag, _ := this.inspector.getReplicationLag()
+	log.Infof("Waiting for ghost table to be migrated. Current lag is %+v", initialLag)
 	<-this.ghostTableMigrated
 	log.Debugf("ghost table migrated")
 	// Yay! We now know the Ghost and Changelog tables are good to examine!


### PR DESCRIPTION
closes https://github.com/github/gh-ost/issues/304

The replication lag is reported as follows:

```
2016-11-02 12:45:48 INFO Waiting for ghost table to be migrated. Current lag is 0
```

or
```
2016-11-02 12:50:36 INFO Waiting for ghost table to be migrated. Current lag is 6s
```

etc.

This at least makes it clearer why `Waiting for ghost table to be migrated` hangs when replica is lagging.