### PR TITLE
support quoted values in interactive commands

### DIFF
--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -130,6 +130,9 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 	arg := ""
 	if len(tokens) > 1 {
 		arg = strings.TrimSpace(tokens[1])
+		if unquoted, err := strconv.Unquote(arg); err == nil {
+			arg = unquoted
+		}
 	}
 	argIsQuestion := (arg == "?")
 	throttleHint := "# Note: you may only throttle for as long as your binary logs are not purged\n"


### PR DESCRIPTION
Closes https://github.com/github/gh-ost/issues/548

This PR support quoted values, such as:

```
echo throttle-query="?" | socat - /tmp/gh-ost.sock
echo throttle-query="select false" | socat - /tmp/gh-ost.sock
echo 'throttle-query="select false"' | socat - /tmp/gh-ost.sock
```

In short, quoting is not a problem anymore.
