### PR TITLE
fix retry failed bug which might result in early quit of migration

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1122,7 +1122,7 @@ func (this *Migrator) iterateChunks() error {
 				}
 				_, rowsAffected, _, err := this.applier.ApplyIterationInsertQuery()
 				if err != nil {
-					return terminateRowIteration(err)
+					return err
 				}
 				atomic.AddInt64(&this.migrationContext.TotalRowsCopied, rowsAffected)
 				atomic.AddInt64(&this.migrationContext.Iteration, 1)


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/483

### Description
`applyCopyRowsFunc` should be retriable. But when there is error, terminateRowIteration is called, which results in a panic. So terminateRowIteration should not be called inside applyCopyRowsFunc

```go
// Copy task:
applyCopyRowsFunc := func() error {
	if atomic.LoadInt64(&this.rowCopyCompleteFlag) == 1 {
		return nil
	}
	_, rowsAffected, _, err := this.applier.ApplyIterationInsertQuery()
	if err != nil {
		return err // terminateRowIteration shouldn't be called if you want retry
	}
	atomic.AddInt64(&this.migrationContext.TotalRowsCopied, rowsAffected)
	atomic.AddInt64(&this.migrationContext.Iteration, 1)
	return nil
}
if err := this.retryOperation(applyCopyRowsFunc); err != nil {
	return terminateRowIteration(err)
}
```