### PR TITLE
localtests support throttle flag file

### DIFF
--- a/localtests/datetime-1970/create.sql
+++ b/localtests/datetime-1970/create.sql
@@ -1,3 +1,5 @@
+set session time_zone='+00:00';
+
 drop table if exists gh_ost_test;
 create table gh_ost_test (
   id int auto_increment,

--- a/localtests/datetime-1970/create.sql
+++ b/localtests/datetime-1970/create.sql
@@ -9,6 +9,7 @@ create table gh_ost_test (
   primary key(id)
 ) auto_increment=1;
 
+set session time_zone='+00:00';
 insert into gh_ost_test values (1, '0000-00-00 00:00:00', now(), 0);
 
 drop event if exists gh_ost_test;
@@ -21,5 +22,6 @@ create event gh_ost_test
   enable
   do
 begin
+  set session time_zone='+00:00';
   update gh_ost_test set counter = counter + 1 where id = 1;
 end ;;

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -20,6 +20,7 @@ master_host=
 master_port=
 replica_host=
 replica_port=
+original_sql_mode=
 
 OPTIND=1
 while getopts "b:" OPTION
@@ -46,6 +47,8 @@ verify_master_and_replica() {
     echo "Cannot enable event_scheduler on master"
     exit 1
   fi
+  original_sql_mode="$(gh-ost-test-mysql-master -e "select @@global.sql_mode" -s -s)"
+  echo "sql_mode on master is ${original_sql_mode}"
 
   if [ "$(gh-ost-test-mysql-replica -e "select 1" -ss)" != "1" ] ; then
     echo "Cannot verify gh-ost-test-mysql-replica"
@@ -88,7 +91,6 @@ start_replication() {
 test_single() {
   local test_name
   test_name="$1"
-  original_sql_mode="$(gh-ost-test-mysql-master -e "select @@global.sql_mode" -s -s)"
 
   if [ -f $tests_path/$test_name/ignore_versions ] ; then
     ignore_versions=$(cat $tests_path/$test_name/ignore_versions)

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -14,6 +14,7 @@ ghost_binary=""
 exec_command_file=/tmp/gh-ost-test.bash
 orig_content_output_file=/tmp/gh-ost-test.orig.content.csv
 ghost_content_output_file=/tmp/gh-ost-test.ghost.content.csv
+throttle_flag_file=/tmp/gh-ost-test.ghost.throttle.flag
 
 master_host=
 master_port=
@@ -108,7 +109,7 @@ test_single() {
     gh-ost-test-mysql-master --default-character-set=utf8mb4 test -e "set @@global.sql_mode='$(cat $tests_path/$test_name/sql_mode)'"
     gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "set @@global.sql_mode='$(cat $tests_path/$test_name/sql_mode)'"
   fi
-  
+
   gh-ost-test-mysql-master --default-character-set=utf8mb4 test < $tests_path/$test_name/create.sql
 
   extra_args=""
@@ -145,6 +146,7 @@ test_single() {
     --initially-drop-old-table \
     --initially-drop-ghost-table \
     --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from _gh_ost_test_ghc' \
+    --throttle-flag-file=$throttle_flag_file \
     --serve-socket-file=/tmp/gh-ost.test.sock \
     --initially-drop-socket-file \
     --test-on-replica \


### PR DESCRIPTION
minor change to improve human testing experience by supporting a `throttle-flag-file` for integration tests