### PR TITLE
testing: convert to character set utf8mb4

### DIFF
--- a/localtests/convert-utf8mb4/create.sql
+++ b/localtests/convert-utf8mb4/create.sql
@@ -1,0 +1,25 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  t varchar(128) charset utf8 collate utf8_general_ci,
+  ta varchar(128) charset ascii not null,
+  primary key(id)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, md5(rand()), 'a');
+  insert into gh_ost_test values (null, 'novo proprietário', 'b');
+  insert into gh_ost_test values (null, 'usuário', 'c');
+  insert into gh_ost_test values (null, 'usuário', 'x');
+
+  delete from gh_ost_test where ta='x' order by id desc limit 1;
+end ;;

--- a/localtests/convert-utf8mb4/create.sql
+++ b/localtests/convert-utf8mb4/create.sql
@@ -2,11 +2,15 @@ drop table if exists gh_ost_test;
 create table gh_ost_test (
   id int auto_increment,
   t varchar(128) charset utf8 collate utf8_general_ci,
+  tl varchar(128) charset latin1 not null,
   ta varchar(128) charset ascii not null,
   primary key(id)
 ) auto_increment=1;
 
-insert into gh_ost_test values (null, 'Hello world, Καλημέρα κόσμε, コンニチハ', 'initial');
+insert into gh_ost_test values (null, 'átesting');
+
+
+insert into gh_ost_test values (null, 'Hello world, Καλημέρα κόσμε, コンニチハ', 'átesting0', 'initial');
 
 drop event if exists gh_ost_test;
 delimiter ;;
@@ -18,10 +22,10 @@ create event gh_ost_test
   enable
   do
 begin
-  insert into gh_ost_test values (null, md5(rand()), 'a');
-  insert into gh_ost_test values (null, 'novo proprietário', 'b');
-  insert into gh_ost_test values (null, '2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm', 'c');
-  insert into gh_ost_test values (null, 'usuário', 'x');
+  insert into gh_ost_test values (null, md5(rand()), 'átesting-a', 'a');
+  insert into gh_ost_test values (null, 'novo proprietário', 'átesting-b', 'b');
+  insert into gh_ost_test values (null, '2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm', 'átesting-c', 'c');
+  insert into gh_ost_test values (null, 'usuário', 'átesting-x', 'x');
 
   delete from gh_ost_test where ta='x' order by id desc limit 1;
 end ;;

--- a/localtests/convert-utf8mb4/create.sql
+++ b/localtests/convert-utf8mb4/create.sql
@@ -6,6 +6,8 @@ create table gh_ost_test (
   primary key(id)
 ) auto_increment=1;
 
+insert into gh_ost_test values (null, 'Hello world, Καλημέρα κόσμε, コンニチハ', 'initial');
+
 drop event if exists gh_ost_test;
 delimiter ;;
 create event gh_ost_test
@@ -18,7 +20,7 @@ create event gh_ost_test
 begin
   insert into gh_ost_test values (null, md5(rand()), 'a');
   insert into gh_ost_test values (null, 'novo proprietário', 'b');
-  insert into gh_ost_test values (null, 'usuário', 'c');
+  insert into gh_ost_test values (null, '2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm', 'c');
   insert into gh_ost_test values (null, 'usuário', 'x');
 
   delete from gh_ost_test where ta='x' order by id desc limit 1;

--- a/localtests/convert-utf8mb4/extra_args
+++ b/localtests/convert-utf8mb4/extra_args
@@ -1,0 +1,1 @@
+--alter='convert to character set utf8mb4'


### PR DESCRIPTION
Adding a test for a `convert to character set utf8mb4` statement, where the table is populated with utf8 data. The test confirms the existing text does not get corrupted.