### PR TITLE
Fixing hanging cut-over waiting on `AllEventsUpToLockProcessed`

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -694,8 +694,7 @@ func (this *Applier) DropAtomicCutOverSentryTableIfExists() error {
 	return this.dropTable(tableName)
 }
 
-// DropAtomicCutOverSentryTableIfExists checks if the "old" table name
-// happens to be a cut-over magic table; if so, it drops it.
+// CreateAtomicCutOverSentryTable
 func (this *Applier) CreateAtomicCutOverSentryTable() error {
 	if err := this.DropAtomicCutOverSentryTableIfExists(); err != nil {
 		return err

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -31,6 +31,10 @@ const (
 	AllEventsUpToLockProcessed                = "AllEventsUpToLockProcessed"
 )
 
+func ReadChangelogState(s string) ChangelogState {
+	return ChangelogState(strings.Split(s, ":")[0])
+}
+
 type tableWriteFunc func() error
 
 const (
@@ -182,7 +186,7 @@ func (this *Migrator) onChangelogStateEvent(dmlEvent *binlog.BinlogDMLEvent) (er
 		return nil
 	}
 	changelogStateString := dmlEvent.NewColumnValues.StringColumn(3)
-	changelogState := ChangelogState(strings.Split(changelogStateString, ":")[0])
+	changelogState := ReadChangelogState(changelogStateString)
 	log.Infof("Intercepted changelog state %s", changelogState)
 	switch changelogState {
 	case GhostTableMigrated:


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/314

This PR addresses the issue of cut-over hanging while attempting to intercept the `AllEventsUpToLockProcessed` state.

Initial commit:

- `waitForEventsUpToLock()` timeout -- if for whatever reason we are not able to intercept the event, we timeout
- more info (logging) on `AllEventsUpToLockProcessed`, before and after injecting/intercepting

ongoing work.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`
