### PR TITLE
Added teammates to authors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,5 @@ Generally speaking, `master` branch is stable, but only [releases](https://githu
 - [@ggunson](https://github.com/ggunson)
 - [@tomkrouper](https://github.com/tomkrouper)
 - [@shlomi-noach](https://github.com/shlomi-noach)
+- [@jessbreckenridge](https://github.com/jessbreckenridge)
+- [@gtowey](https://github.com/gtowey)


### PR DESCRIPTION
This PR adds 2 team member names to the README.

I just noticed the teammates list was over a year old.

@jessbreckenridge @gtowey You might not want to be publicly associated with the rest of us, so please raise any objections. 

/cc @github/database-infrastructure 