### PR TITLE
MySQL 8.0.13: rename table

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1000,63 +1000,6 @@ func (this *Applier) buildDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) (result
 	return append(results, newDmlBuildResultError(fmt.Errorf("Unknown dml event type: %+v", dmlEvent.DML)))
 }
 
-// ApplyDMLEventQuery writes an entry to the ghost table, in response to an intercepted
-// original-table binlog event
-func (this *Applier) ApplyDMLEventQuery(dmlEvent *binlog.BinlogDMLEvent) error {
-	for _, buildResult := range this.buildDMLEventQuery(dmlEvent) {
-		if buildResult.err != nil {
-			return buildResult.err
-		}
-		// TODO The below is in preparation for transactional writes on the ghost tables.
-		// Such writes would be, for example:
-		// - prepended with sql_mode setup
-		// - prepended with time zone setup
-		// - prepended with SET SQL_LOG_BIN=0
-		// - prepended with SET FK_CHECKS=0
-		// etc.
-		//
-		// a known problem: https://github.com/golang/go/issues/9373 -- bitint unsigned values, not supported in database/sql
-		// is solved by silently converting unsigned bigints to string values.
-		//
-
-		err := func() error {
-			tx, err := this.db.Begin()
-			if err != nil {
-				return err
-			}
-			rollback := func(err error) error {
-				tx.Rollback()
-				return err
-			}
-			sessionQuery := `SET
-			SESSION time_zone = '+00:00',
-			sql_mode = CONCAT(@@session.sql_mode, ',STRICT_ALL_TABLES')
-			`
-			if _, err := tx.Exec(sessionQuery); err != nil {
-				return rollback(err)
-			}
-			if _, err := tx.Exec(buildResult.query, buildResult.args...); err != nil {
-				return rollback(err)
-			}
-			if err := tx.Commit(); err != nil {
-				return err
-			}
-			return nil
-		}()
-
-		if err != nil {
-			err = fmt.Errorf("%s; query=%s; args=%+v", err.Error(), buildResult.query, buildResult.args)
-			return log.Errore(err)
-		}
-		// no error
-		atomic.AddInt64(&this.migrationContext.TotalDMLEventsApplied, 1)
-		if this.migrationContext.CountTableRows {
-			atomic.AddInt64(&this.migrationContext.RowsDeltaEstimate, buildResult.rowsDelta)
-		}
-	}
-	return nil
-}
-
 // ApplyDMLEventQueries applies multiple DML queries onto the _ghost_ table
 func (this *Applier) ApplyDMLEventQueries(dmlEvents [](*binlog.BinlogDMLEvent)) error {
 

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -519,7 +519,7 @@ func (this *Migrator) cutOver() (err error) {
 		}
 	}
 	var cutOverFunc func() error
-	if !mysql.IsSmallerMajorVersion(this.migrationContext.ApplierMySQLVersion, "8.0.13") {
+	if !mysql.IsSmallerMinorVersion(this.migrationContext.ApplierMySQLVersion, "8.0.13") {
 		// This is MySQL 8.0 or above. We can utilize a new ALTER TABLE featiure that supports
 		// RENAME while the table is locked.
 		cutOverFunc = this.cutOverMySQL8013

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -144,7 +144,7 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 	switch command {
 	case "help":
 		{
-			fmt.Fprintln(writer, `available commands:
+			fmt.Fprint(writer, `available commands:
 status                               # Print a detailed status message
 sup                                  # Print a short status message
 coordinates													 # Print the currently inspected coordinates

--- a/go/mysql/utils_test.go
+++ b/go/mysql/utils_test.go
@@ -1,0 +1,30 @@
+/*
+   Copyright 2016 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestIsSmallerMajorVersion(t *testing.T) {
+	i55 := "5.5"
+	i5517 := "5.5.17"
+	i56 := "5.6"
+	i8013 := "8.0.13"
+
+	test.S(t).ExpectFalse(IsSmallerMajorVersion(i55, i5517))
+	test.S(t).ExpectFalse(IsSmallerMajorVersion(i56, i5517))
+	test.S(t).ExpectTrue(IsSmallerMajorVersion(i55, i56))
+	test.S(t).ExpectTrue(IsSmallerMajorVersion(i56, i8013))
+	test.S(t).ExpectFalse(IsSmallerMajorVersion(i8013, i56))
+}

--- a/go/mysql/utils_test.go
+++ b/go/mysql/utils_test.go
@@ -6,6 +6,7 @@
 package mysql
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/outbrain/golib/log"
@@ -16,15 +17,40 @@ func init() {
 	log.SetLevel(log.ERROR)
 }
 
+func TestVersionTokens(t *testing.T) {
+	test.S(t).ExpectTrue(reflect.DeepEqual(versionTokens("5.7.24-log", 3), []int{5, 7, 24}))
+	test.S(t).ExpectTrue(reflect.DeepEqual(versionTokens("8.0.13", 3), []int{8, 0, 13}))
+	test.S(t).ExpectTrue(reflect.DeepEqual(versionTokens("5.5", 2), []int{5, 5}))
+	test.S(t).ExpectTrue(reflect.DeepEqual(versionTokens("5.5", 3), []int{5, 5, 0}))
+	test.S(t).ExpectTrue(reflect.DeepEqual(versionTokens("5.5-log", 3), []int{5, 5, 0}))
+}
+
 func TestIsSmallerMajorVersion(t *testing.T) {
 	i55 := "5.5"
+	i5516 := "5.5.16"
 	i5517 := "5.5.17"
 	i56 := "5.6"
 	i8013 := "8.0.13"
 
 	test.S(t).ExpectFalse(IsSmallerMajorVersion(i55, i5517))
+	test.S(t).ExpectFalse(IsSmallerMajorVersion(i5516, i5517))
 	test.S(t).ExpectFalse(IsSmallerMajorVersion(i56, i5517))
 	test.S(t).ExpectTrue(IsSmallerMajorVersion(i55, i56))
 	test.S(t).ExpectTrue(IsSmallerMajorVersion(i56, i8013))
 	test.S(t).ExpectFalse(IsSmallerMajorVersion(i8013, i56))
+}
+
+func TestIsSmallerMinorVersion(t *testing.T) {
+	i55 := "5.5"
+	i5516 := "5.5.16"
+	i5517 := "5.5.17"
+	i56 := "5.6"
+	i8013 := "8.0.13"
+
+	test.S(t).ExpectTrue(IsSmallerMinorVersion(i55, i5517))
+	test.S(t).ExpectTrue(IsSmallerMinorVersion(i5516, i5517))
+	test.S(t).ExpectFalse(IsSmallerMinorVersion(i56, i5517))
+	test.S(t).ExpectTrue(IsSmallerMinorVersion(i55, i56))
+	test.S(t).ExpectTrue(IsSmallerMinorVersion(i56, i8013))
+	test.S(t).ExpectFalse(IsSmallerMinorVersion(i8013, i56))
 }


### PR DESCRIPTION
Solves https://github.com/github/gh-ost/issues/714

Possibly solves #687 

This PR utilizes `8.0.13` `RENAME TABLE` which supports renaming while holding `WRITE` lock on table. This allows us to use simpler cut-over logic.
