### PR TITLE
Bump default-retries to 3

### DIFF
--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -152,7 +152,7 @@ test_single() {
     --serve-socket-file=/tmp/gh-ost.test.sock \
     --initially-drop-socket-file \
     --test-on-replica \
-    --default-retries=1 \
+    --default-retries=3 \
     --chunk-size=10 \
     --verbose \
     --debug \


### PR DESCRIPTION
fixes https://github.com/github/gh-ost/issues/753

There are some legitimate retries that can occur during testing. Namely
`logic.ExpectProcess()` (in `applier.go`). We'll look for a process that
does exist, but timing-wise doesn't have the `state` or `info` columns
populated.

Without this, the test will fail abruptly.
