### PR TITLE
interpolateParams=true: client side prepared statements

### DIFF
--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -56,5 +56,5 @@ func (this *ConnectionConfig) GetDBUri(databaseName string) string {
 		// Wrap IPv6 literals in square brackets
 		hostname = fmt.Sprintf("[%s]", hostname)
 	}
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4,utf8,latin1", this.User, this.Password, hostname, this.Key.Port, databaseName)
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&charset=utf8mb4,utf8,latin1", this.User, this.Password, hostname, this.Key.Port, databaseName)
 }


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/454

In an attempt to speed up applying of binlog events, this is a low hanging fruit: set `interpolateParams=true` ([doc](https://github.com/go-sql-driver/mysql#interpolateparams))

This will set client-side prepared statements. The benefit to that is reduced round trips to the MySQL server: only one per query instead of three per query.
