### PR TITLE
timestamp/datetime submillis corruption fix

### DIFF
--- a/localtests/datetime-submillis-zeroleading/create.sql
+++ b/localtests/datetime-submillis-zeroleading/create.sql
@@ -1,0 +1,27 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  dt0 datetime(6),
+  dt1 datetime(6),
+  ts2 timestamp(6),
+  updated tinyint unsigned default 0,
+  primary key(id),
+  key i_idx(i)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, 11, '2016-10-31 11:22:33.0123', now(), '2016-10-31 11:22:33.0369', 0);
+  update gh_ost_test set dt1='2016-10-31 11:22:33.0246', updated = 1 where i = 11 order by id desc limit 1;
+
+  insert into gh_ost_test values (null, 13, '2016-10-31 11:22:33.0123', now(6), '2016-10-31 11:22:33.0369', 0);
+end ;;

--- a/localtests/datetime-submillis-zeroleading/create.sql
+++ b/localtests/datetime-submillis-zeroleading/create.sql
@@ -23,5 +23,5 @@ begin
   insert into gh_ost_test values (null, 11, '2016-10-31 11:22:33.0123', now(), '2016-10-31 11:22:33.0369', 0);
   update gh_ost_test set dt1='2016-10-31 11:22:33.0246', updated = 1 where i = 11 order by id desc limit 1;
 
-  insert into gh_ost_test values (null, 13, '2016-10-31 11:22:33.0123', now(6), '2016-10-31 11:22:33.0369', 0);
+  insert into gh_ost_test values (null, 13, '2016-10-31 11:22:33.0123', '2016-10-31 11:22:33.789', '2016-10-31 11:22:33.0369', 0);
 end ;;

--- a/vendor/github.com/siddontang/go-mysql/replication/row_event.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/row_event.go
@@ -666,7 +666,7 @@ func decodeDatetime2(data []byte, dec uint16) (interface{}, int, error) {
 	hour := int((hms >> 12))
 
 	if secPart != 0 {
-		return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%d", year, month, day, hour, minute, second, secPart), n, nil // commented by Shlomi Noach. Yes I know about `git blame`
+		return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, minute, second, secPart), n, nil // commented by Shlomi Noach. Yes I know about `git blame`
 	}
 	return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second), n, nil // commented by Shlomi Noach. Yes I know about `git blame`
 }


### PR DESCRIPTION
fixes https://github.com/github/gh-ost/issues/450

This PR will fix the following issue: when applying events from binlog and where column type is `TIMESTAMP(6)` or `DATETIME(6)`, submillis can get corrupted. In particular this happens when submillis are `0*`. For example, the value `2016-10-31 11:22:33.012300` turns to `2016-10-31 11:22:33.123000`.

Initial commit adds a test to reproduce & validate the problem.
