### PR TITLE
improve output without --verbose option

### DIFF
--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -242,5 +242,5 @@ func main() {
 		migrator.ExecOnFailureHook()
 		log.Fatale(err)
 	}
-	log.Info("Done")
+        fmt.Fprintf(os.Stdout, "# Done\n")
 }


### PR DESCRIPTION
Related issue: #280 

### Description

This PR tries to improve visibility of the tool when running without the `--verbose` option by printing the "# Done" message to stdout rather than through the logging facility.
