### PR TITLE
Clearer error message on config file read error

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -700,7 +700,7 @@ func (this *MigrationContext) ReadConfigFile() error {
 	gcfg.RelaxedParserMode = true
 	gcfgscanner.RelaxedScannerMode = true
 	if err := gcfg.ReadFileInto(&this.config, this.ConfigFile); err != nil {
-		return err
+		return fmt.Errorf("Error reading config file %s. Details: %s", this.ConfigFile, err.Error())
 	}
 
 	// We accept user & password in the form "${SOME_ENV_VARIABLE}" in which case we pull


### PR DESCRIPTION
Fixes https://github.com/github/gh-ost/issues/467

Previously, on config file read error, `gh-ost` would print the direct error, but this could make it unclear that `gh-ost` had an error reading the config file.

With this PR `gh-ost` explicitly identifies the error with reading the config file. e.g.:

```
2017-09-10 08:19:32 FATAL Error reading config file /tmp/c.cfg. Details: open /tmp/c.cfg: no such file or directory
```
