### PR TITLE
check the slave status when find recursive find the master, so suppor…

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -692,7 +692,7 @@ func (this *Inspector) readChangelogState() (map[string]string, error) {
 }
 
 func (this *Inspector) getMasterConnectionConfig() (applierConfig *mysql.ConnectionConfig, err error) {
-	log.Infof("Start find master, recursive to execute show slave status from the host to find the master.")
+	log.Infof("Recursively searching for replication master")
 	visitedKeys := mysql.NewInstanceKeyMap()
 	return mysql.GetMasterConnectionConfigSafe(this.connectionConfig, visitedKeys, this.migrationContext.AllowedMasterMaster)
 }

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -692,6 +692,7 @@ func (this *Inspector) readChangelogState() (map[string]string, error) {
 }
 
 func (this *Inspector) getMasterConnectionConfig() (applierConfig *mysql.ConnectionConfig, err error) {
+	log.Infof("Start find master, recursive to execute show slave status from the host to find the master.")
 	visitedKeys := mysql.NewInstanceKeyMap()
 	return mysql.GetMasterConnectionConfigSafe(this.connectionConfig, visitedKeys, this.migrationContext.AllowedMasterMaster)
 }

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -83,7 +83,10 @@ func GetMasterKeyFromSlaveStatus(connectionConfig *ConnectionConfig) (masterKey 
 		return nil, err
 	}
 	err = sqlutils.QueryRowsMap(db, `show slave status`, func(rowMap sqlutils.RowMap) error {
-		// Using reset slave not reset slave all, the Master_Log_File is empty.
+		// We wish to recognize the case where the topology's master actually has replication configuration.
+		// This can happen when a DBA issues a `RESET SLAVE` instead of `RESET SLAVE ALL`.
+
+		// An empty log file indicates this is a master:
 		if rowMap.GetString("Master_Log_File") == "" {
 			return nil
 		}
@@ -91,10 +94,10 @@ func GetMasterKeyFromSlaveStatus(connectionConfig *ConnectionConfig) (masterKey 
 		slaveIORunning := rowMap.GetString("Slave_IO_Running")
 		slaveSQLRunning := rowMap.GetString("Slave_SQL_Running")
 
-		// If not using reset slave or reset slave all and slave is break, something is wrong, so we stop.
+		//
 		if slaveIORunning != "Yes" || slaveSQLRunning != "Yes" {
-			return fmt.Errorf("The slave %s is break: Slave_IO_Running:%s Slave_SQL_Running:%s please make sure the replication is correct.",
-				connectionConfig.Key.Hostname,
+			return fmt.Errorf("Replication on %+v is broken: Slave_IO_Running: %s, Slave_SQL_Running: %s. Please make sure replication runs before using gh-ost.",
+				connectionConfig.Key,
 				slaveIORunning,
 				slaveSQLRunning,
 			)

--- a/localtests/trivial/create.sql
+++ b/localtests/trivial/create.sql
@@ -1,0 +1,13 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  color varchar(32),
+  primary key(id)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+
+insert into gh_ost_test values (null, 11, 'red');
+insert into gh_ost_test values (null, 13, 'green');
+insert into gh_ost_test values (null, 17, 'blue');

--- a/localtests/trivial/extra_args
+++ b/localtests/trivial/extra_args
@@ -1,0 +1,1 @@
+--throttle-query='select false' \


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/323

The following is all don.
- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`
- [x] the binary is test.
- [x] the log does not output.


### Description

1. DBA using reset slave rather than reset slave all. The Master_Host and Master_Port exist.
2. DBA not execute reset slave or reset slave all when they promote the slave to master. The Master_Host and Master_Port exist, but the replication is break.

In the above case, we using recursive to execute show slave status from the host to find the master but not check the slave status, may find the wrong master.

So we can check the Master_Log_File and Slave_IO_Running Slave_SQL_Running.

```
if show slave status output is not empty:
    if Master_Log_File is empty:
        return
    else    Slave_IO_Running or Slave_SQL_Running not yes:
       exit
    else
       this may be the master
```

**Have a question,** I think log before we recursive  find the master, but he log.Infof not work in go/logic/inspect.go.