### PR TITLE
fixing phantom throttle-control-replicas lag result

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -559,7 +559,11 @@ func (this *MigrationContext) GetControlReplicasLagResult() mysql.ReplicationLag
 func (this *MigrationContext) SetControlReplicasLagResult(lagResult *mysql.ReplicationLagResult) {
 	this.throttleMutex.Lock()
 	defer this.throttleMutex.Unlock()
-	this.controlReplicasLagResult = *lagResult
+	if lagResult == nil {
+		this.controlReplicasLagResult = *mysql.NewNoReplicationLagResult()
+	} else {
+		this.controlReplicasLagResult = *lagResult
+	}
 }
 
 func (this *MigrationContext) GetThrottleControlReplicaKeys() *mysql.InstanceKeyMap {

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -158,9 +158,7 @@ func (this *Throttler) collectControlReplicasLag() {
 			// No need to read lag
 			return
 		}
-		if result := readControlReplicasLag(); result != nil {
-			this.migrationContext.SetControlReplicasLagResult(result)
-		}
+		this.migrationContext.SetControlReplicasLagResult(readControlReplicasLag())
 	}
 	aggressiveTicker := time.Tick(100 * time.Millisecond)
 	relaxedFactor := 10

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -22,6 +22,14 @@ type ReplicationLagResult struct {
 	Err error
 }
 
+func NewNoReplicationLagResult() *ReplicationLagResult {
+	return &ReplicationLagResult{Lag: 0, Err: nil}
+}
+
+func (this *ReplicationLagResult) HasLag() bool {
+	return this.Lag > 0
+}
+
 // GetReplicationLag returns replication lag for a given connection config; either by explicit query
 // or via SHOW SLAVE STATUS
 func GetReplicationLag(connectionConfig *ConnectionConfig) (replicationLag time.Duration, err error) {


### PR DESCRIPTION
Fixes https://github.com/github/gh-ost/issues/361

A bug was introduced via https://github.com/github/gh-ost/commit/e900dae2e99cb7150cf669058da5b6060c2f03cf and
https://github.com/github/gh-ost/commit/fc831b0548b33f62d34b6b6aadff0614507117c8, when moving into the new more-async throttling logic.

With this bug, the throttling check for throttle-control-replicas lag would consistently return some phantom value even if the throttle control list is empty. More specifically, it would retain the result of the last known throttle-control-replicas list before changing to an empty list.

With this fix an empty throttle control list always returns a "no lag" result.
