### PR TITLE
Changing the panic message

### DIFF
--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -341,7 +341,7 @@ help                                 # This message
 				err := fmt.Errorf("User commanded 'panic' on %s, but migrated table is %s; ignoring request.", arg, this.migrationContext.OriginalTableName)
 				return NoPrintStatusRule, err
 			}
-			err := fmt.Errorf("User commanded 'panic'. I will now panic, without cleanup. PANIC!")
+			err := fmt.Errorf("User commanded 'panic'. The migration will be aborted without cleanup. Please drop the gh-ost tables before trying again.")
 			this.migrationContext.PanicAbort <- err
 			return NoPrintStatusRule, err
 		}


### PR DESCRIPTION
This PR isn't associated with an issue. 

### Description

This PR changes the output message when the user executes the `panic` command.

The current message goes:

> User commanded 'panic'. I will now panic, without cleanup. PANIC!

This message:
- says "panic" 3 times
- doesn't explain what "panic" means
- doesn't say what "cleanup" is
- ascribes emotions to software

My suggestion is:

> User commanded 'panic'. The migration will be aborted without cleanup. Please drop the gh-ost tables before trying again.

- says "panic" once
- says what it will do
- says generally what to do for "cleanup" (I don't know if it's worth outputting the gh-ost table names here, if that's known; that could also be good)

If there's a better suggestion I'd be here for it, I just want something more informative and actionable. 

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.