### PR TITLE
Add possibility to set serverId as gh-ost option

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -123,6 +123,7 @@ type MigrationContext struct {
 	InitiallyDropOldTable        bool
 	InitiallyDropGhostTable      bool
 	CutOverType                  CutOver
+	ReplicaServerId              uint
 
 	Hostname                               string
 	AssumeMasterHostname                   string

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -9,16 +9,13 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 
 	"github.com/outbrain/golib/log"
 	gomysql "github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
-)
-
-const (
-	serverId = 99999
 )
 
 type GoMySQLReader struct {
@@ -28,6 +25,7 @@ type GoMySQLReader struct {
 	currentCoordinates       mysql.BinlogCoordinates
 	currentCoordinatesMutex  *sync.Mutex
 	LastAppliedRowsEventHint mysql.BinlogCoordinates
+	MigrationContext         *base.MigrationContext
 }
 
 func NewGoMySQLReader(connectionConfig *mysql.ConnectionConfig) (binlogReader *GoMySQLReader, err error) {
@@ -37,7 +35,10 @@ func NewGoMySQLReader(connectionConfig *mysql.ConnectionConfig) (binlogReader *G
 		currentCoordinatesMutex: &sync.Mutex{},
 		binlogSyncer:            nil,
 		binlogStreamer:          nil,
+		MigrationContext:        base.GetMigrationContext(),
 	}
+
+	serverId := uint32(binlogReader.MigrationContext.ReplicaServerId)
 	binlogReader.binlogSyncer = replication.NewBinlogSyncer(serverId, "mysql")
 
 	return binlogReader, err

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -104,6 +104,8 @@ func main() {
 	flag.StringVar(&migrationContext.HooksPath, "hooks-path", "", "directory where hook files are found (default: empty, ie. hooks disabled). Hook files found on this path, and conforming to hook naming conventions will be executed")
 	flag.StringVar(&migrationContext.HooksHintMessage, "hooks-hint", "", "arbitrary message to be injected to hooks via GH_OST_HOOKS_HINT, for your convenience")
 
+	flag.UintVar(&migrationContext.ReplicaServerId, "replica-server-id", 99999, "server id used by gh-ost process. Default: 99999")
+
 	maxLoad := flag.String("max-load", "", "Comma delimited status-name=threshold. e.g: 'Threads_running=100,Threads_connected=500'. When status exceeds threshold, app throttles writes")
 	criticalLoad := flag.String("critical-load", "", "Comma delimited status-name=threshold, same format as --max-load. When status exceeds threshold, app panics and quits")
 	flag.Int64Var(&migrationContext.CriticalLoadIntervalMilliseconds, "critical-load-interval-millis", 0, "When 0, migration immediately bails out upon meeting critical-load. When non-zero, a second check is done after given interval, and migration only bails out if 2nd check still meets critical load")


### PR DESCRIPTION
Signed-off-by: Cyprian Nosek <cypiszzz@gmail.com>

In a case where I want to run several gh-ost processes in parallel it seems to be not possible due to all of the processes show up with the same serverId: 99999 (it's const in the code).

Possibility to pass serverId as an option with command line (with default set to 99999) would solve the problem.

The change adds optional `-replica-server-id` flag where it's possible to set serverId.