### PR TITLE
--dml-batch-size cap at 1000

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -47,6 +47,7 @@ const (
 
 const (
 	HTTPStatusOK = 200
+	maxBatchSize = 5000
 )
 
 var (
@@ -441,8 +442,8 @@ func (this *MigrationContext) SetDMLBatchSize(batchSize int64) {
 	if batchSize < 1 {
 		batchSize = 1
 	}
-	if batchSize > 100 {
-		batchSize = 100
+	if batchSize > maxBatchSize {
+		batchSize = maxBatchSize
 	}
 	atomic.StoreInt64(&this.DMLBatchSize, batchSize)
 }

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -47,7 +47,7 @@ const (
 
 const (
 	HTTPStatusOK = 200
-	maxBatchSize = 5000
+	maxBatchSize = 1000
 )
 
 var (


### PR DESCRIPTION
This quick PR increases the cap for `--dml-batch-size` from `100` to `1000`. The default remains `10`.