### PR TITLE
RDS documentation update

### DIFF
--- a/doc/rds.md
+++ b/doc/rds.md
@@ -1,20 +1,40 @@
-`gh-ost` has been updated to work with Amazon RDS however due to GitHub not relying using AWS for databases, this documentation is community driven so if you find a bug please [open an issue][new_issue]!
+**Note:** `gh-ost` supports Amazon RDS. However, GitHub Engineering does not use AWS for production databases and this page is community-driven. If you find a bug in the documentation please [open an issue][new_issue].
 
 # Amazon RDS
 
 ## Limitations
 
-- No `SUPER` privileges.
-- `gh-ost` runs should be setup use [`--assume-rbr`][assume_rbr_docs] and use `binlog_format=ROW`.
-- Aurora does not allow editing of the `read_only` parameter. While it is defined as `{TrueIfReplica}`, the parameter is non-modifiable field.
+- `gh-ost` must be run directly on the master, as RDS replicas cannot have binary logging enabled.
+
+- RDS does not allow `SUPER` user privileges. Set the `gh-ost` user to have these privileges:
+
+| Privilege | Scope |
+|--|--|
+| ALTER, CREATE, DELETE, DROP, INDEX, INSERT, LOCK TABLES, SELECT, TRIGGER, UPDATE | [schema].* |
+| REPLICATION CLIENT, REPLICATION SLAVE | \*.\* |
+
+## Requirements
+
+- `binlog_format=ROW` must be set on the master.
+  - `--switch-to-rbr` will not work on RDS as it requires the `SUPER` privilege.
+  - MySQL settings are contained in the [DB Parameter Groups](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html). To modify `binlog_format` for an instance, you can either:
+    - modify the value in the instance's current DB Parameter Group, wait several minutes for the parameter group to be "in-sync", and bounce any persistent connections to the database
+    - change the instance's parameter group; this requires a restart of the instance.
+
+    Note that modifying a DB Parameter Group will change the settings for all instances using that parameter group.
+
+- Required `gh-ost` options:
+  - `--host` set to the master host
+  - [`--allow-on-master`](https://github.com/github/gh-ost/blob/master/doc/command-line-flags.md#allow-on-master)
+  - [`--assume-rbr`][assume_rbr_docs]
 
 ## Aurora
 
 #### Replication
 
-In Aurora replication, you have separate reader and writer endpoints however because the cluster shares the underlying storage layer, `gh-ost` will detect it is running on the master. This becomes an issue when you wish to use [migrate/test on replica][migrate_test_on_replica_docs] because you won't be able to use a single cluster in the same way you would with MySQL RDS.
+In Aurora replication, you have separate reader and writer endpoints; however, because the cluster shares the underlying storage layer, `gh-ost` will detect it as running on the master. This becomes an issue when you wish to use [migrate/test on replica][migrate_test_on_replica_docs] because you won't be able to use a single cluster in the same way you would with MySQL RDS.
 
-To work around this, you can follow along the [AWS replication between clusters documentation][aws_replication_docs] for Aurora with one small caveat. For the "Create a Snapshot of Your Replication Master" step, the binlog position is not available in the AWS console. You will need to issue the SQL query `SHOW SLAVE STATUS` or `aws rds describe-events` API call to get the correct position.
+To work around this, you can follow the [AWS replication between clusters documentation][aws_replication_docs] for Aurora with one small caveat: for the "Create a Snapshot of Your Replication Master" step, the binlog position will not be available in the AWS console. You will need to issue the SQL query `SHOW SLAVE STATUS` or the `aws rds describe-events` API call to get the correct position.
 
 #### Percona Toolkit
 
@@ -31,10 +51,10 @@ This tool requires binlog_format=STATEMENT, but the current binlog_format is set
 Before trying to run any `gh-ost` migrations you will want to confirm the following:
 
 - [ ] You have a secondary cluster available that will act as a replica. Rule of thumb here has been a 1 instance per cluster to mimic MySQL-style replication as opposed to Aurora style.
-- [ ] The database instance parameters and database cluster parameters are consistent between your master and replicas
+- [ ] The database instance parameters and database cluster parameters are consistent between your master and replicas.
 - [ ] Executing `SHOW SLAVE STATUS\G` on your replica cluster displays the correct master host, binlog position, etc.
-- [ ] Database backup retention is greater than 1 day to enable binlogs
-- [ ] You have setup [`hooks`][ghost_hooks] to issue RDS procedures for stopping and starting replication. (see [github/gh-ost#163][ghost_rds_issue_tracking] for examples)
+- [ ] Database backup retention is greater than 1 day (to enable binary logging).
+- [ ] You have set up [`hooks`][ghost_hooks] to issue RDS procedures for stopping and starting replication. (see [github/gh-ost#163][ghost_rds_issue_tracking] for examples)
 
 [new_issue]: https://github.com/github/gh-ost/issues/new
 [assume_rbr_docs]: https://github.com/github/gh-ost/blob/master/doc/command-line-flags.md#assume-rbr


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

This is not associated with a specific issue but I do see some RDS issues open (e.g., https://github.com/github/gh-ost/issues/396)

### Description

This PR modifies the RDS documentation (not Aurora):

- some grammar/structure edits
- specific limitations and requirements, including options

Note I don't have production experience with RDS, but was using gh-ost on RDS for a talk. I was unable to get binary logging enabled on a read replica, so the instructions are for `--allow-on-master`. If I am misinformed, and you can run gh-ost using a replica (in non-Aurora RDS) please let me know. 