### PR TITLE
Clarify it's foreign key /constraints/ that don't work

### DIFF
--- a/doc/requirements-and-limitations.md
+++ b/doc/requirements-and-limitations.md
@@ -22,7 +22,7 @@ The `SUPER` privilege is required for `STOP SLAVE`, `START SLAVE` operations. Th
 
 ### Limitations
 
-- Foreign keys not supported. They may be supported in the future, to some extent.
+- Foreign key constraints are not supported. They may be supported in the future, to some extent.
 
 - Triggers are not supported. They may be supported in the future.
 


### PR DESCRIPTION
This section of the documentation is a little confusing: it makes it sound like you can't use foreign keys with gh-ost when joins across foreign key relationships still work fine, it's just foreign key constraints which aren't available.