### PR TITLE
don't check the critical-load at cut-over section

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -219,7 +219,11 @@ func (this *Migrator) onChangelogStateEvent(dmlEvent *binlog.BinlogDMLEvent) (er
 // listenOnPanicAbort aborts on abort request
 func (this *Migrator) listenOnPanicAbort() {
 	err := <-this.migrationContext.PanicAbort
+
+	//should cleanup before exit.
+	this.finalCleanup()
 	log.Fatale(err)
+
 }
 
 // validateStatement validates the `alter` statement meets criteria.

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -163,10 +163,15 @@ func (this *Throttler) collectGeneralThrottleMetrics() error {
 	if err != nil {
 		return setThrottle(true, fmt.Sprintf("%s %s", variableName, err), base.NoThrottleReasonHint)
 	}
-	if criticalLoadMet && this.migrationContext.CriticalLoadIntervalMilliseconds == 0 {
+
+	// we don't throttle even critical-load when cutting over.
+	isThrottle, _, _ := this.migrationContext.IsThrottled()
+	isThrottle = true
+
+	if isThrottle && criticalLoadMet && this.migrationContext.CriticalLoadIntervalMilliseconds == 0 {
 		this.migrationContext.PanicAbort <- fmt.Errorf("critical-load met: %s=%d, >=%d", variableName, value, threshold)
 	}
-	if criticalLoadMet && this.migrationContext.CriticalLoadIntervalMilliseconds > 0 {
+	if isThrottle && criticalLoadMet && this.migrationContext.CriticalLoadIntervalMilliseconds > 0 {
 		log.Errorf("critical-load met once: %s=%d, >=%d. Will check again in %d millis", variableName, value, threshold, this.migrationContext.CriticalLoadIntervalMilliseconds)
 		go func() {
 			timer := time.NewTimer(time.Millisecond * time.Duration(this.migrationContext.CriticalLoadIntervalMilliseconds))


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/329

### Description

don't check the critical-load at cut-over section, details in the issue.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

