### PR TITLE
Panic on missing _ghc and _gho tables

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -736,3 +736,20 @@ func (this *MigrationContext) ReadConfigFile() error {
 
 	return nil
 }
+
+func (this *MigrationContext) PanicAbortIfTableError(err error) {
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), mysql.Error1146TableDoesntExist) || strings.Contains(err.Error(), mysql.Error1017CantFindFile) {
+		this.PanicAbortOnError(err)
+	}
+	// otherwise irrelevant error and we do not panic
+}
+
+func (this *MigrationContext) PanicAbortOnError(err error) {
+	if err == nil {
+		return
+	}
+	this.PanicAbort <- err
+}

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -916,6 +916,8 @@ func (this *Applier) AtomicCutoverRename(sessionIdChan chan int64, tablesRenamed
 	)
 	log.Infof("Issuing and expecting this to block: %s", query)
 	if _, err := tx.Exec(query); err != nil {
+		this.migrationContext.PanicAbortIfTableError(err)
+
 		tablesRenamed <- err
 		return log.Errore(err)
 	}

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -290,6 +290,7 @@ func (this *Applier) WriteChangelog(hint, value string) (string, error) {
 		sql.EscapeName(this.migrationContext.GetChangelogTableName()),
 	)
 	_, err := sqlutils.ExecNoPrepare(this.db, query, explicitId, hint, value)
+	this.migrationContext.PanicAbortIfTableError(err)
 	return hint, err
 }
 

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -342,7 +342,7 @@ help                                 # This message
 				return NoPrintStatusRule, err
 			}
 			err := fmt.Errorf("User commanded 'panic'. I will now panic, without cleanup. PANIC!")
-			this.migrationContext.PanicAbort <- err
+			this.migrationContext.PanicAbortOnError(err)
 			return NoPrintStatusRule, err
 		}
 	default:

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/outbrain/golib/sqlutils"
 )
 
+const (
+	Error1017CantFindFile     = "Error 1017:"
+	Error1146TableDoesntExist = "Error 1146:"
+)
+
 const MaxTableNameLength = 64
 const MaxReplicationPasswordLength = 32
 

--- a/localtests/fail-drop-ghc-table-no-read/create.sql
+++ b/localtests/fail-drop-ghc-table-no-read/create.sql
@@ -1,0 +1,23 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  color varchar(32),
+  primary key(id)
+) auto_increment=1;
+
+insert into gh_ost_test values (null, 1, 'red');
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp + interval 3 second
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, 1, 'blue');
+  drop table if exists _gh_ost_test_ghc;
+end ;;

--- a/localtests/fail-drop-ghc-table-no-read/expect_failure
+++ b/localtests/fail-drop-ghc-table-no-read/expect_failure
@@ -1,0 +1,1 @@
+Error 1146: Table 'test._gh_ost_test_ghc' doesn't exist

--- a/localtests/fail-drop-ghc-table-no-read/extra_args
+++ b/localtests/fail-drop-ghc-table-no-read/extra_args
@@ -1,0 +1,1 @@
+--throttle-query='select sleep(1)'

--- a/localtests/fail-drop-ghc-table/create.sql
+++ b/localtests/fail-drop-ghc-table/create.sql
@@ -1,0 +1,23 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  color varchar(32),
+  primary key(id)
+) auto_increment=1;
+
+insert into gh_ost_test values (null, 1, 'red');
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp + interval 3 second
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, 1, 'blue');
+  drop table if exists _gh_ost_test_ghc;
+end ;;

--- a/localtests/fail-drop-ghc-table/expect_failure
+++ b/localtests/fail-drop-ghc-table/expect_failure
@@ -1,0 +1,1 @@
+Error 1146: Table 'test._gh_ost_test_ghc' doesn't exist

--- a/localtests/fail-drop-gho-table-no-data/create.sql
+++ b/localtests/fail-drop-gho-table-no-data/create.sql
@@ -1,0 +1,22 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  color varchar(32),
+  primary key(id)
+) auto_increment=1;
+
+insert into gh_ost_test values (null, 1, 'blue');
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  drop table if exists _gh_ost_test_gho;
+end ;;

--- a/localtests/fail-drop-gho-table-no-data/expect_failure
+++ b/localtests/fail-drop-gho-table-no-data/expect_failure
@@ -1,0 +1,1 @@
+Error 1146: Table 'test._gh_ost_test_gho' doesn't exist

--- a/localtests/fail-drop-gho-table-no-data/extra_args
+++ b/localtests/fail-drop-gho-table-no-data/extra_args
@@ -1,0 +1,1 @@
+--throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from _gh_ost_test_ghc'

--- a/localtests/fail-drop-gho-table/create.sql
+++ b/localtests/fail-drop-gho-table/create.sql
@@ -1,0 +1,22 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  color varchar(32),
+  primary key(id)
+) auto_increment=1;
+
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, 1, 'blue');
+  drop table if exists _gh_ost_test_gho;
+end ;;

--- a/localtests/fail-drop-gho-table/expect_failure
+++ b/localtests/fail-drop-gho-table/expect_failure
@@ -1,0 +1,1 @@
+Error 1146: Table 'test._gh_ost_test_gho' doesn't exist


### PR DESCRIPTION
Fixes https://github.com/github/gh-ost/issues/763

In case of accidental removal of `_gho` table while migration was running, `gh-ost` was correctly bailing out on failing to apply rows to the `_gho` table, but did not panic during cut-over phase.

With this PR:

- `gh-ost` correctly panics at cut-over phase
- Also, `gh-ost` now correctly panics when the `_ghc` table is accidentally removed throughout the migration.

cc @tomkrouper @ggunson 