### PR TITLE
fix: bailing out on no PRIMARY/UNIQUE KEY

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -95,7 +95,7 @@ func (this *Inspector) InspectTableColumnsAndUniqueKeys(tableName string) (colum
 
 func (this *Inspector) InspectOriginalTable() (err error) {
 	this.migrationContext.OriginalTableColumns, this.migrationContext.OriginalTableUniqueKeys, err = this.InspectTableColumnsAndUniqueKeys(this.migrationContext.OriginalTableName)
-	if err == nil {
+	if err != nil {
 		return err
 	}
 	return nil

--- a/go/sql/parser_test.go
+++ b/go/sql/parser_test.go
@@ -98,13 +98,11 @@ func TestTokenizeAlterStatement(t *testing.T) {
 	{
 		alterStatement := "add column t int, add column e enum('a','b','c')"
 		tokens, _ := parser.tokenizeAlterStatement(alterStatement)
-		log.Errorf("%#v", tokens)
 		test.S(t).ExpectTrue(reflect.DeepEqual(tokens, []string{"add column t int", "add column e enum('a','b','c')"}))
 	}
 	{
 		alterStatement := "add column t int(11), add column e enum('a','b','c')"
 		tokens, _ := parser.tokenizeAlterStatement(alterStatement)
-		log.Errorf("%#v", tokens)
 		test.S(t).ExpectTrue(reflect.DeepEqual(tokens, []string{"add column t int(11)", "add column e enum('a','b','c')"}))
 	}
 }

--- a/localtests/no-unique-key/create.sql
+++ b/localtests/no-unique-key/create.sql
@@ -1,0 +1,9 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  i int not null,
+  ts timestamp default current_timestamp,
+  dt datetime,
+  key i_idx(i)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;

--- a/localtests/no-unique-key/expect_failure
+++ b/localtests/no-unique-key/expect_failure
@@ -1,0 +1,1 @@
+No PRIMARY nor UNIQUE key found in table

--- a/localtests/no-unique-key/extra_args
+++ b/localtests/no-unique-key/extra_args
@@ -1,0 +1,1 @@
+--alter="add column v varchar(32)"


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/332

`gh-ost` must bail out when no `PRIMARY KEY` or otherwise a `UNIQUE KEY` can be found on the migrated table.
A bug prevented that error from presenting itself, causing `gh-ost` to panic on a later stage.

- [x] contributed code is using same conventions as original code
- [x] code is formatted via `gofmt` (please avoid `goimports`)
- [x] code is built via `./build.sh`
- [x] code is tested via `./test.sh`

