### PR TITLE
WIP: Resurrect

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -124,7 +124,7 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 		return fmt.Errorf("No shared unique key can be found after ALTER! Bailing out")
 	}
 	this.migrationContext.UniqueKey = sharedUniqueKeys[0]
-	log.Infof("Chosen shared unique key is %s", this.migrationContext.UniqueKey.Name)
+	log.Infof("Chosen shared unique key is %+v", this.migrationContext.UniqueKey)
 	if this.migrationContext.UniqueKey.HasNullable {
 		if this.migrationContext.NullableUniqueKeyAllowed {
 			log.Warningf("Chosen key (%s) has nullable columns. You have supplied with --allow-nullable-unique-key and so this migration proceeds. As long as there aren't NULL values in this key's column, migration should be fine. NULL values will corrupt migration's data", this.migrationContext.UniqueKey)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -31,6 +31,8 @@ const (
 	AllEventsUpToLockProcessed                = "AllEventsUpToLockProcessed"
 )
 
+const contextDumpInterval time.Duration = 1 * time.Second
+
 func ReadChangelogState(s string) ChangelogState {
 	return ChangelogState(strings.Split(s, ":")[0])
 }
@@ -124,7 +126,7 @@ func (this *Migrator) initiateHooksExecutor() (err error) {
 // initiateContextDump
 func (this *Migrator) initiateContextDump() (err error) {
 	go func() {
-		contextDumpTick := time.Tick(1 * time.Minute)
+		contextDumpTick := time.Tick(contextDumpInterval)
 		for range contextDumpTick {
 			if dumpFile, err := this.migrationContext.DumpJSON(); err == nil {
 				this.contextDumpFiles = append(this.contextDumpFiles, dumpFile)

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -28,13 +28,15 @@ type Server struct {
 	tcpListener      net.Listener
 	hooksExecutor    *HooksExecutor
 	printStatus      printStatusFunc
+	panicAbort       chan error
 }
 
-func NewServer(hooksExecutor *HooksExecutor, printStatus printStatusFunc) *Server {
+func NewServer(hooksExecutor *HooksExecutor, printStatus printStatusFunc, panicAbort chan error) *Server {
 	return &Server{
 		migrationContext: base.GetMigrationContext(),
 		hooksExecutor:    hooksExecutor,
 		printStatus:      printStatus,
+		panicAbort:       panicAbort,
 	}
 }
 
@@ -251,7 +253,7 @@ help                                 # This message
 	case "panic":
 		{
 			err := fmt.Errorf("User commanded 'panic'. I will now panic, without cleanup. PANIC!")
-			this.migrationContext.PanicAbort <- err
+			this.panicAbort <- err
 			return NoPrintStatusRule, err
 		}
 	default:

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -6,6 +6,9 @@
 package sql
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -216,7 +219,7 @@ func (this *UniqueKey) String() string {
 	if this.IsAutoIncrement {
 		description = fmt.Sprintf("%s (auto_increment)", description)
 	}
-	return fmt.Sprintf("%s: %s; has nullable: %+v", description, this.Columns.Names(), this.HasNullable)
+	return fmt.Sprintf("%s: %s; has nullable: %+v", description, this.Columns.String(), this.HasNullable)
 }
 
 type ColumnValues struct {
@@ -246,6 +249,32 @@ func ToColumnValues(abstractValues []interface{}) *ColumnValues {
 	}
 
 	return result
+}
+
+func NewColumnValuesFromBase64(b64 string) (columnValues *ColumnValues, err error) {
+	var abstractValues []interface{}
+
+	b, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, err
+	}
+	buff := bytes.Buffer{}
+	buff.Write(b)
+	decoder := gob.NewDecoder(&buff)
+	err = decoder.Decode(&abstractValues)
+	if err != nil {
+		return nil, err
+	}
+	return ToColumnValues(abstractValues), nil
+}
+
+func (this *ColumnValues) ToBase64() (b64 string, err error) {
+	buff := bytes.Buffer{}
+	encoder := gob.NewEncoder(&buff)
+	if err = encoder.Encode(this.abstractValues); err != nil {
+		return b64, err
+	}
+	return base64.StdEncoding.EncodeToString(buff.Bytes()), nil
 }
 
 // MarshalJSON will marshal this object as JSON

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -6,6 +6,7 @@
 package sql
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -245,6 +246,11 @@ func ToColumnValues(abstractValues []interface{}) *ColumnValues {
 	}
 
 	return result
+}
+
+// MarshalJSON will marshal this object as JSON
+func (this *ColumnValues) MarshalJSON() ([]byte, error) {
+	return json.Marshal(this.abstractValues)
 }
 
 func (this *ColumnValues) AbstractValues() []interface{} {


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/205

WORK IN PROGRESS: resurrecting a migration after failure.
The idea is that `gh-ost` would routinely dump migration status/context. It would be ossible for one `gh-ost` process to fail (e.g. having met `critical-load`) and for another `gh-ost` process to pick up from where the first left off.

Initial commits present exporting of migration context, with some shuffling & cleanup.