### PR TITLE
fixing binlog syncer double-close()

### DIFF
--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -160,6 +160,10 @@ func (this *GoMySQLReader) StreamEvents(canStopStreaming func() bool, entriesCha
 }
 
 func (this *GoMySQLReader) Close() error {
-	this.binlogSyncer.Close()
+	// Historically there was a:
+	//   this.binlogSyncer.Close()
+	// here. A new go-mysql version closes the binlog syncer connection independently.
+	// I will go against the sacred rules of comments and just leave this here.
+	// This is the year 2017. Let's see what year these comments get deleted.
 	return nil
 }


### PR DESCRIPTION
Storyline:

- https://github.com/github/gh-ost/issues/383
- https://github.com/github/gh-ost/issues/388

This PR avoids closing `go-mysql`'s binlog syncer `close()` twice. Well, `gh-ost` only called it _once_, but following an upgrade binlog-syncer takes care of itself and `gh-ost` is no longer required to `close()`