### PR TITLE
go/base: Do not ignore f.Close error

### DIFF
--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -40,10 +40,9 @@ func FileExists(fileName string) bool {
 func TouchFile(fileName string) error {
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE, 0755)
 	if err != nil {
-		return (err)
+		return err
 	}
-	defer f.Close()
-	return nil
+	return f.Close()
 }
 
 // StringContainsAll returns true if `s` contains all non empty given `substrings`


### PR DESCRIPTION
### Description

Do not ignore os.File.Close error.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
