### PR TITLE
gh-ost uses autocommit=1 for all connections

### DIFF
--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -56,5 +56,5 @@ func (this *ConnectionConfig) GetDBUri(databaseName string) string {
 		// Wrap IPv6 literals in square brackets
 		hostname = fmt.Sprintf("[%s]", hostname)
 	}
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&charset=utf8mb4,utf8,latin1", this.User, this.Password, hostname, this.Key.Port, databaseName)
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&autocommit=true&charset=utf8mb4,utf8,latin1", this.User, this.Password, hostname, this.Key.Port, databaseName)
 }


### PR DESCRIPTION
Fixes https://github.com/github/gh-ost/issues/480

All connections use `autocommit=1` overriding whatever global value is set for `autocommit`.

cc @renecannao