### PR TITLE
Update docs to include info about throttle-HTTP and some undocumented flags

### DIFF
--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -69,6 +69,10 @@ This is somewhat similar to a Nagios `n`-times test, where `n` in our case is al
 
 Optional. Default is `safe`. See more discussion in [`cut-over`](cut-over.md)
 
+### cut-over-lock-timeout-seconds
+
+Default `3`.  Max number of seconds to hold locks on tables while attempting to cut-over (retry attempted when lock exceeds timeout).
+
 ### discard-foreign-keys
 
 **Danger**: this flag will _silently_ discard any foreign keys existing on your table.
@@ -107,6 +111,10 @@ While the ongoing estimated number of rows is still heuristic, it's almost exact
 
 Without this parameter, migration is a _noop_: testing table creation and validity of migration, but not touching data.
 
+### force-table-names
+
+Table name prefix to be used on the temporary tables.
+
 ### gcp
 
 Add this flag when executing on a 1st generation Google Cloud Platform (GCP).
@@ -124,6 +132,10 @@ We think `gh-ost` should not take chances or make assumptions about the user's t
 ### initially-drop-old-table
 
 See [`initially-drop-ghost-table`](#initially-drop-ghost-table)
+
+### initially-drop-socket-file
+
+Default False. Should `gh-ost` forcibly delete an existing socket file. Be careful: this might drop the socket file of a running migration!
 
 ### max-lag-millis
 
@@ -168,6 +180,10 @@ See [`approve-renamed-columns`](#approve-renamed-columns)
 ### test-on-replica
 
 Issue the migration on a replica; do not modify data on master. Useful for validating, testing and benchmarking. See [`testing-on-replica`](testing-on-replica.md)
+
+### test-on-replica-skip-replica-stop
+
+Default `False`. When `--test-on-replica` is enabled, do not issue commands stop replication (requires `--test-on-replica`).
 
 ### throttle-control-replicas
 

--- a/doc/throttle.md
+++ b/doc/throttle.md
@@ -46,6 +46,14 @@ Note that you may dynamically change both `--max-lag-millis` and the `throttle-c
 
 An example query could be: `--throttle-query="select hour(now()) between 8 and 17"` which implies throttling auto-starts `8:00am` and migration auto-resumes at `18:00pm`.
 
+#### HTTP Throttle
+
+The `--throttle-HTTP` flag allows for throttling via HTTP. Every 100ms `gh-ost` issues a `HEAD` request to the provided URL. If the response status code is not `200` throttling will kick in until a `200` response status code is returned.
+
+If no URL is provided or the URL provided doesn't contain the scheme then the HTTP check will be disabled. For example `--throttle-HTTP="http://1.2.3.4:6789/throttle"` will enable the HTTP check/throttling, but `--throttle-HTTP=1.2.3.4:6789/throttle` will not.
+
+The URL can be queried and updated dynamically via [interactive interface](interactive-commands.md).
+
 #### Manual control
 
 In addition to the above, you are able to take control and throttle the operation any time you like.

--- a/doc/throttle.md
+++ b/doc/throttle.md
@@ -50,7 +50,7 @@ An example query could be: `--throttle-query="select hour(now()) between 8 and 1
 
 The `--throttle-HTTP` flag allows for throttling via HTTP. Every 100ms `gh-ost` issues a `HEAD` request to the provided URL. If the response status code is not `200` throttling will kick in until a `200` response status code is returned.
 
-If no URL is provided or the URL provided doesn't contain the scheme then the HTTP check will be disabled. For example `--throttle-HTTP="http://1.2.3.4:6789/throttle"` will enable the HTTP check/throttling, but `--throttle-HTTP=1.2.3.4:6789/throttle` will not.
+If no URL is provided or the URL provided doesn't contain the scheme then the HTTP check will be disabled. For example `--throttle-HTTP="http://1.2.3.4:6789/throttle"` will enable the HTTP check/throttling, but `--throttle-HTTP="1.2.3.4:6789/throttle"` will not.
 
 The URL can be queried and updated dynamically via [interactive interface](interactive-commands.md).
 


### PR DESCRIPTION
### Description

PR only contains documentation changes.
- Added documentation for throttle-HTTP to the throttle docs
- Added documentation for flags that were previously undocumented. I copied all of these descriptions straight from the help text in the code.


