### PR TITLE
Implement Teardown (added back DB cache)

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/satori/go.uuid"
+
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 
@@ -71,6 +73,8 @@ func NewThrottleCheckResult(throttle bool, reason string, reasonHint ThrottleRea
 // MigrationContext has the general, global state of migration. It is used by
 // all components throughout the migration process.
 type MigrationContext struct {
+	Uuid string
+
 	DatabaseName      string
 	OriginalTableName string
 	AlterStatement    string
@@ -212,6 +216,7 @@ type ContextConfig struct {
 
 func NewMigrationContext() *MigrationContext {
 	return &MigrationContext{
+		Uuid:                                uuid.NewV4().String(),
 		defaultNumRetries:                   60,
 		ChunkSize:                           1000,
 		InspectorConnectionConfig:           mysql.NewConnectionConfig(),

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -158,10 +158,6 @@ func (this *GoMySQLReader) StreamEvents(canStopStreaming func() bool, entriesCha
 }
 
 func (this *GoMySQLReader) Close() error {
-	// Historically there was a:
-	//   this.binlogSyncer.Close()
-	// here. A new go-mysql version closes the binlog syncer connection independently.
-	// I will go against the sacred rules of comments and just leave this here.
-	// This is the year 2017. Let's see what year these comments get deleted.
+	this.binlogSyncer.Close()
 	return nil
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -68,12 +68,13 @@ func NewApplier(migrationContext *base.MigrationContext) *Applier {
 }
 
 func (this *Applier) InitDBConnections() (err error) {
+
 	applierUri := this.connectionConfig.GetDBUri(this.migrationContext.DatabaseName)
-	if this.db, err = mysql.GetDB(applierUri); err != nil {
+	if this.db, _, err = mysql.GetDB(this.migrationContext.Uuid, applierUri); err != nil {
 		return err
 	}
 	singletonApplierUri := fmt.Sprintf("%s?timeout=0", applierUri)
-	if this.singletonDB, err = mysql.GetDB(singletonApplierUri); err != nil {
+	if this.singletonDB, _, err = mysql.GetDB(this.migrationContext.Uuid, singletonApplierUri); err != nil {
 		return err
 	}
 	this.singletonDB.SetMaxOpenConns(1)

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -41,12 +41,12 @@ func NewInspector(migrationContext *base.MigrationContext) *Inspector {
 
 func (this *Inspector) InitDBConnections() (err error) {
 	inspectorUri := this.connectionConfig.GetDBUri(this.migrationContext.DatabaseName)
-	if this.db, err = mysql.GetDB(inspectorUri); err != nil {
+	if this.db, _, err = mysql.GetDB(this.migrationContext.Uuid, inspectorUri); err != nil {
 		return err
 	}
 
 	informationSchemaUri := this.connectionConfig.GetDBUri("information_schema")
-	if this.informationSchemaDb, err = mysql.GetDB(informationSchemaUri); err != nil {
+	if this.informationSchemaDb, _, err = mysql.GetDB(this.migrationContext.Uuid, informationSchemaUri); err != nil {
 		return err
 	}
 

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -104,7 +104,7 @@ func (this *EventsStreamer) notifyListeners(binlogEvent *binlog.BinlogDMLEvent) 
 
 func (this *EventsStreamer) InitDBConnections() (err error) {
 	EventsStreamerUri := this.connectionConfig.GetDBUri(this.migrationContext.DatabaseName)
-	if this.db, err = mysql.GetDB(EventsStreamerUri); err != nil {
+	if this.db, _, err = mysql.GetDB(this.migrationContext.Uuid, EventsStreamerUri); err != nil {
 		return err
 	}
 	if _, err := base.ValidateConnection(this.db, this.connectionConfig); err != nil {

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -186,7 +186,7 @@ func (this *Throttler) collectControlReplicasLag() {
 		dbUri := connectionConfig.GetDBUri("information_schema")
 
 		var heartbeatValue string
-		if db, err := mysql.GetDB(dbUri); err != nil {
+		if db, _, err := mysql.GetDB(this.migrationContext.Uuid, dbUri); err != nil {
 			return lag, err
 		} else if err = db.QueryRow(replicationLagQuery).Scan(&heartbeatValue); err != nil {
 			return lag, err
@@ -461,6 +461,6 @@ func (this *Throttler) throttle(onThrottled func()) {
 }
 
 func (this *Throttler) Teardown() {
-	this.migrationContext.Log.Debugf("Tearing down...")
+	log.Debugf("Tearing down...")
 	atomic.StoreInt64(&this.finishedMigrating, 1)
 }


### PR DESCRIPTION
This is a continuation of #479 and implements a migration specific DB cache that was causing memory issues observed in #526 

There are two important differences added in separate commits:
- fac1ba7 - Throttler teardown
  - We noticed in our own monitoring that there were still go routines that were hanging around in the throttler. This commit makes sure to close those out and implements the Teardown method in the same fashion
- ec6ceff - Pass in a migrationContext UUID for a migration specific connections
  - This implements the migration specific database connection cache (a migration UUID was added to the migrationContext), which should hopefully fix the memory leak. Things look stable from a migration we ran as a test from our end, but we never saw the memory get as high as a gig like you had mentioned - would be interested to hear what load you are putting it under to reproduce that scenario.
- e82d563 - Close the binlog syncer
  - I noticed in my testing that the binlog syncer was not stopping, despite the comments indicating that the library itself should do this. Explicitly adding back the close fixed this issue for me, curious to hear the context behind taking it out.

Let me know your thoughts on this approach! Happy to revise what's needed.

Thanks again :)
