### PR TITLE
cli: --check-flag

### DIFF
--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -115,8 +115,13 @@ func main() {
 	stack := flag.Bool("stack", false, "add stack trace upon error")
 	help := flag.Bool("help", false, "Display usage")
 	version := flag.Bool("version", false, "Print version & exit")
+	checkFlag := flag.Bool("check-flag", false, "Check if another flag exists/supported. This allows for cross-version scripting. Exits with 0 when all additional provided flags exist, nonzero otherwise. You must provide (dummy) values for flags that require a value. Example: gh-ost --check-flag --cut-over-lock-timeout-seconds --nice-ratio 0")
+
 	flag.Parse()
 
+	if *checkFlag {
+		return
+	}
 	if *help {
 		fmt.Fprintf(os.Stderr, "Usage of gh-ost:\n")
 		flag.PrintDefaults()


### PR DESCRIPTION
Running `gh-ost` with `--check-flag` is a way of testing for existence of other flags. You may be using different versions of `gh-ost`, possibly testing a new version that has a new feature. It's now possible to validate that `gh-ost` supports a flag.

Running with `--check-flag` doesn't actually _do_ anything. The app terminates immediately, with:

- return code `0` if all flags are good (flags that normally require a value must get such value)
- return code `1` if one or more flags are not recognized, or are missing a value.

Examples:

#### Returning exit code 0

- `gh-ost --check-flag --initially-drop-socket-file`
- `gh-ost --check-flag --initially-drop-socket-file --nice-ratio 0`

#### Returning nonzero exit code


- `gh-ost --check-flag --no-such-flag`
- `gh-ost --check-flag --initially-drop-socket-file --nice-ratio`
