### PR TITLE
testing 5.7 and JSON

### DIFF
--- a/localtests/datetime-to-timestamp-pk-fail/create.sql
+++ b/localtests/datetime-to-timestamp-pk-fail/create.sql
@@ -3,9 +3,9 @@ create table gh_ost_test (
   id int unsigned auto_increment,
   i int not null,
   ts0 timestamp default current_timestamp,
-  ts1 timestamp,
+  ts1 timestamp null,
   dt2 datetime,
-  t   datetime,
+  t   datetime default current_timestamp,
   updated tinyint unsigned default 0,
   primary key(id, t),
   key i_idx(i)

--- a/localtests/datetime-to-timestamp-pk-fail/extra_args
+++ b/localtests/datetime-to-timestamp-pk-fail/extra_args
@@ -1,1 +1,1 @@
---alter="change column t t timestamp not null"
+--alter="change column t t timestamp default current_timestamp"

--- a/localtests/datetime-to-timestamp/create.sql
+++ b/localtests/datetime-to-timestamp/create.sql
@@ -3,9 +3,9 @@ create table gh_ost_test (
   id int unsigned auto_increment,
   i int not null,
   ts0 timestamp default current_timestamp,
-  ts1 timestamp,
+  ts1 timestamp null,
   dt2 datetime,
-  t   datetime,
+  t   datetime null,
   updated tinyint unsigned default 0,
   primary key(id),
   key i_idx(i)

--- a/localtests/datetime-to-timestamp/extra_args
+++ b/localtests/datetime-to-timestamp/extra_args
@@ -1,1 +1,1 @@
---alter="change column t t timestamp not null"
+--alter="change column t t timestamp null"

--- a/localtests/enum-pk/create.sql
+++ b/localtests/enum-pk/create.sql
@@ -2,7 +2,7 @@ drop table if exists gh_ost_test;
 create table gh_ost_test (
   id int auto_increment,
   i int not null,
-  e enum('red', 'green', 'blue', 'orange') null default null collate 'utf8_bin',
+  e enum('red', 'green', 'blue', 'orange') not null default 'red' collate 'utf8_bin',
   primary key(id, e)
 ) auto_increment=1;
 

--- a/localtests/json57/create.sql
+++ b/localtests/json57/create.sql
@@ -1,0 +1,21 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  j json,
+  primary key(id)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, '"sometext"');
+  insert into gh_ost_test values (null, '{"key":"val"}');
+  insert into gh_ost_test values (null, '{"is-it": true, "count": 3, "elements": []}');
+end ;;

--- a/localtests/timestamp-to-datetime/create.sql
+++ b/localtests/timestamp-to-datetime/create.sql
@@ -3,7 +3,7 @@ create table gh_ost_test (
   id int auto_increment,
   i int not null,
   ts0 timestamp default current_timestamp,
-  ts1 timestamp,
+  ts1 timestamp default current_timestamp,
   dt2 datetime,
   t   datetime,
   updated tinyint unsigned default 0,

--- a/localtests/timestamp/create.sql
+++ b/localtests/timestamp/create.sql
@@ -3,8 +3,8 @@ create table gh_ost_test (
   id int auto_increment,
   i int not null,
   ts0 timestamp default current_timestamp,
-  ts1 timestamp,
-  ts2 timestamp,
+  ts1 timestamp default current_timestamp,
+  ts2 timestamp default current_timestamp,
   updated tinyint unsigned default 0,
   primary key(id),
   key i_idx(i)

--- a/localtests/tz-datetime-ts/create.sql
+++ b/localtests/tz-datetime-ts/create.sql
@@ -3,7 +3,7 @@ create table gh_ost_test (
   id int auto_increment,
   i int not null,
   ts0 timestamp default current_timestamp,
-  ts1 timestamp,
+  ts1 timestamp default current_timestamp,
   dt2 datetime,
   t   datetime,
   updated tinyint unsigned default 0,

--- a/localtests/tz-datetime-ts/extra_args
+++ b/localtests/tz-datetime-ts/extra_args
@@ -1,1 +1,1 @@
---alter="change column t t timestamp not null"
+--alter="change column t t timestamp not null default current_timestamp"

--- a/localtests/tz/create.sql
+++ b/localtests/tz/create.sql
@@ -3,8 +3,8 @@ create table gh_ost_test (
   id int auto_increment,
   i int not null,
   ts0 timestamp default current_timestamp,
-  ts1 timestamp,
-  ts2 timestamp,
+  ts1 timestamp default current_timestamp,
+  ts2 timestamp default current_timestamp,
   updated tinyint unsigned default 0,
   primary key(id),
   key i_idx(i)


### PR DESCRIPTION
This PR runs localtests on `5.7`. It also adds `JSON` datatype tests.