### PR TITLE
Add a force-table-names command flag

### DIFF
--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -44,4 +44,12 @@ func TestGetTableNames(t *testing.T) {
 		oldTableName := context.GetOldTableName()
 		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123_20130203195400_del")
 	}
+	{
+		context.OriginalTableName = "foo_bar_baz"
+		context.ForceTmpTableName = "tmp"
+		context.TimestampOldTable = false
+		test.S(t).ExpectEquals(context.GetOldTableName(), "_tmp_del")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "_tmp_gho")
+		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_tmp_ghc")
+	}
 }

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -120,6 +120,7 @@ func main() {
 	help := flag.Bool("help", false, "Display usage")
 	version := flag.Bool("version", false, "Print version & exit")
 	checkFlag := flag.Bool("check-flag", false, "Check if another flag exists/supported. This allows for cross-version scripting. Exits with 0 when all additional provided flags exist, nonzero otherwise. You must provide (dummy) values for flags that require a value. Example: gh-ost --check-flag --cut-over-lock-timeout-seconds --nice-ratio 0")
+	flag.StringVar(&migrationContext.ForceTmpTableName, "force-table-names", "", "table name prefix to be used on the temporary tables")
 
 	flag.Parse()
 


### PR DESCRIPTION
usage example:
```
gh-ost  ...  --force-table-names=migration_tbl
```

The force-table-names flag will receive a table name and use that name
when creating the _del, _gho, _ghc tables.
For instance, for that example above, the tables would be:

```
_migration_tbl_del
_migration_tbl_gho
_migration_tbl_ghc
```

[fixes #399]
