### PR TITLE
error and nil checks on socket connection

### DIFF
--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -98,8 +98,13 @@ func (this *Server) Serve() (err error) {
 }
 
 func (this *Server) handleConnection(conn net.Conn) (err error) {
-	defer conn.Close()
+	if conn != nil {
+		defer conn.Close()
+	}
 	command, _, err := bufio.NewReader(conn).ReadLine()
+	if err != nil {
+		return err
+	}
 	return this.onServerCommand(string(command), bufio.NewWriter(conn))
 }
 


### PR DESCRIPTION
Fixes the `panic: runtime error: invalid memory address or nil pointer dereference` error in https://github.com/github/gh-ost/issues/400

This adds a `nil` check and an `error` check when handling a socket connection.