### PR TITLE
Adds error checking for an err variable that was left unchecked

### DIFF
--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -492,6 +492,9 @@ func BuildDMLUpdateQuery(databaseName, tableName string, tableColumns, sharedCol
 	}
 
 	setClause, err := BuildSetPreparedClause(mappedSharedColumns)
+	if err != nil {
+		return "", sharedArgs, uniqueKeyArgs, err
+	}
 
 	equalsComparison, err := BuildEqualsPreparedComparison(uniqueKeyColumns.Names())
 	result = fmt.Sprintf(`


### PR DESCRIPTION
This PR is not related to an issue, but is adding an error check where an err variable was set but not checked. This could potentially help find errors when developing in the future.

### Description

This PR adds an error checks for an err variable which was assigned but never checked.

> In case this PR introduced Go code changes:

- [X] contributed code is using same conventions as original code
- [X] `script/cibuild` returns with no formatting errors, build errors or unit test errors.

This issues was found using CodeLingo - [codelingo.io](url)