### PR TITLE
ghost/changelog/del table names support max characters limit

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -243,9 +243,18 @@ func GetMigrationContext() *MigrationContext {
 	return context
 }
 
+func getSafeTableName(baseName string, suffix string) string {
+	name := fmt.Sprintf("_%s_%s", baseName, suffix)
+	if len(name) <= mysql.MaxTableNameLength {
+		return name
+	}
+	extraCharacters := len(name) - mysql.MaxTableNameLength
+	return fmt.Sprintf("_%s_%s", baseName[0:len(baseName)-extraCharacters], suffix)
+}
+
 // GetGhostTableName generates the name of ghost table, based on original table name
 func (this *MigrationContext) GetGhostTableName() string {
-	return fmt.Sprintf("_%s_gho", this.OriginalTableName)
+	return getSafeTableName(this.OriginalTableName, "gho")
 }
 
 // GetOldTableName generates the name of the "old" table, into which the original table is renamed.
@@ -255,14 +264,14 @@ func (this *MigrationContext) GetOldTableName() string {
 		timestamp := fmt.Sprintf("%d%02d%02d%02d%02d%02d",
 			t.Year(), t.Month(), t.Day(),
 			t.Hour(), t.Minute(), t.Second())
-		return fmt.Sprintf("_%s_%s_del", this.OriginalTableName, timestamp)
+		return getSafeTableName(this.OriginalTableName, fmt.Sprintf("%s_del", timestamp))
 	}
-	return fmt.Sprintf("_%s_del", this.OriginalTableName)
+	return getSafeTableName(this.OriginalTableName, "del")
 }
 
 // GetChangelogTableName generates the name of changelog table, based on original table name
 func (this *MigrationContext) GetChangelogTableName() string {
-	return fmt.Sprintf("_%s_ghc", this.OriginalTableName)
+	return getSafeTableName(this.OriginalTableName, "ghc")
 }
 
 // GetVoluntaryLockName returns a name of a voluntary lock to be used throughout

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2016 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package base
+
+import (
+	"testing"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestGetTableNames(t *testing.T) {
+	context = newMigrationContext()
+	{
+		context.OriginalTableName = "some_table"
+		test.S(t).ExpectEquals(context.GetOldTableName(), "_some_table_del")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "_some_table_gho")
+		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_some_table_ghc")
+	}
+	{
+		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890"
+		test.S(t).ExpectEquals(context.GetOldTableName(), "_a1234567890123456789012345678901234567890123456789012345678_del")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "_a1234567890123456789012345678901234567890123456789012345678_gho")
+		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_a1234567890123456789012345678901234567890123456789012345678_ghc")
+	}
+	{
+		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
+		oldTableName := context.GetOldTableName()
+		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123456789012345678_del")
+	}
+}

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -7,6 +7,7 @@ package base
 
 import (
 	"testing"
+	"time"
 
 	"github.com/outbrain/golib/log"
 	test "github.com/outbrain/golib/tests"
@@ -34,5 +35,13 @@ func TestGetTableNames(t *testing.T) {
 		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
 		oldTableName := context.GetOldTableName()
 		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123456789012345678_del")
+	}
+	{
+		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
+		context.TimestampOldTable = true
+		longForm := "Jan 2, 2006 at 3:04pm (MST)"
+		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
+		oldTableName := context.GetOldTableName()
+		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123_20130203195400_del")
 	}
 }


### PR DESCRIPTION
With this PR it's OK for the original table name to be very long, and up to maxlen (`64` characters).

The _old_, _ghost_ and _changelog_ names are truncated as needed to accommodate.

Furthermore, the truncation happens on the table name part, rather than on the suffix. To illustrate, this table name:

```
a12345678901234567890123456789012345678901234567890123456789012
```

is `63` characters long. The names `gh-ost` will pick are:
```
_a123456789012345678901234567890123456789012345678901234567_del
_a123456789012345678901234567890123456789012345678901234567_gho
_a123456789012345678901234567890123456789012345678901234567_ghc
```
Furthermore, if using `--timestamp-old-table` the suffix is even longer, and this truncates even more of the original name, e.g:
```
_a1234567890123456789012345678901234567890123_20130203195400_del
```
