### PR TITLE
Throttle on HTTP throttle error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin/
 /libexec/
 /.vendor/
+.idea/

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -119,7 +119,7 @@ type MigrationContext struct {
 	ThrottleAdditionalFlagFile          string
 	throttleQuery                       string
 	throttleHTTP                        string
-	ignoreHTTPErrors					bool
+	ignoreHTTPErrors                    bool
 	ThrottleCommandedByUser             int64
 	HibernateUntil                      int64
 	maxLoad                             LoadMap

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -119,6 +119,7 @@ type MigrationContext struct {
 	ThrottleAdditionalFlagFile          string
 	throttleQuery                       string
 	throttleHTTP                        string
+	ignoreHTTPErrors					bool
 	ThrottleCommandedByUser             int64
 	HibernateUntil                      int64
 	maxLoad                             LoadMap
@@ -572,6 +573,13 @@ func (this *MigrationContext) SetThrottleHTTP(throttleHTTP string) {
 	defer this.throttleHTTPMutex.Unlock()
 
 	this.throttleHTTP = throttleHTTP
+}
+
+func (this *MigrationContext) SetIgnoreHTTPErrors(ignoreHTTPErrors bool) {
+	this.throttleHTTPMutex.Lock()
+	defer this.throttleHTTPMutex.Unlock()
+
+	this.ignoreHTTPErrors = ignoreHTTPErrors
 }
 
 func (this *MigrationContext) GetMaxLoad() LoadMap {

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -119,7 +119,7 @@ type MigrationContext struct {
 	ThrottleAdditionalFlagFile          string
 	throttleQuery                       string
 	throttleHTTP                        string
-	ignoreHTTPErrors                    bool
+	IgnoreHTTPErrors                    bool
 	ThrottleCommandedByUser             int64
 	HibernateUntil                      int64
 	maxLoad                             LoadMap
@@ -579,7 +579,7 @@ func (this *MigrationContext) SetIgnoreHTTPErrors(ignoreHTTPErrors bool) {
 	this.throttleHTTPMutex.Lock()
 	defer this.throttleHTTPMutex.Unlock()
 
-	this.ignoreHTTPErrors = ignoreHTTPErrors
+	this.IgnoreHTTPErrors = ignoreHTTPErrors
 }
 
 func (this *MigrationContext) GetMaxLoad() LoadMap {

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -106,6 +106,7 @@ func main() {
 	throttleControlReplicas := flag.String("throttle-control-replicas", "", "List of replicas on which to check for lag; comma delimited. Example: myhost1.com:3306,myhost2.com,myhost3.com:3307")
 	throttleQuery := flag.String("throttle-query", "", "when given, issued (every second) to check if operation should throttle. Expecting to return zero for no-throttle, >0 for throttle. Query is issued on the migrated server. Make sure this query is lightweight")
 	throttleHTTP := flag.String("throttle-http", "", "when given, gh-ost checks given URL via HEAD request; any response code other than 200 (OK) causes throttling; make sure it has low latency response")
+	ignoreHTTPErrors := flag.Bool("ignore-http-error", false, "ignore HTTP connection errors during throttle check")
 	heartbeatIntervalMillis := flag.Int64("heartbeat-interval-millis", 100, "how frequently would gh-ost inject a heartbeat value")
 	flag.StringVar(&migrationContext.ThrottleFlagFile, "throttle-flag-file", "", "operation pauses when this file exists; hint: use a file that is specific to the table being altered")
 	flag.StringVar(&migrationContext.ThrottleAdditionalFlagFile, "throttle-additional-flag-file", "/tmp/gh-ost.throttle", "operation pauses when this file exists; hint: keep default, use for throttling multiple gh-ost operations")
@@ -259,6 +260,7 @@ func main() {
 	migrationContext.SetMaxLagMillisecondsThrottleThreshold(*maxLagMillis)
 	migrationContext.SetThrottleQuery(*throttleQuery)
 	migrationContext.SetThrottleHTTP(*throttleHTTP)
+	migrationContext.SetIgnoreHTTPErrors(*ignoreHTTPErrors)
 	migrationContext.SetDefaultNumRetries(*defaultRetries)
 	migrationContext.ApplyCredentials()
 	if err := migrationContext.SetupTLS(); err != nil {

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -106,7 +106,7 @@ func main() {
 	throttleControlReplicas := flag.String("throttle-control-replicas", "", "List of replicas on which to check for lag; comma delimited. Example: myhost1.com:3306,myhost2.com,myhost3.com:3307")
 	throttleQuery := flag.String("throttle-query", "", "when given, issued (every second) to check if operation should throttle. Expecting to return zero for no-throttle, >0 for throttle. Query is issued on the migrated server. Make sure this query is lightweight")
 	throttleHTTP := flag.String("throttle-http", "", "when given, gh-ost checks given URL via HEAD request; any response code other than 200 (OK) causes throttling; make sure it has low latency response")
-	ignoreHTTPErrors := flag.Bool("ignore-http-error", false, "ignore HTTP connection errors during throttle check")
+	ignoreHTTPErrors := flag.Bool("ignore-http-errors", false, "ignore HTTP connection errors during throttle check")
 	heartbeatIntervalMillis := flag.Int64("heartbeat-interval-millis", 100, "how frequently would gh-ost inject a heartbeat value")
 	flag.StringVar(&migrationContext.ThrottleFlagFile, "throttle-flag-file", "", "operation pauses when this file exists; hint: use a file that is specific to the table being altered")
 	flag.StringVar(&migrationContext.ThrottleAdditionalFlagFile, "throttle-additional-flag-file", "/tmp/gh-ost.throttle", "operation pauses when this file exists; hint: keep default, use for throttling multiple gh-ost operations")

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -104,7 +104,7 @@ func (this *Throttler) shouldThrottle() (result bool, reason string, reasonHint 
 		}
 	}
 	// Got here? No metrics indicates we need throttling.
-	return false, "", base.NoThrottleReasonHint
+	return true, "", base.NoThrottleReasonHint
 }
 
 // parseChangelogHeartbeat parses a string timestamp and deduces replication lag

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -291,8 +291,10 @@ func (this *Throttler) collectThrottleHTTPStatus(firstThrottlingCollected chan<-
 
 	_, err := collectFunc()
 	if err != nil {
-		// If an error occurs during the HTTP throttle check, let's throttle to be safe
-		atomic.StoreInt64(&this.migrationContext.ThrottleHTTPStatusCode, int64(-1))
+		// If not told to ignore errors, we'll throttle on HTTP connection issues
+		if !this.migrationContext.IgnoreHTTPErrors {
+			atomic.StoreInt64(&this.migrationContext.ThrottleHTTPStatusCode, int64(-1))
+		}
 	}
 
 	firstThrottlingCollected <- true

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -25,7 +25,7 @@ var (
 		417: "Expectation failed",
 		429: "Too many requests",
 		500: "Internal server error",
-		 -1: "Connection error",
+		-1:  "Connection error",
 	}
 	// See https://github.com/github/freno/blob/master/doc/http.md
 	httpStatusFrenoMessages = map[int]string{
@@ -295,7 +295,6 @@ func (this *Throttler) collectThrottleHTTPStatus(firstThrottlingCollected chan<-
 	if err != nil {
 		// If not told to ignore errors, we'll throttle on HTTP connection issues
 		if !this.migrationContext.IgnoreHTTPErrors {
-			log.Errorf("errors occurred during HTTP throttle check: %+v", err)
 			atomic.StoreInt64(&this.migrationContext.ThrottleHTTPStatusCode, int64(-1))
 		}
 	}
@@ -312,7 +311,6 @@ func (this *Throttler) collectThrottleHTTPStatus(firstThrottlingCollected chan<-
 		if err != nil {
 			// If not told to ignore errors, we'll throttle on HTTP connection issues
 			if !this.migrationContext.IgnoreHTTPErrors {
-				log.Errorf("errors occurred during HTTP throttle check: %+v", err)
 				atomic.StoreInt64(&this.migrationContext.ThrottleHTTPStatusCode, int64(-1))
 			}
 		}

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -293,6 +293,7 @@ func (this *Throttler) collectThrottleHTTPStatus(firstThrottlingCollected chan<-
 	if err != nil {
 		// If not told to ignore errors, we'll throttle on HTTP connection issues
 		if !this.migrationContext.IgnoreHTTPErrors {
+			log.Errorf("errors occurred during HTTP throttle check: %+v", err)
 			atomic.StoreInt64(&this.migrationContext.ThrottleHTTPStatusCode, int64(-1))
 		}
 	}

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -291,6 +291,7 @@ func (this *Throttler) collectThrottleHTTPStatus(firstThrottlingCollected chan<-
 
 	_, err := collectFunc()
 	if err != nil {
+		// If an error occurs during the HTTP throttle check, let's throttle to be safe
 		atomic.StoreInt64(&this.migrationContext.ThrottleHTTPStatusCode, int64(-1))
 	}
 

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -19,20 +19,22 @@ import (
 )
 
 var (
-	httpStatusMessages map[int]string = map[int]string{
+	httpStatusMessages = map[int]string{
 		200: "OK",
 		404: "Not found",
 		417: "Expectation failed",
 		429: "Too many requests",
 		500: "Internal server error",
+		 -1: "Connection error",
 	}
 	// See https://github.com/github/freno/blob/master/doc/http.md
-	httpStatusFrenoMessages map[int]string = map[int]string{
+	httpStatusFrenoMessages = map[int]string{
 		200: "OK",
 		404: "freno: unknown metric",
 		417: "freno: access forbidden",
 		429: "freno: threshold exceeded",
 		500: "freno: internal error",
+		-1:  "freno: connection error",
 	}
 )
 


### PR DESCRIPTION
Related issue: #832 

### Description

This PR changes the default throttling behavior when using an HTTP throttler (such as https://github.com/github/freno) that is unresponsive, or returns unexpected/missing data.  This change throttles gh-ost during these failure scenarios.  Because this changes the existing behavior, a `--ignore-http-errors` flag was added to allow the migration to continue if the HTTP throttler goes offline.


- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
