### PR TITLE
build.sh: supporting go1.9 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Please see [Coding gh-ost](doc/coding-ghost.md) for a guide to getting started d
 
 [Download latest release here](https://github.com/github/gh-ost/releases/latest)
 
-`gh-ost` is a Go project; it is built with Go `1.8` (though `1.7` should work as well). To build on your own, use either:
+`gh-ost` is a Go project; it is built with Go `1.9` and above. To build on your own, use either:
 - [script/build](https://github.com/github/gh-ost/blob/master/script/build) - this is the same build script used by CI hence the authoritative; artifact is `./bin/gh-ost` binary.
 - [build.sh](https://github.com/github/gh-ost/blob/master/build.sh) for building `tar.gz` artifacts in `/tmp/gh-ost`
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ function build {
     GOOS=$3
     GOARCH=$4
 
-    if [[ $(go version | egrep "go1[.][012345678]") ]]; then
+    if ! go version | egrep -q 'go(1[.]9|1[.]1[0-9])' ; then
       echo "go version is too low. Must use 1.9 or above"
       exit 1
     fi


### PR DESCRIPTION
Fixes https://github.com/github/gh-ost/issues/571

`gh-ost` requires `1.9` or above, and supports `1.10` - `1.19` (at this time latest go version is `1.10`)

cc @FortuneOSarcasm 