### PR TITLE
Experiment: removing LOCK IN SHARE MODE

### DIFF
--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -214,18 +214,14 @@ func BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName strin
 		return "", explodedArgs, err
 	}
 	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
-	transactionalClause := ""
-	if transactionalTable {
-		transactionalClause = "lock in share mode"
-	}
 	result = fmt.Sprintf(`
       insert /* gh-ost %s.%s */ ignore into %s.%s (%s)
       (select %s from %s.%s force index (%s)
-        where (%s and %s) %s
+        where (%s and %s)
       )
     `, databaseName, originalTableName, databaseName, ghostTableName, mappedSharedColumnsListing,
 		sharedColumnsListing, databaseName, originalTableName, uniqueKey,
-		rangeStartComparison, rangeEndComparison, transactionalClause)
+		rangeStartComparison, rangeEndComparison)
 	return result, explodedArgs, nil
 }
 


### PR DESCRIPTION
Storyline: https://github.com/github/gh-ost/issues/542

This PR experiments with removing `LOCK IN SHARE MODE` while running rowcopy.

To be deployed onto testing servers in prod.