### PR TITLE
inspector uptime check: validate inspector has not restarted

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -179,6 +179,7 @@ type MigrationContext struct {
 	TotalRowsCopied                        int64
 	TotalDMLEventsApplied                  int64
 	DMLBatchSize                           int64
+	InspectorUptimeSeconds                 int64
 	isThrottled                            bool
 	throttleReason                         string
 	throttleReasonHint                     ThrottleReasonHint

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -752,6 +752,13 @@ func (this *Inspector) readChangelogState(hint string) (string, error) {
 	return result, err
 }
 
+// readUptime reads MySQL server uptime (in seconds)
+func (this *Inspector) readUptime() (uptime int64, err error) {
+	var dummy string
+	err = this.db.QueryRow("show global status like 'Uptime'").Scan(&dummy, &uptime)
+	return uptime, err
+}
+
 func (this *Inspector) getMasterConnectionConfig() (applierConfig *mysql.ConnectionConfig, err error) {
 	log.Infof("Recursively searching for replication master")
 	visitedKeys := mysql.NewInstanceKeyMap()

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -342,6 +342,7 @@ func (this *Migrator) Migrate() (err error) {
 	if err := this.initiateInspector(); err != nil {
 		return err
 	}
+	go this.initiateInspectorHealthCheck()
 	if err := this.initiateStreaming(); err != nil {
 		return err
 	}
@@ -709,6 +710,21 @@ func (this *Migrator) initiateServer() (err error) {
 
 	go this.server.Serve()
 	return nil
+}
+
+func (this *Migrator) initiateInspectorHealthCheck() {
+	ticker := time.Tick(10 * time.Second)
+	for range ticker {
+		lastUptime := atomic.LoadInt64(&this.migrationContext.InspectorUptimeSeconds)
+		if uptime, err := this.inspector.readUptime(); err != nil {
+			log.Errore(err)
+		} else {
+			if uptime < lastUptime {
+				this.migrationContext.PanicAbort <- fmt.Errorf("Inspector Uptime is %+v, less than previously measured uptime %+v. Has the inspector been restarted? Bailing out.", uptime, lastUptime)
+			}
+			atomic.StoreInt64(&this.migrationContext.InspectorUptimeSeconds, uptime)
+		}
+	}
 }
 
 // initiateInspector connects, validates and inspects the "inspector" server.


### PR DESCRIPTION
Closes https://github.com/github/gh-ost/issues/785

A relaxed (10sec interval) monitoring of the inspector's `Uptime` global status value; this value should be ever increasing; if found to be smaller than previous read, this suggests the inspector has been restarted in the duration of the migration. `gh-ost` will abort with error in such case.