### PR TITLE
Initial SSL Connection Support

### DIFF
--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -177,6 +177,18 @@ By default `gh-ost` verifies no foreign keys exist on the migrated table. On ser
 
 See [`approve-renamed-columns`](#approve-renamed-columns)
 
+### ssl
+
+By default `gh-ost` does not use ssl/tls connections to the database servers when performing migrations. This flag instructs `gh-ost` to use encrypted connections. If enabled, `gh-ost` will use the system's ca certificate pool for server certificate verification. If a different certificate is needed for server verification, see `--ssl-ca`. If you wish to skip server verification, but still use encrypted connections, use with `--ssl-allow-insecure`.
+
+### ssl-allow-insecure
+
+Allows `gh-ost` to connect to the MySQL servers using encrypted connections, but without verifying the validity of the certificate provided by the server during the connection. Requires `--ssl`.
+
+### ssl-ca
+
+`--ssl-ca=/path/to/ca-cert.pem`: ca certificate file (in PEM format) to use for server certificate verification. If specified, the default system ca cert pool will not be used for verification, only the ca cert provided here. Requires `--ssl`.
+
 ### test-on-replica
 
 Issue the migration on a replica; do not modify data on master. Useful for validating, testing and benchmarking. See [`testing-on-replica`](testing-on-replica.md)

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -94,16 +94,16 @@ type MigrationContext struct {
 	AliyunRDS                bool
 	GoogleCloudPlatform      bool
 
-	config                ContextConfig
-	configMutex           *sync.Mutex
-	ConfigFile            string
-	CliUser               string
-	CliPassword           string
-	UseTLS                bool
-	TLSInsecureSkipVerify bool
-	TLSCACertificate      string
-	CliMasterUser         string
-	CliMasterPassword     string
+	config            ContextConfig
+	configMutex       *sync.Mutex
+	ConfigFile        string
+	CliUser           string
+	CliPassword       string
+	UseTLS            bool
+	TLSAllowInsecure  bool
+	TLSCACertificate  string
+	CliMasterUser     string
+	CliMasterPassword string
 
 	HeartbeatIntervalMilliseconds       int64
 	defaultNumRetries                   int64
@@ -700,7 +700,7 @@ func (this *MigrationContext) ApplyCredentials() {
 
 func (this *MigrationContext) SetupTLS() error {
 	if this.UseTLS {
-		return this.InspectorConnectionConfig.UseTLS(this.TLSCACertificate)
+		return this.InspectorConnectionConfig.UseTLS(this.TLSCACertificate, this.TLSAllowInsecure)
 	}
 	return nil
 }

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -99,6 +99,8 @@ type MigrationContext struct {
 	ConfigFile        string
 	CliUser           string
 	CliPassword       string
+	UseTLS            bool
+	TlsCACertificate  string
 	CliMasterUser     string
 	CliMasterPassword string
 
@@ -693,6 +695,13 @@ func (this *MigrationContext) ApplyCredentials() {
 		// Override
 		this.InspectorConnectionConfig.Password = this.CliPassword
 	}
+}
+
+func (this *MigrationContext) SetupTLS() error {
+	if this.UseTLS {
+		return this.InspectorConnectionConfig.UseTLS(this.TlsCACertificate)
+	}
+	return nil
 }
 
 // ReadConfigFile attempts to read the config file, if it exists

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -94,15 +94,16 @@ type MigrationContext struct {
 	AliyunRDS                bool
 	GoogleCloudPlatform      bool
 
-	config            ContextConfig
-	configMutex       *sync.Mutex
-	ConfigFile        string
-	CliUser           string
-	CliPassword       string
-	UseTLS            bool
-	TLSCACertificate  string
-	CliMasterUser     string
-	CliMasterPassword string
+	config                ContextConfig
+	configMutex           *sync.Mutex
+	ConfigFile            string
+	CliUser               string
+	CliPassword           string
+	UseTLS                bool
+	TLSInsecureSkipVerify bool
+	TLSCACertificate      string
+	CliMasterUser         string
+	CliMasterPassword     string
 
 	HeartbeatIntervalMilliseconds       int64
 	defaultNumRetries                   int64

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -100,7 +100,7 @@ type MigrationContext struct {
 	CliUser           string
 	CliPassword       string
 	UseTLS            bool
-	TlsCACertificate  string
+	TLSCACertificate  string
 	CliMasterUser     string
 	CliMasterPassword string
 
@@ -699,7 +699,7 @@ func (this *MigrationContext) ApplyCredentials() {
 
 func (this *MigrationContext) SetupTLS() error {
 	if this.UseTLS {
-		return this.InspectorConnectionConfig.UseTLS(this.TlsCACertificate)
+		return this.InspectorConnectionConfig.UseTLS(this.TLSCACertificate)
 	}
 	return nil
 }

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -46,6 +46,7 @@ func NewGoMySQLReader(migrationContext *base.MigrationContext) (binlogReader *Go
 		Port:       uint16(binlogReader.connectionConfig.Key.Port),
 		User:       binlogReader.connectionConfig.User,
 		Password:   binlogReader.connectionConfig.Password,
+		TLSConfig:  binlogReader.connectionConfig.TLSConfig(),
 		UseDecimal: true,
 	}
 	binlogReader.binlogSyncer = replication.NewBinlogSyncer(binlogSyncerConfig)

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -57,6 +57,7 @@ func main() {
 
 	flag.BoolVar(&migrationContext.UseTLS, "ssl", false, "Enable SSL encrypted connections to MySQL hosts")
 	flag.StringVar(&migrationContext.TLSCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections to MySQL hosts. Requires --ssl")
+	flag.StringVar(&migrationContext.TLSInsecureSkipVerify, "ssl-insecure", false, "Do not verify that the TLS connection is secure. Requires --ssl")
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
 	flag.StringVar(&migrationContext.OriginalTableName, "table", "", "table name (mandatory)")
@@ -200,6 +201,9 @@ func main() {
 	}
 	if migrationContext.TLSCACertificate != "" && !migrationContext.UseTLS {
 		log.Fatalf("--ssl-ca requires --ssl")
+	}
+	if migrationContext.TLSInsecureSkipVerify && !migrationContext.UseTLS {
+		log.Fatalf("--ssl-insecure requires --ssl")
 	}
 	if *replicationLagQuery != "" {
 		log.Warningf("--replication-lag-query is deprecated")

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -245,7 +245,9 @@ func main() {
 	migrationContext.SetThrottleHTTP(*throttleHTTP)
 	migrationContext.SetDefaultNumRetries(*defaultRetries)
 	migrationContext.ApplyCredentials()
-	migrationContext.SetupTLS()
+	if err := migrationContext.SetupTLS(); err != nil {
+		log.Fatale(err)
+	}
 	if err := migrationContext.SetCutOverLockTimeoutSeconds(*cutOverLockTimeoutSeconds); err != nil {
 		log.Errore(err)
 	}

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	flag.BoolVar(&migrationContext.UseTLS, "ssl", false, "Enable SSL encrypted connections to MySQL hosts")
 	flag.StringVar(&migrationContext.TLSCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections to MySQL hosts. Requires --ssl")
-	flag.StringVar(&migrationContext.TLSInsecureSkipVerify, "ssl-insecure", false, "Do not verify that the TLS connection is secure. Requires --ssl")
+	flag.BoolVar(&migrationContext.TLSAllowInsecure, "ssl-allow-insecure", false, "Skips verification of MySQL hosts' certificate chain and host name. Requires --ssl")
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
 	flag.StringVar(&migrationContext.OriginalTableName, "table", "", "table name (mandatory)")
@@ -202,8 +202,8 @@ func main() {
 	if migrationContext.TLSCACertificate != "" && !migrationContext.UseTLS {
 		log.Fatalf("--ssl-ca requires --ssl")
 	}
-	if migrationContext.TLSInsecureSkipVerify && !migrationContext.UseTLS {
-		log.Fatalf("--ssl-insecure requires --ssl")
+	if migrationContext.TLSAllowInsecure && !migrationContext.UseTLS {
+		log.Fatalf("--ssl-allow-insecure requires --ssl")
 	}
 	if *replicationLagQuery != "" {
 		log.Warningf("--replication-lag-query is deprecated")

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -55,8 +55,8 @@ func main() {
 	flag.StringVar(&migrationContext.ConfigFile, "conf", "", "Config file")
 	askPass := flag.Bool("ask-pass", false, "prompt for MySQL password")
 
-	flag.BoolVar(&migrationContext.UseTLS, "ssl", false, "Enable SSL encrypted connections to MySQL")
-	flag.StringVar(&migrationContext.TLSCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections. Requires --ssl")
+	flag.BoolVar(&migrationContext.UseTLS, "ssl", false, "Enable SSL encrypted connections to MySQL hosts")
+	flag.StringVar(&migrationContext.TLSCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections to MySQL hosts. Requires --ssl")
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
 	flag.StringVar(&migrationContext.OriginalTableName, "table", "", "table name (mandatory)")

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -56,7 +56,7 @@ func main() {
 	askPass := flag.Bool("ask-pass", false, "prompt for MySQL password")
 
 	flag.BoolVar(&migrationContext.UseTLS, "ssl", false, "Enable SSL encrypted connections to MySQL")
-	flag.StringVar(&migrationContext.TlsCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections. Requires --ssl")
+	flag.StringVar(&migrationContext.TLSCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections. Requires --ssl")
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
 	flag.StringVar(&migrationContext.OriginalTableName, "table", "", "table name (mandatory)")
@@ -198,7 +198,7 @@ func main() {
 	if migrationContext.CliMasterPassword != "" && migrationContext.AssumeMasterHostname == "" {
 		log.Fatalf("--master-password requires --assume-master-host")
 	}
-	if migrationContext.TlsCACertificate != "" && !migrationContext.UseTLS {
+	if migrationContext.TLSCACertificate != "" && !migrationContext.UseTLS {
 		log.Fatalf("--ssl-ca requires --ssl")
 	}
 	if *replicationLagQuery != "" {

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -73,7 +73,7 @@ func (this *Applier) InitDBConnections() (err error) {
 	if this.db, _, err = mysql.GetDB(this.migrationContext.Uuid, applierUri); err != nil {
 		return err
 	}
-	singletonApplierUri := fmt.Sprintf("%s?timeout=0", applierUri)
+	singletonApplierUri := fmt.Sprintf("%s&timeout=0", applierUri)
 	if this.singletonDB, _, err = mysql.GetDB(this.migrationContext.Uuid, singletonApplierUri); err != nil {
 		return err
 	}

--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -57,11 +57,11 @@ func (this *ConnectionConfig) Equals(other *ConnectionConfig) bool {
 	return this.Key.Equals(&other.Key) || this.ImpliedKey.Equals(other.ImpliedKey)
 }
 
-func (this *ConnectionConfig) UseTLS(caCertificatePath string) error {
+func (this *ConnectionConfig) UseTLS(caCertificatePath string, allowInsecure bool) error {
 	var rootCertPool *x509.CertPool
 	var err error
 
-	if !this.TLSInsecureSkipVerify {
+	if !allowInsecure {
 		if caCertificatePath == "" {
 			rootCertPool, err = x509.SystemCertPool()
 			if err != nil {
@@ -81,7 +81,7 @@ func (this *ConnectionConfig) UseTLS(caCertificatePath string) error {
 
 	this.tlsConfig = &tls.Config{
 		RootCAs:            rootCertPool,
-		InsecureSkipVerify: this.TLSInsecureSkipVerify,
+		InsecureSkipVerify: allowInsecure,
 	}
 
 	return mysql.RegisterTLSConfig(this.Key.StringCode(), this.tlsConfig)

--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -91,6 +91,8 @@ func (this *ConnectionConfig) GetDBUri(databaseName string) string {
 		hostname = fmt.Sprintf("[%s]", hostname)
 	}
 	interpolateParams := true
+	// go-mysql-driver defaults to false if tls param is not provided; explicitly setting here to
+	// simplify construction of the DSN below.
 	tlsOption := "false"
 	if this.tlsConfig != nil {
 		tlsOption = this.Key.StringCode()

--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -76,10 +76,7 @@ func (this *ConnectionConfig) UseTLS(caCertificatePath string) error {
 		InsecureSkipVerify: skipVerify,
 	}
 
-	if err := mysql.RegisterTLSConfig(this.Key.StringCode(), this.tlsConfig); err != nil {
-		return err
-	}
-	return nil
+	return mysql.RegisterTLSConfig(this.Key.StringCode(), this.tlsConfig)
 }
 
 func (this *ConnectionConfig) TLSConfig() *tls.Config {


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/521

### Description

This PR adds initial support for enforcing TLS/SSL connections for the databases involved in the schema changes. In this initial pass, a gh-ost user can enforce ssl be used for connections using the `--ssl` flag on the command line. If the user wishes to enforce checking validity of the database's certificate, the user can also specify a CA certificate in pem format with the `--ssl-ca` option.

Adding these two options is sufficient for our use case right now in connecting to [AWS RDS instances](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.SSLSupport). While there are plenty more options that can be specified by the native mysql client regarding ssl, this can provide a good starting point for other work by those with more complex needs.

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.

### Testing

We tested this updated code against an Aurora2 cluster running a MySQL 5.7 compatible engine. 
-  For testing we added a user to the mysql cluster with `REQUIRE SSL` set. 
- We then attempted to run an alter table command using `gh-ost` against the cluster, but without the new ssl options enabled. As expected we received an access denied when attempting to connect with `gh-ost`. 
- We then attempted the same alter table command using all the same options, except also adding on the new `--ssl` flag, along with specifying the `--ssl-ca` certificate for AWS RDS. The job executed flawlessly.
