### PR TITLE
handling column name case change

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -656,18 +656,21 @@ func (this *Inspector) getSharedUniqueKeys(originalUniqueKeys, ghostUniqueKeys [
 
 // getSharedColumns returns the intersection of two lists of columns in same order as the first list
 func (this *Inspector) getSharedColumns(originalColumns, ghostColumns *sql.ColumnList, columnRenameMap map[string]string) (*sql.ColumnList, *sql.ColumnList) {
-	columnsInGhost := make(map[string]bool)
-	for _, ghostColumn := range ghostColumns.Names() {
-		columnsInGhost[ghostColumn] = true
-	}
 	sharedColumnNames := []string{}
 	for _, originalColumn := range originalColumns.Names() {
 		isSharedColumn := false
-		if columnsInGhost[originalColumn] || columnsInGhost[columnRenameMap[originalColumn]] {
-			isSharedColumn = true
+		for _, ghostColumn := range ghostColumns.Names() {
+			if strings.EqualFold(originalColumn, ghostColumn) {
+				isSharedColumn = true
+			}
+			if strings.EqualFold(columnRenameMap[originalColumn], ghostColumn) {
+				isSharedColumn = true
+			}
 		}
-		if this.migrationContext.DroppedColumnsMap[originalColumn] {
-			isSharedColumn = false
+		for droppedColumn := range this.migrationContext.DroppedColumnsMap {
+			if strings.EqualFold(originalColumn, droppedColumn) {
+				isSharedColumn = false
+			}
 		}
 		if isSharedColumn {
 			sharedColumnNames = append(sharedColumnNames, originalColumn)

--- a/localtests/modify-change-case-pk/create.sql
+++ b/localtests/modify-change-case-pk/create.sql
@@ -1,0 +1,26 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  c1 int not null default 0,
+  c2 int not null default 0,
+  primary key (id)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert ignore into gh_ost_test values (1, 11, 23);
+  insert ignore into gh_ost_test values (2, 13, 23);
+  insert into gh_ost_test values (null, 17, 23);
+  set @last_insert_id := last_insert_id();
+  update gh_ost_test set c1=c1+@last_insert_id, c2=c2+@last_insert_id where id=@last_insert_id order by id desc limit 1;
+  delete from gh_ost_test where id=1;
+  delete from gh_ost_test where c1=13; -- id=2
+end ;;

--- a/localtests/modify-change-case-pk/expect_failure
+++ b/localtests/modify-change-case-pk/expect_failure
@@ -1,0 +1,1 @@
+No shared unique key can be found after ALTER

--- a/localtests/modify-change-case-pk/extra_args
+++ b/localtests/modify-change-case-pk/extra_args
@@ -1,0 +1,1 @@
+--alter="modify ID int"

--- a/localtests/modify-change-case/create.sql
+++ b/localtests/modify-change-case/create.sql
@@ -1,0 +1,26 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  c1 int not null default 0,
+  c2 int not null default 0,
+  primary key (id)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert ignore into gh_ost_test values (1, 11, 23);
+  insert ignore into gh_ost_test values (2, 13, 23);
+  insert into gh_ost_test values (null, 17, 23);
+  set @last_insert_id := last_insert_id();
+  update gh_ost_test set c1=c1+@last_insert_id, c2=c2+@last_insert_id where id=@last_insert_id order by id desc limit 1;
+  delete from gh_ost_test where id=1;
+  delete from gh_ost_test where c1=13; -- id=2
+end ;;

--- a/localtests/modify-change-case/extra_args
+++ b/localtests/modify-change-case/extra_args
@@ -1,0 +1,1 @@
+--alter="modify C2 int not null default 0"


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/446

This PR will fix the scenario where a column is changes its case. Example:
```
create table gh_ost_test (
  id int auto_increment,
  c1 int not null default 0,
  c2 int not null default 0,
  primary key (id)
) auto_increment=1;
```
and
```
--alter="modify C2 int not null default 0"
```

leading to a `C2` column in altered table.

Right now `gh-ost` does not detect `c2` and `C2` are the same.

initial commit: an integration test to catch the error (confirmed)