### PR TITLE
Remove unused acceptSignals function in logic/migrator.go

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -10,10 +10,8 @@ import (
 	"io"
 	"math"
 	"os"
-	"os/signal"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/github/gh-ost/go/base"
@@ -101,21 +99,6 @@ func NewMigrator() *Migrator {
 		handledChangelogStates: make(map[string]bool),
 	}
 	return migrator
-}
-
-// acceptSignals registers for OS signals
-func (this *Migrator) acceptSignals() {
-	c := make(chan os.Signal, 1)
-
-	signal.Notify(c, syscall.SIGHUP)
-	go func() {
-		for sig := range c {
-			switch sig {
-			case syscall.SIGHUP:
-				log.Debugf("Received SIGHUP. Reloading configuration")
-			}
-		}
-	}()
 }
 
 // initiateHooksExecutor


### PR DESCRIPTION
I realize there is no open issue for this, but I'm not sure it's worthy of one.

As I was browsing through the `logic/migrator.go` code I noticed an incomplete and unused `acceptSignals` function.

The https://github.com/github/gh-ost/commit/04525887f3a9c59deecaddb2617c8b8486c1a222 commit seems to suggest this was work in progress.

It looks the signal handling code ended up in [`main.go`](https://github.com/github/gh-ost/blob/5294ab6bd10c36bba7cd37e5739e6cab70b2cfda/go/cmd/gh-ost/main.go#L24) instead.

I believe this code is safe to :fire:.

cc @shlomi-noach  