### PR TITLE
Support Aliyun RDS

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -91,6 +91,7 @@ type MigrationContext struct {
 	SkipRenamedColumns       bool
 	IsTungsten               bool
 	DiscardForeignKeys       bool
+	AliyunRDS                bool
 
 	config            ContextConfig
 	configMutex       *sync.Mutex
@@ -213,6 +214,8 @@ type ContextConfig struct {
 		Max_Load              string
 	}
 }
+
+var Context *MigrationContext
 
 func NewMigrationContext() *MigrationContext {
 	return &MigrationContext{

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -65,15 +65,24 @@ func StringContainsAll(s string, substrings ...string) bool {
 }
 
 func ValidateConnection(db *gosql.DB, connectionConfig *mysql.ConnectionConfig) (string, error) {
-	query := `select @@global.port, @@global.version`
+	versionQuery := `select @@global.version`
 	var port, extraPort int
 	var version string
-	if err := db.QueryRow(query).Scan(&port, &version); err != nil {
+	if err := db.QueryRow(versionQuery).Scan(&version); err != nil {
 		return "", err
 	}
 	extraPortQuery := `select @@global.extra_port`
 	if err := db.QueryRow(extraPortQuery).Scan(&extraPort); err != nil {
 		// swallow this error. not all servers support extra_port
+	}
+	// AliyunRDS set users port to "NULL", replace it by gh-ost param
+	if Context.AliyunRDS {
+		port = connectionConfig.Key.Port
+	} else {
+		portQuery := `select @@global.port`
+		if err := db.QueryRow(portQuery).Scan(&port); err != nil {
+			return "", err
+		}
 	}
 
 	if connectionConfig.Key.Port == port || (extraPort > 0 && connectionConfig.Key.Port == extraPort) {

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -44,6 +44,7 @@ func acceptSignals(migrationContext *base.MigrationContext) {
 // main is the application's entry point. It will either spawn a CLI or HTTP interfaces.
 func main() {
 	migrationContext := base.NewMigrationContext()
+	base.Context = migrationContext
 
 	flag.StringVar(&migrationContext.InspectorConnectionConfig.Key.Hostname, "host", "127.0.0.1", "MySQL hostname (preferably a replica, not the master)")
 	flag.StringVar(&migrationContext.AssumeMasterHostname, "assume-master-host", "", "(optional) explicitly tell gh-ost the identity of the master. Format: some.host.com[:port] This is useful in master-master setups where you wish to pick an explicit master, or in a tungsten-replicator where gh-ost is unable to determine the master")
@@ -68,6 +69,7 @@ func main() {
 	flag.BoolVar(&migrationContext.IsTungsten, "tungsten", false, "explicitly let gh-ost know that you are running on a tungsten-replication based topology (you are likely to also provide --assume-master-host)")
 	flag.BoolVar(&migrationContext.DiscardForeignKeys, "discard-foreign-keys", false, "DANGER! This flag will migrate a table that has foreign keys and will NOT create foreign keys on the ghost table, thus your altered table will have NO foreign keys. This is useful for intentional dropping of foreign keys")
 	flag.BoolVar(&migrationContext.SkipForeignKeyChecks, "skip-foreign-key-checks", false, "set to 'true' when you know for certain there are no foreign keys on your table, and wish to skip the time it takes for gh-ost to verify that")
+	flag.BoolVar(&migrationContext.AliyunRDS, "aliyun-rds", false, "set to 'true' when you execute on Aliyun RDS.")
 
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration replication is stopped, and tables are swapped and immediately swap-revert. Replication remains stopped and you can compare the two tables for building trust")

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -89,10 +89,12 @@ func (this *Applier) InitDBConnections() (err error) {
 	if err := this.validateAndReadTimeZone(); err != nil {
 		return err
 	}
-	if impliedKey, err := mysql.GetInstanceKey(this.db); err != nil {
+	if impliedKey, err := mysql.GetInstanceKey(this.db, this.migrationContext.AliyunRDS); err != nil {
 		return err
 	} else {
-		this.connectionConfig.ImpliedKey = impliedKey
+		if this.migrationContext.AliyunRDS != true {
+			this.connectionConfig.ImpliedKey = impliedKey
+		}
 	}
 	if err := this.readTableColumns(); err != nil {
 		return err

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -53,10 +53,12 @@ func (this *Inspector) InitDBConnections() (err error) {
 	if err := this.validateConnection(); err != nil {
 		return err
 	}
-	if impliedKey, err := mysql.GetInstanceKey(this.db); err != nil {
+	if impliedKey, err := mysql.GetInstanceKey(this.db, this.migrationContext.AliyunRDS); err != nil {
 		return err
 	} else {
-		this.connectionConfig.ImpliedKey = impliedKey
+		if this.migrationContext.AliyunRDS != true {
+			this.connectionConfig.ImpliedKey = impliedKey
+		}
 	}
 	if err := this.validateGrants(); err != nil {
 		return err

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -171,9 +171,11 @@ func GetSelfBinlogCoordinates(db *gosql.DB) (selfBinlogCoordinates *BinlogCoordi
 }
 
 // GetInstanceKey reads hostname and port on given DB
-func GetInstanceKey(db *gosql.DB) (instanceKey *InstanceKey, err error) {
+func GetInstanceKey(db *gosql.DB, isAliyunRDS bool) (instanceKey *InstanceKey, err error) {
 	instanceKey = &InstanceKey{}
-	err = db.QueryRow(`select @@global.hostname, @@global.port`).Scan(&instanceKey.Hostname, &instanceKey.Port)
+	if isAliyunRDS != true {
+		err = db.QueryRow(`select @@global.hostname, @@global.port`).Scan(&instanceKey.Hostname, &instanceKey.Port)
+	}
 	return instanceKey, err
 }
 


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/470
### Description

This PR makes gh-ost to support Aliyun RDS.  

Aliyun RDS is the largest cloud database in China, and the third of the world. For the reason of security and architecture , we need to hide some mysql variables so gh-ost will get ilegal values. This PR add --aliyun-rds flag to avoid getting them.

### Usage
For now, users can't connect to the slave node of rds, so gh-ost may working directly on master with flags:
* --allow-on-master
* --assume-rbr
* --assume-master-host
* --aliyun-rds

Thanks for gh-ost team developed an excellent tools for online DDL, and hope more people can use it on cloud database.  

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.


