### PR TITLE
Support exponential backoff for cutover attempts

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -100,30 +100,30 @@ type MigrationContext struct {
 	CliMasterUser     string
 	CliMasterPassword string
 
-	HeartbeatIntervalMilliseconds        int64
-	defaultNumRetries                    int64
-	ChunkSize                            int64
-	niceRatio                            float64
-	MaxLagMillisecondsThrottleThreshold  int64
-	throttleControlReplicaKeys           *mysql.InstanceKeyMap
-	ThrottleFlagFile                     string
-	ThrottleAdditionalFlagFile           string
-	throttleQuery                        string
-	throttleHTTP                         string
-	ThrottleCommandedByUser              int64
-	HibernateUntil                       int64
-	maxLoad                              LoadMap
-	criticalLoad                         LoadMap
-	CriticalLoadIntervalMilliseconds     int64
-	CriticalLoadHibernateSeconds         int64
-	PostponeCutOverFlagFile              string
-	CutOverLockTimeoutSeconds            int64
-	CutOverExponentialBackoff            bool
-	CutOverExponentialBackoffMaxInterval int64
-	ForceNamedCutOverCommand             bool
-	PanicFlagFile                        string
-	HooksPath                            string
-	HooksHintMessage                     string
+	HeartbeatIntervalMilliseconds       int64
+	defaultNumRetries                   int64
+	ChunkSize                           int64
+	niceRatio                           float64
+	MaxLagMillisecondsThrottleThreshold int64
+	throttleControlReplicaKeys          *mysql.InstanceKeyMap
+	ThrottleFlagFile                    string
+	ThrottleAdditionalFlagFile          string
+	throttleQuery                       string
+	throttleHTTP                        string
+	ThrottleCommandedByUser             int64
+	HibernateUntil                      int64
+	maxLoad                             LoadMap
+	criticalLoad                        LoadMap
+	CriticalLoadIntervalMilliseconds    int64
+	CriticalLoadHibernateSeconds        int64
+	PostponeCutOverFlagFile             string
+	CutOverLockTimeoutSeconds           int64
+	CutOverExponentialBackoff           bool
+	ExponentialBackoffMaxInterval       int64
+	ForceNamedCutOverCommand            bool
+	PanicFlagFile                       string
+	HooksPath                           string
+	HooksHintMessage                    string
 
 	DropServeSocket bool
 	ServeSocketFile string
@@ -343,11 +343,11 @@ func (this *MigrationContext) SetCutOverLockTimeoutSeconds(timeoutSeconds int64)
 	return nil
 }
 
-func (this *MigrationContext) SetCutOverExponentialBackoffMaxInterval(intervalSeconds int64) error {
+func (this *MigrationContext) SetExponentialBackoffMaxInterval(intervalSeconds int64) error {
 	if intervalSeconds < 2 {
-		return fmt.Errorf("Minimal maximum interval is 2sec. Timeout remains at %d", this.CutOverExponentialBackoffMaxInterval)
+		return fmt.Errorf("Minimal maximum interval is 2sec. Timeout remains at %d", this.ExponentialBackoffMaxInterval)
 	}
-	this.CutOverExponentialBackoffMaxInterval = intervalSeconds
+	this.ExponentialBackoffMaxInterval = intervalSeconds
 	return nil
 }
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -82,8 +82,8 @@ func main() {
 
 	flag.BoolVar(&migrationContext.SwitchToRowBinlogFormat, "switch-to-rbr", false, "let this tool automatically switch binary log format to 'ROW' on the replica, if needed. The format will NOT be switched back. I'm too scared to do that, and wish to protect you if you happen to execute another migration while this one is running")
 	flag.BoolVar(&migrationContext.AssumeRBR, "assume-rbr", false, "set to 'true' when you know for certain your server uses 'ROW' binlog_format. gh-ost is unable to tell, event after reading binlog_format, whether the replication process does indeed use 'ROW', and restarts replication to be certain RBR setting is applied. Such operation requires SUPER privileges which you might not have. Setting this flag avoids restarting replication and you can proceed to use gh-ost without SUPER privileges")
-	flag.BoolVar(&migrationContext.CutOverExponentialBackoff, "cut-over-exponential-backoff", false, "Wait exponentially longer times between failed cut-over attempts (obeys a maximum interval configurable with 'cut-over-exponential-backoff-max-interval'). Ignores 'default-retries.'")
-	cutOverExponentialBackoffMaxInterval := flag.Int64("cut-over-exponential-backoff-max-interval", 64, "Maximum number of seconds to wait between failed cut-over attempts. Ignored unless 'cut-over-exponential-backoff' is 'true.' When the maximum is reached, attempts will stop, regardless of whether the last was successful.")
+	flag.BoolVar(&migrationContext.CutOverExponentialBackoff, "cut-over-exponential-backoff", false, "Wait exponentially longer intervals between failed cut-over attempts. Wait intervals obey a maximum configurable with 'exponential-backoff-max-interval').")
+	exponentialBackoffMaxInterval := flag.Int64("exponential-backoff-max-interval", 64, "Maximum number of seconds to wait between attempts when performing various operations with exponential backoff.")
 	chunkSize := flag.Int64("chunk-size", 1000, "amount of rows to handle in each iteration (allowed range: 100-100,000)")
 	dmlBatchSize := flag.Int64("dml-batch-size", 10, "batch size for DML events to apply in a single transaction (range 1-100)")
 	defaultRetries := flag.Int64("default-retries", 60, "Default number of retries for various operations before panicking")
@@ -239,7 +239,7 @@ func main() {
 	if err := migrationContext.SetCutOverLockTimeoutSeconds(*cutOverLockTimeoutSeconds); err != nil {
 		log.Errore(err)
 	}
-	if err := migrationContext.SetCutOverExponentialBackoffMaxInterval(*cutOverExponentialBackoffMaxInterval); err != nil {
+	if err := migrationContext.SetExponentialBackoffMaxInterval(*exponentialBackoffMaxInterval); err != nil {
 		log.Errore(err)
 	}
 

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -149,10 +149,11 @@ func (this *Migrator) retryOperation(operation func() error, notFatalHint ...boo
 	return err
 }
 
-// retryOperation attempts running given function, waiting 2^(n-1) seconds
-// between each attempt, where n is the running number of attempts. exits
-// as soon as the function returns with non-error, or as soon as the next
-// wait interval exceeds `CutOverExponentialBackoffMaxInterval`.
+// `retryOperationWithExponentialBackoff` attempts running given function, waiting 2^(n-1)
+// seconds between each attempt, where `n` is the running number of attempts. Exits
+// as soon as the function returns with non-error, or as soon as `MaxRetries`
+// attempts are reached. Wait intervals between attempts obey a maximum of
+// `ExponentialBackoffMaxInterval`.
 func (this *Migrator) retryOperationWithExponentialBackoff(operation func() error, notFatalHint ...bool) (err error) {
 	var interval int64
 	maxRetries := int(this.migrationContext.MaxRetries())

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -154,17 +154,21 @@ func (this *Migrator) retryOperation(operation func() error, notFatalHint ...boo
 // as soon as the function returns with non-error, or as soon as the next
 // wait interval exceeds `CutOverExponentialBackoffMaxInterval`.
 func (this *Migrator) retryOperationWithExponentialBackoff(operation func() error, notFatalHint ...bool) (err error) {
-	numAttempts := 0
 	var interval int64
-	maxInterval := this.migrationContext.CutOverExponentialBackoffMaxInterval
-	for interval < maxInterval {
-		time.Sleep(time.Duration(interval) * time.Second)
+	maxRetries := int(this.migrationContext.MaxRetries())
+	maxInterval := this.migrationContext.ExponentialBackoffMaxInterval
+	for i := 0; i < maxRetries; i++ {
+		newInterval := int64(math.Exp2(float64(i - 1)))
+		if newInterval <= maxInterval {
+			interval = newInterval
+		}
+		if i != 0 {
+			time.Sleep(time.Duration(interval) * time.Second)
+		}
 		err = operation()
 		if err == nil {
 			return nil
 		}
-		interval = int64(math.Exp2(float64(numAttempts)))
-		numAttempts++
 	}
 	if len(notFatalHint) == 0 {
 		this.migrationContext.PanicAbort <- err


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/558

### Description

This PR introduces the flags `cut-over-exponential-backoff` and `cut-over-exponential-backoff-max-interval`. `cut-over-exponential-backoff` is a boolean flag which, if set to `true`, spaces out cutover attempts using an exponential backoff algorithm. This flag defaults to `false`.`cut-over-exponential-backoff-max-interval` is a numeric flag which dictates the upper bound that the exponentially increasing attempt spacing should obey. This flag defaults to 64 seconds, or 8 total attempts. I enforced a minimum of 2 seconds for this value, which would correspond to 3 total attempts. I added this validation because enabling exponential backoff with fewer than 3 attempts seems both pointless and likely accidental.

The exponential backoff is implemented as a separate function `retryOperationWithExponentialBackoff`. Like `retryOperation`, this function would be reusable in other parts of the project if desired.

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
