### PR TITLE
Collecting and presenting MySQL versions of applier and inspector

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -135,7 +135,9 @@ type MigrationContext struct {
 	OriginalBinlogFormat                   string
 	OriginalBinlogRowImage                 string
 	InspectorConnectionConfig              *mysql.ConnectionConfig
+	InspectorMySQLVersion                  string
 	ApplierConnectionConfig                *mysql.ConnectionConfig
+	ApplierMySQLVersion                    string
 	StartTime                              time.Time
 	RowCopyStartTime                       time.Time
 	RowCopyEndTime                         time.Time

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -70,14 +70,15 @@ func (this *Applier) InitDBConnections() (err error) {
 	if err := this.readTableColumns(); err != nil {
 		return err
 	}
+	log.Infof("Applier initiated on %+v, version %+v", this.connectionConfig.ImpliedKey, this.migrationContext.ApplierMySQLVersion)
 	return nil
 }
 
 // validateConnection issues a simple can-connect to MySQL
 func (this *Applier) validateConnection(db *gosql.DB) error {
-	query := `select @@global.port`
+	query := `select @@global.port, @@global.version`
 	var port int
-	if err := db.QueryRow(query).Scan(&port); err != nil {
+	if err := db.QueryRow(query).Scan(&port, &this.migrationContext.ApplierMySQLVersion); err != nil {
 		return err
 	}
 	if port != this.connectionConfig.Key.Port {

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -60,6 +60,7 @@ func (this *Inspector) InitDBConnections() (err error) {
 	if err := this.applyBinlogFormat(); err != nil {
 		return err
 	}
+	log.Infof("Inspector initiated on %+v, version %+v", this.connectionConfig.ImpliedKey, this.migrationContext.InspectorMySQLVersion)
 	return nil
 }
 
@@ -168,9 +169,9 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 
 // validateConnection issues a simple can-connect to MySQL
 func (this *Inspector) validateConnection() error {
-	query := `select @@global.port`
+	query := `select @@global.port, @@global.version`
 	var port int
-	if err := this.db.QueryRow(query).Scan(&port); err != nil {
+	if err := this.db.QueryRow(query).Scan(&port, &this.migrationContext.InspectorMySQLVersion); err != nil {
 		return err
 	}
 	if port != this.connectionConfig.Key.Port {


### PR DESCRIPTION
For auditing and bug-reporting purposes, this exposes MySQL versions of applier and insepector:

```
2017-02-07 09:40:53 INFO starting gh-ost
2017-02-07 09:40:53 INFO Migrating `test`.`gh_ost_test`
2017-02-07 09:40:53 INFO connection validated on testhost:22297
2017-02-07 09:40:53 INFO User has ALL privileges
2017-02-07 09:40:53 INFO binary logs validated on testhost:22297
2017-02-07 09:40:53 INFO Restarting replication on testhost:22297 to make sure binlog settings apply to replication thread
2017-02-07 09:40:54 DEBUG Replication restarted
2017-02-07 09:40:54 INFO Inspector initiated on testhost:22297, version 5.6.28-log
2017-02-07 09:40:54 INFO Table found. Engine=InnoDB
2017-02-07 09:40:54 DEBUG Estimated number of rows via STATUS: 3
2017-02-07 09:40:54 DEBUG Validated no foreign keys exist on table
2017-02-07 09:40:54 DEBUG Validated no triggers exist on table
2017-02-07 09:40:54 INFO Estimated number of rows via EXPLAIN: 3
2017-02-07 09:40:54 DEBUG Potential unique keys in gh_ost_test: [PRIMARY (auto_increment): [id]; has nullable: false]
2017-02-07 09:40:54 INFO Recursively searching for replication master
2017-02-07 09:40:54 DEBUG Looking for master on testhost:22297
2017-02-07 09:40:54 DEBUG Master of testhost:22297 is testhost:22293
2017-02-07 09:40:54 DEBUG Looking for master on testhost:22293
2017-02-07 09:40:54 INFO Master found to be testhost:22293
2017-02-07 09:40:54 INFO --test-on-replica or --migrate-on-replica given. Will not execute on master testhost:22293 but rather on replica testhost:22297 itself
2017-02-07 09:40:54 INFO log_slave_updates validated on testhost:22297
2017-02-07 09:40:54 INFO connection validated on testhost:22297
2017-02-07 09:40:54 DEBUG Streamer binlog coordinates: mysql-bin.001013:166291938
2017-02-07 09:40:54 INFO Registering replica at testhost:22297
2017-02-07 09:40:54 INFO Connecting binlog streamer at mysql-bin.001013:166291938
2017-02-07 09:40:54 DEBUG Beginning streaming
2017-02-07 09:40:54 INFO connection validated on testhost:22297
2017-02-07 09:40:54 INFO rotate to next log name: mysql-bin.001013
2017-02-07 09:40:54 INFO connection validated on testhost:22297
2017-02-07 09:40:54 INFO will use time_zone='SYSTEM' on applier
2017-02-07 09:40:54 INFO Examining table structure on applier
2017-02-07 09:40:54 INFO Applier initiated on testhost:22297, version 5.6.28-log
...
```
in the above:
```
2017-02-07 09:40:54 INFO Inspector initiated on testhost:22297, version 5.6.28-log
...
2017-02-07 09:40:54 INFO Applier initiated on testhost:22297, version 5.6.28-log
```

both inspector and applier happen to be the same server because this is a `test-on-replica`