### PR TITLE
Adding script/dock: simplifying testing/packaging

### DIFF
--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -1,18 +1,4 @@
-# Requires Docker 17.09 or later (multi stage builds)
 #
-# Orchestrator will look for a configuration file at /etc/orchestrator.conf.json.
-# It will listen on port 3000.
-# If not present a minimal configuration will be generated using the following environment variables:
-#
-# Default variables which can be used are:
-#
-# ORC_TOPOLOGY_USER (default: orchestrator): username used by orchestrator to login to MySQL when polling/discovering
-# ORC_TOPOLOGY_PASSWORD (default: orchestrator):  password needed to login to MySQL when polling/discovering
-# ORC_DB_HOST (default: orchestrator):  orchestrator backend MySQL host
-# ORC_DB_PORT (default: 3306):  port used by orchestrator backend MySQL server
-# ORC_DB_NAME (default: orchestrator): database named used by orchestrator backend MySQL server
-# ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
-# ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
 FROM golang:1.12.6
 

--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -1,0 +1,36 @@
+# Requires Docker 17.09 or later (multi stage builds)
+#
+# Orchestrator will look for a configuration file at /etc/orchestrator.conf.json.
+# It will listen on port 3000.
+# If not present a minimal configuration will be generated using the following environment variables:
+#
+# Default variables which can be used are:
+#
+# ORC_TOPOLOGY_USER (default: orchestrator): username used by orchestrator to login to MySQL when polling/discovering
+# ORC_TOPOLOGY_PASSWORD (default: orchestrator):  password needed to login to MySQL when polling/discovering
+# ORC_DB_HOST (default: orchestrator):  orchestrator backend MySQL host
+# ORC_DB_PORT (default: 3306):  port used by orchestrator backend MySQL server
+# ORC_DB_NAME (default: orchestrator): database named used by orchestrator backend MySQL server
+# ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
+# ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
+
+FROM golang:1.12.6
+
+RUN apt-get update
+RUN apt-get install -y ruby ruby-dev rubygems build-essential
+RUN gem install --no-ri --no-rdoc fpm
+ENV GOPATH=/tmp/go
+
+RUN apt-get install -y curl
+RUN apt-get install -y rsync
+RUN apt-get install -y gcc
+RUN apt-get install -y g++
+RUN apt-get install -y bash
+RUN apt-get install -y git
+RUN apt-get install -y tar
+RUN apt-get install -y rpm
+
+RUN mkdir -p $GOPATH/src/github.com/github/gh-ost
+WORKDIR $GOPATH/src/github.com/github/gh-ost
+COPY . .
+RUN bash build.sh

--- a/build.sh
+++ b/build.sh
@@ -61,11 +61,11 @@ main() {
 
   mkdir -p ${buildpath}
   rm -rf ${buildpath:?}/*
-  build macOS osx darwin amd64
   build GNU/Linux linux linux amd64
+  # build macOS osx darwin amd64
 
   echo "Binaries found in:"
-  ls -1 $buildpath/gh-ost-binary*${timestamp}.tar.gz
+  find $buildpath/gh-ost* -type f -maxdepth 1
 }
 
 main "$@"

--- a/script/dock
+++ b/script/dock
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Usage:
+# dock <test|alpine|packages> [arg]
+#   dock test:                build gh-ost & run unit and integration tests
+#   docker alpine:            build and run gh-ost on alpine linux
+#   docker pkg [target-path]: build gh-ost release packages and copy to target path (default path: /tmp/gh-ost-release)
+
+command="$1"
+
+case "$command" in
+  "test")
+    docker_target="gh-ost-test"
+    docker build . -f Dockerfile.test -t "${docker_target}" && docker run --rm -it "${docker_target}:latest"
+    ;;
+  "alpine")
+    docker_target="gh-ost-alpine"
+    docker build . -f Dockerfile -t "${docker_target}" && docker run --rm -it -p 3000:3000 "${docker_target}:latest"
+    ;;
+  "pkg")
+    packages_path="${2:-/tmp/gh-ost-release}"
+    docker_target="gh-ost-packaging"
+    docker build . -f Dockerfile.packaging -t "${docker_target}" && docker run --rm -it -v "${packages_path}:/tmp/pkg" "${docker_target}:latest" bash -c 'find /tmp/gh-ost-release/ -maxdepth 1 -type f | xargs cp -t /tmp/pkg'
+    echo "packages generated on ${packages_path}:"
+    ls -l "${packages_path}"
+    ;;
+  *)
+    >&2 echo "Usage: dock dock <test|alpine|packages> [arg]"
+    exit 1
+esac

--- a/script/dock
+++ b/script/dock
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 # Usage:
-# dock <test|alpine|packages> [arg]
+# dock <test|packages> [arg]
 #   dock test:                build gh-ost & run unit and integration tests
-#   docker alpine:            build and run gh-ost on alpine linux
 #   docker pkg [target-path]: build gh-ost release packages and copy to target path (default path: /tmp/gh-ost-release)
 
 command="$1"
@@ -12,10 +11,6 @@ case "$command" in
   "test")
     docker_target="gh-ost-test"
     docker build . -f Dockerfile.test -t "${docker_target}" && docker run --rm -it "${docker_target}:latest"
-    ;;
-  "alpine")
-    docker_target="gh-ost-alpine"
-    docker build . -f Dockerfile -t "${docker_target}" && docker run --rm -it -p 3000:3000 "${docker_target}:latest"
     ;;
   "pkg")
     packages_path="${2:-/tmp/gh-ost-release}"


### PR DESCRIPTION
`script/dock` is a shell script that wraps docker builds/runs:
```
# Usage:
# dock <test|packages> [arg]
#   dock test:                build gh-ost & run unit and integration tests
#   docker pkg [target-path]: build gh-ost release packages and copy to target path (default path: /tmp/gh-ost-release)
```

e.g. to build `gh-ost` packages for Linux you will:

```
script/dock pkg /tmp/gh-ost-release
```


