### PR TITLE
Dev-where branch : Add a feature to filter the data you need 

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -205,6 +205,8 @@ type MigrationContext struct {
 	ForceTmpTableName                string
 
 	recentBinlogCoordinates mysql.BinlogCoordinates
+
+	Where string
 }
 
 type ContextConfig struct {

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -207,6 +207,7 @@ type MigrationContext struct {
 	recentBinlogCoordinates mysql.BinlogCoordinates
 
 	Where string
+	ForceQueryMigrationRangeValuesOnMaster bool
 }
 
 type ContextConfig struct {

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -126,6 +126,7 @@ func main() {
 	flag.StringVar(&migrationContext.ForceTmpTableName, "force-table-names", "", "table name prefix to be used on the temporary tables")
 
 	flag.StringVar(&migrationContext.Where, "where-reserve", "", "used for only copy where stmt values")
+	flag.BoolVar(&migrationContext.ForceQueryMigrationRangeValuesOnMaster, "force-query-migration-range-values-on-master", false, "if you use where-reserve flag, by default, will query initial migration range values with corresponding where stmt on slave. Also you can specify this flag to true , it will query on master and not care where stmt like usual")
 
 	flag.CommandLine.SetOutput(os.Stdout)
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -125,7 +125,7 @@ func main() {
 	checkFlag := flag.Bool("check-flag", false, "Check if another flag exists/supported. This allows for cross-version scripting. Exits with 0 when all additional provided flags exist, nonzero otherwise. You must provide (dummy) values for flags that require a value. Example: gh-ost --check-flag --cut-over-lock-timeout-seconds --nice-ratio 0")
 	flag.StringVar(&migrationContext.ForceTmpTableName, "force-table-names", "", "table name prefix to be used on the temporary tables")
 
-	flag.StringVar(&migrationContext.Where, "where-reserve", "", "used for only copy where stmt values")
+	flag.StringVar(&migrationContext.Where, "where-reserve-clause", "", "used for only copy where clause stmt values")
 	flag.BoolVar(&migrationContext.ForceQueryMigrationRangeValuesOnMaster, "force-query-migration-range-values-on-master", false, "if you use where-reserve flag, by default, will query initial migration range values with corresponding where stmt on slave. Also you can specify this flag to true , it will query on master and not care where stmt like usual")
 
 	flag.CommandLine.SetOutput(os.Stdout)

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -124,6 +124,9 @@ func main() {
 	version := flag.Bool("version", false, "Print version & exit")
 	checkFlag := flag.Bool("check-flag", false, "Check if another flag exists/supported. This allows for cross-version scripting. Exits with 0 when all additional provided flags exist, nonzero otherwise. You must provide (dummy) values for flags that require a value. Example: gh-ost --check-flag --cut-over-lock-timeout-seconds --nice-ratio 0")
 	flag.StringVar(&migrationContext.ForceTmpTableName, "force-table-names", "", "table name prefix to be used on the temporary tables")
+
+	flag.StringVar(&migrationContext.Where, "where", "", "used for only copy where stmt values")
+
 	flag.CommandLine.SetOutput(os.Stdout)
 
 	flag.Parse()

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -126,7 +126,7 @@ func main() {
 	flag.StringVar(&migrationContext.ForceTmpTableName, "force-table-names", "", "table name prefix to be used on the temporary tables")
 
 	flag.StringVar(&migrationContext.Where, "where-reserve-clause", "", "used for only copy where clause stmt values")
-	flag.BoolVar(&migrationContext.ForceQueryMigrationRangeValuesOnMaster, "force-query-migration-range-values-on-master", false, "if you use where-reserve flag, by default, will query initial migration range values with corresponding where stmt on slave. Also you can specify this flag to true , it will query on master and not care where stmt like usual")
+	flag.BoolVar(&migrationContext.ForceQueryMigrationRangeValuesOnMaster, "force-query-migration-range-values-on-master", false, "if you use where-reserve-clause flag, by default, will query initial migration range values with corresponding where stmt on slave. Also you can specify this flag to true , it will query on master and not care where clause stmt like usual and the where clause would be used at copy rows to gho table")
 
 	flag.CommandLine.SetOutput(os.Stdout)
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
 	flag.StringVar(&migrationContext.OriginalTableName, "table", "", "table name (mandatory)")
-	flag.StringVar(&migrationContext.AlterStatement, "alter", "", "alter statement (mandatory)")
+	flag.StringVar(&migrationContext.AlterStatement, "alter", "", "alter statement (mandatory),you can specify Noop if don't change the table structure")
 	flag.BoolVar(&migrationContext.CountTableRows, "exact-rowcount", false, "actually count table rows as opposed to estimate them (results in more accurate progress estimation)")
 	flag.BoolVar(&migrationContext.ConcurrentCountTableRows, "concurrent-rowcount", true, "(with --exact-rowcount), when true (default): count rows after row-copy begins, concurrently, and adjust row estimate later on; when false: first count rows, then start row copy")
 	flag.BoolVar(&migrationContext.AllowedRunningOnMaster, "allow-on-master", false, "allow this migration to run directly on master. Preferably it would run on a replica")
@@ -125,7 +125,7 @@ func main() {
 	checkFlag := flag.Bool("check-flag", false, "Check if another flag exists/supported. This allows for cross-version scripting. Exits with 0 when all additional provided flags exist, nonzero otherwise. You must provide (dummy) values for flags that require a value. Example: gh-ost --check-flag --cut-over-lock-timeout-seconds --nice-ratio 0")
 	flag.StringVar(&migrationContext.ForceTmpTableName, "force-table-names", "", "table name prefix to be used on the temporary tables")
 
-	flag.StringVar(&migrationContext.Where, "where", "", "used for only copy where stmt values")
+	flag.StringVar(&migrationContext.Where, "where-reserve", "", "used for only copy where stmt values")
 
 	flag.CommandLine.SetOutput(os.Stdout)
 

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -357,7 +357,7 @@ func (this *Applier) ExecuteThrottleQuery() (int64, error) {
 // ReadMigrationMinValues returns the minimum values to be iterated on rowcopy
 func (this *Applier) ReadMigrationMinValues(uniqueKey *sql.UniqueKey) error {
 	log.Debugf("Reading migration range according to key: %s", uniqueKey.Name)
-	query, err := sql.BuildUniqueKeyMinValuesPreparedQuery(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, &uniqueKey.Columns)
+	query, err := sql.BuildUniqueKeyMinValuesPreparedQuery(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, this.migrationContext.Where, &uniqueKey.Columns)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (this *Applier) ReadMigrationMinValues(uniqueKey *sql.UniqueKey) error {
 // ReadMigrationMaxValues returns the maximum values to be iterated on rowcopy
 func (this *Applier) ReadMigrationMaxValues(uniqueKey *sql.UniqueKey) error {
 	log.Debugf("Reading migration range according to key: %s", uniqueKey.Name)
-	query, err := sql.BuildUniqueKeyMaxValuesPreparedQuery(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, &uniqueKey.Columns)
+	query, err := sql.BuildUniqueKeyMaxValuesPreparedQuery(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, this.migrationContext.Where, &uniqueKey.Columns)
 	if err != nil {
 		return err
 	}
@@ -424,6 +424,7 @@ func (this *Applier) CalculateNextIterationRangeEndValues() (hasFurtherRange boo
 		query, explodedArgs, err := buildFunc(
 			this.migrationContext.DatabaseName,
 			this.migrationContext.OriginalTableName,
+			this.migrationContext.Where,
 			&this.migrationContext.UniqueKey.Columns,
 			this.migrationContext.MigrationIterationRangeMinValues.AbstractValues(),
 			this.migrationContext.MigrationRangeMaxValues.AbstractValues(),
@@ -464,6 +465,7 @@ func (this *Applier) ApplyIterationInsertQuery() (chunkSize int64, rowsAffected 
 		this.migrationContext.DatabaseName,
 		this.migrationContext.OriginalTableName,
 		this.migrationContext.GetGhostTableName(),
+		this.migrationContext.Where,
 		this.migrationContext.SharedColumns.Names(),
 		this.migrationContext.MappedSharedColumns.Names(),
 		this.migrationContext.UniqueKey.Name,

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -19,6 +19,7 @@ import (
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/sqlutils"
 	"github.com/juju/errors"
+	"strings"
 )
 
 const (
@@ -202,6 +203,12 @@ func (this *Applier) AlterGhost() error {
 		sql.EscapeName(this.migrationContext.GetGhostTableName()),
 	)
 	log.Debugf("ALTER statement: %s", query)
+
+	if strings.ToLower(this.migrationContext.AlterStatement) == "noop"{
+		log.Infof("Noop,Just rebuild the table and not change the table structure")
+		return nil
+	}
+
 	if _, err := sqlutils.ExecNoPrepare(this.db, query); err != nil {
 		return err
 	}

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -776,6 +776,23 @@ func (this *Inspector) getReplicationLag() (replicationLag time.Duration, err er
 	return replicationLag, err
 }
 
+func (this *Inspector) SlaveCatchedUp(binfile string,binpos int) (bool,error){
+
+	var value gosql.NullInt64
+	log.Infof("validate whether catchup,select master_pos_wait(%s,%d,0.2)",binfile,binpos)
+	err := this.informationSchemaDb.QueryRow(`select MASTER_POS_WAIT(?,?,0.2)`,binfile,binpos).Scan(&value)
+	// fmt.Println(this.connectionConfig.Key.Hostname,value)
+	if err != nil {
+		return false,err
+	}
+
+	if ! value.Valid || value.Int64 == 0{
+		return true,nil
+	}
+
+	return false,nil
+}
+
 func (this *Inspector) Teardown() {
 	this.db.Close()
 	this.informationSchemaDb.Close()

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -500,7 +500,13 @@ func (this *Inspector) validateTableTriggers() error {
 
 // estimateTableRowsViaExplain estimates number of rows on original table
 func (this *Inspector) estimateTableRowsViaExplain() error {
-	query := fmt.Sprintf(`explain select /* gh-ost */ * from %s.%s where 1=1`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
+
+	whereStmt := ""
+	if this.migrationContext.Where != ""{
+		whereStmt = fmt.Sprintf(`and %s`,this.migrationContext.Where)
+	}
+
+	query := fmt.Sprintf(`explain select /* gh-ost */ * from %s.%s where 1=1 %s`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName),whereStmt)
 
 	outputFound := false
 	err := sqlutils.QueryRowsMap(this.db, query, func(rowMap sqlutils.RowMap) error {
@@ -527,7 +533,12 @@ func (this *Inspector) CountTableRows() error {
 
 	log.Infof("As instructed, I'm issuing a SELECT COUNT(*) on the table. This may take a while")
 
-	query := fmt.Sprintf(`select /* gh-ost */ count(*) as rows from %s.%s`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
+	whereStmt := ""
+	if this.migrationContext.Where != ""{
+		whereStmt = fmt.Sprintf(`where %s`,this.migrationContext.Where)
+	}
+
+	query := fmt.Sprintf(`select /* gh-ost */ count(*) as rows from %s.%s %s`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName),whereStmt)
 	var rowsEstimate int64
 	if err := this.db.QueryRow(query).Scan(&rowsEstimate); err != nil {
 		return err

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1046,7 +1046,7 @@ func (this *Migrator) initiateThrottler() error {
 }
 
 func (this *Migrator) initiateApplier() error {
-	this.applier = NewApplier(this.migrationContext)
+	this.applier = NewApplier(this.migrationContext,this.inspector)
 	if err := this.applier.InitDBConnections(); err != nil {
 		return err
 	}

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -75,6 +75,17 @@ func GetReplicationLag(informationSchemaDb *gosql.DB, connectionConfig *Connecti
 	return replicationLag, err
 }
 
+
+func GetMasterStatus(informationSchemaDb *gosql.DB) (binfile string,binpos int ,err error){
+	err = sqlutils.QueryRowsMap(informationSchemaDb,`show master status`,func(m sqlutils.RowMap) error {
+		binfile = m.GetString("File")
+		binpos = m.GetInt("Position")
+		return nil
+	})
+
+	return binfile,binpos,err
+}
+
 func GetMasterKeyFromSlaveStatus(connectionConfig *ConnectionConfig) (masterKey *InstanceKey, err error) {
 	currentUri := connectionConfig.GetDBUri("information_schema")
 	// This function is only called once, okay to not have a cached connection pool


### PR DESCRIPTION
The main usage scenarios are as follows:

1. If you need to clean up some of the data before you doing the gh-ost release, it can release with `-where-reserve-clause` directly and you don't need to do a clean up first. 

2. If you just wanna clear a lot of data, especially for the amount of cleaning is greater than the amount of retention, it can avoid `DELETE + OPTIMIZE` operation.

add 2 flags:

- `where-reserve-clause:` used for only copy where clause stmt values
- `force-query-migration-range-values-on-master:` if you use where-reserve-clause flag, by default, will query initial migration range values with corresponding where clause stmt on slave. Also you can specify this flag to true , it will query on master and not care where clause stmt like usual and the where clause stmt would be used at copy rows to gho table.

modify 1 flag 
-`alter:` you can specify Noop if you just wanna do a table slimming and not change the table structure



