### PR TITLE
avoid prepared statements for changelog table

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -290,7 +290,7 @@ func (this *Applier) WriteChangelog(hint, value string) (string, error) {
 		sql.EscapeName(this.migrationContext.DatabaseName),
 		sql.EscapeName(this.migrationContext.GetChangelogTableName()),
 	)
-	_, err := sqlutils.Exec(this.db, query, explicitId, hint, value)
+	_, err := sqlutils.ExecNoPrepare(this.db, query, explicitId, hint, value)
 	return hint, err
 }
 


### PR DESCRIPTION
Writes to the changelog table were left using server side prepared statements, even as all other writes were set to use client-side prepared statements.

cc @ggunson 