### PR TITLE
Fix a trivial it's/its typo.

### DIFF
--- a/doc/requirements-and-limitations.md
+++ b/doc/requirements-and-limitations.md
@@ -38,7 +38,7 @@ The `SUPER` privilege is required for `STOP SLAVE`, `START SLAVE` operations. Th
 - It is not allowed to migrate a table where another table exists with same name and different upper/lower case.
   - For example, you may not migrate `MyTable` if another table called `MYtable` exists in the same schema.
 
-- Amazon RDS works, but has it's own [limitations](rds.md).
+- Amazon RDS works, but has its own [limitations](rds.md).
 - Google Cloud SQL works, `--gcp` flag required.
 - Aliyun RDS works, `--aliyun-rds` flag required.
 


### PR DESCRIPTION
This PR fixes a trivial typo in `doc/requirements-and-limitations.md` where "it's" (a contraction for "it is") was being used in place of "its" (the possessive).