### PR TITLE
Dont share the same context in the table name tests

### DIFF
--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -18,25 +18,28 @@ func init() {
 }
 
 func TestGetTableNames(t *testing.T) {
-	context = newMigrationContext()
 	{
+		context = newMigrationContext()
 		context.OriginalTableName = "some_table"
 		test.S(t).ExpectEquals(context.GetOldTableName(), "_some_table_del")
 		test.S(t).ExpectEquals(context.GetGhostTableName(), "_some_table_gho")
 		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_some_table_ghc")
 	}
 	{
+		context = newMigrationContext()
 		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890"
 		test.S(t).ExpectEquals(context.GetOldTableName(), "_a1234567890123456789012345678901234567890123456789012345678_del")
 		test.S(t).ExpectEquals(context.GetGhostTableName(), "_a1234567890123456789012345678901234567890123456789012345678_gho")
 		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_a1234567890123456789012345678901234567890123456789012345678_ghc")
 	}
 	{
+		context = newMigrationContext()
 		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
 		oldTableName := context.GetOldTableName()
 		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123456789012345678_del")
 	}
 	{
+		context = newMigrationContext()
 		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
 		context.TimestampOldTable = true
 		longForm := "Jan 2, 2006 at 3:04pm (MST)"
@@ -45,9 +48,9 @@ func TestGetTableNames(t *testing.T) {
 		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123_20130203195400_del")
 	}
 	{
+		context = newMigrationContext()
 		context.OriginalTableName = "foo_bar_baz"
 		context.ForceTmpTableName = "tmp"
-		context.TimestampOldTable = false
 		test.S(t).ExpectEquals(context.GetOldTableName(), "_tmp_del")
 		test.S(t).ExpectEquals(context.GetGhostTableName(), "_tmp_gho")
 		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_tmp_ghc")


### PR DESCRIPTION
Related to https://github.com/github/gh-ost/pull/451/files#r128858491
When adding a new test to the table name context method I had to reset some context state as it was being shared between different test cases.
I moved the context creation to inside the {} block, and create a new context per test so it will be more isolated and won't give us mixed results depending on the left over state from a previous test.