### PR TITLE
Hidden password from /proc/{pid}/cmdline or ps command output

### DIFF
--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -110,9 +110,18 @@ func HiddenPasswordFromCmdline() {
 	argsLength := len(os.Args)
 	for i, arg := range os.Args {
 		switch arg {
+		// -password aaa, --password aaa
 		case "--password", "-password", "-master-password", "--master-password":
 			if i+1 < argsLength {
 				os.Args[i+1] = "xxx"
+			}
+		default:
+			// -password=aaa, --password=aaa
+			switch strings.Split(arg, "=")[0] {
+			case "--password", "-password":
+				arg = "-password=xxx"
+			case "-master-password", "--master-password":
+				arg = "-master-password=xxx"
 			}
 		}
 		cmdline = append(cmdline, arg)

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -134,6 +134,7 @@ func main() {
 	flag.CommandLine.SetOutput(os.Stdout)
 
 	flag.Parse()
+	base.HiddenPasswordFromCmdline()
 
 	if *checkFlag {
 		return

--- a/vendor/github.com/ErikDubbelboer/gspt/.travis.yml
+++ b/vendor/github.com/ErikDubbelboer/gspt/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+  - 1.1
+  - tip

--- a/vendor/github.com/ErikDubbelboer/gspt/LICENSE
+++ b/vendor/github.com/ErikDubbelboer/gspt/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Erik Dubbelboer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/ErikDubbelboer/gspt/README.md
+++ b/vendor/github.com/ErikDubbelboer/gspt/README.md
@@ -1,0 +1,28 @@
+gspt
+====
+
+`setproctitle()` package for Go.
+
+[![Build Status](https://travis-ci.org/erikdubbelboer/gspt.png?branch=master)](https://travis-ci.org/erikdubbelboer/gspt)
+
+--------------------------------
+
+Installation
+------------
+
+Simple install the package to your [$GOPATH](https://github.com/golang/go/wiki/GOPATH) with the [go tool](http://golang.org/cmd/go/):
+```bash
+go get github.com/erikdubbelboer/gspt
+```
+Make sure [Git is installed](http://git-scm.com/downloads) on your machine and in your system's `PATH`.
+
+Usage
+-----
+
+```go
+import "github.com/erikdubbelboer/gspt"
+
+gspt.SetProcTitle("some title")
+```
+
+Please check the [documentation](http://godoc.org/github.com/erikdubbelboer/gspt) for more details.

--- a/vendor/github.com/ErikDubbelboer/gspt/example/example.go
+++ b/vendor/github.com/ErikDubbelboer/gspt/example/example.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"os"
+	"os/exec"
+
+	"github.com/erikdubbelboer/gspt"
+)
+
+func main() {
+	fmt.Println("HaveSetProcTitle:", gspt.HaveSetProcTitle)
+	fmt.Println("HaveSetProcTitleFast:", gspt.HaveSetProcTitleFast)
+
+	gspt.SetProcTitle("some title")
+
+	fmt.Println("The title has been set, 'ps a' now shows:")
+
+	out, err := exec.Command("ps", "aux").Output()
+	if err != nil {
+		// Could not execute 'ps'.
+		return
+	}
+	lines := strings.Split(string(out), "\n")
+	fmt.Println(lines[0])
+	for _, line := range lines {
+		if strings.Contains(line, "some title") {
+			fmt.Println(line)
+		}
+	}
+
+	fmt.Println("----")
+	fmt.Println("os.Environ() should still contain things like:")
+	fmt.Println("PATH =", os.Getenv("PATH"))
+
+	fmt.Println("----")
+	fmt.Println("os.Args should still be correct:")
+
+	for i, a := range os.Args {
+		fmt.Println(i, ":", a)
+	}
+
+	fmt.Println("----")
+	fmt.Println("You can now check the output of 'ps a' or 'top'.")
+	fmt.Println("Press Ctrl+C to kill this program.")
+
+	time.Sleep(time.Minute * 5)
+}

--- a/vendor/github.com/ErikDubbelboer/gspt/gspt.go
+++ b/vendor/github.com/ErikDubbelboer/gspt/gspt.go
@@ -1,0 +1,71 @@
+package gspt
+
+/*
+
+#include "setproctitle.h"
+
+*/
+import "C"
+
+import (
+	"os"
+	"strings"
+	"unsafe"
+)
+
+const (
+	// These values must match the return values for spt_init1() used in C.
+	HaveNone        = 0
+	HaveNative      = 1
+	HaveReplacement = 2
+)
+
+var (
+	HaveSetProcTitle     int
+	HaveSetProcTitleFast int
+)
+
+func init() {
+	HaveSetProcTitle = int(C.spt_init1())
+	HaveSetProcTitleFast = int(C.spt_fast_init1())
+
+	if HaveSetProcTitle == HaveReplacement {
+		newArgs := make([]string, len(os.Args))
+		for i, s := range os.Args {
+			// Use cgo to force go to make copies of the strings.
+			cs := C.CString(s)
+			newArgs[i] = C.GoString(cs)
+			C.free(unsafe.Pointer(cs))
+		}
+		os.Args = newArgs
+
+		env := os.Environ()
+		for _, kv := range env {
+			skv := strings.SplitN(kv, "=", 2)
+			os.Setenv(skv[0], skv[1])
+		}
+
+		argc := C.int(len(os.Args))
+		arg0 := C.CString(os.Args[0])
+		defer C.free(unsafe.Pointer(arg0))
+
+		C.spt_init2(argc, arg0)
+
+		// Restore the original title.
+		SetProcTitle(os.Args[0])
+	}
+}
+
+func SetProcTitle(title string) {
+	cs := C.CString(title)
+	defer C.free(unsafe.Pointer(cs))
+
+	C.spt_setproctitle(cs)
+}
+
+func SetProcTitleFast(title string) {
+	cs := C.CString(title)
+	defer C.free(unsafe.Pointer(cs))
+
+	C.spt_setproctitle_fast(cs)
+}

--- a/vendor/github.com/ErikDubbelboer/gspt/gspt_test.go
+++ b/vendor/github.com/ErikDubbelboer/gspt/gspt_test.go
@@ -1,0 +1,61 @@
+package gspt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"encoding/binary"
+	"encoding/hex"
+
+	"crypto/md5"
+	"os/exec"
+)
+
+func randomMD5() string {
+	str := md5.New()
+	random := new(bytes.Buffer)
+
+	binary.Write(random, binary.LittleEndian, time.Now().UTC().UnixNano())
+
+	str.Write(random.Bytes())
+
+	return hex.EncodeToString(str.Sum(nil))
+}
+
+func TestSetProcTitle(t *testing.T) {
+	if HaveSetProcTitle == HaveNone {
+		t.SkipNow()
+	}
+
+	title := randomMD5()
+
+	SetProcTitle(title)
+
+	out, err := exec.Command("/bin/ps", "ax").Output()
+	if err != nil {
+		// No ps available on this platform.
+		t.SkipNow()
+	} else if !strings.Contains(string(out), title) {
+		t.FailNow()
+	}
+}
+
+func TestSetProcTitleFast(t *testing.T) {
+	if HaveSetProcTitleFast == HaveNone {
+		t.SkipNow()
+	}
+
+	title := randomMD5()
+
+	SetProcTitleFast(title)
+
+	out, err := exec.Command("/bin/ps", "ax").Output()
+	if err != nil {
+		// No ps available on this platform.
+		t.SkipNow()
+	} else if !strings.Contains(string(out), title) {
+		t.FailNow()
+	}
+}

--- a/vendor/github.com/ErikDubbelboer/gspt/setproctitle.h
+++ b/vendor/github.com/ErikDubbelboer/gspt/setproctitle.h
@@ -1,0 +1,307 @@
+/* ==========================================================================
+ * setproctitle.h - Linux/Darwin setproctitle.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2010  William Ahern
+ * Copyright (C) 2013  Salvatore Sanfilippo
+ * Copyright (C) 2013  Stam He
+ * Copyright (C) 2013  Erik Dubbelboer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ==========================================================================
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stddef.h> // NULL size_t
+#include <stdarg.h> // va_list va_start va_end
+#include <stdlib.h> // malloc(3) setenv(3) clearenv(3) setproctitle(3) getprogname(3)
+#include <stdio.h>  // vsnprintf(3) snprintf(3)
+#include <string.h> // strlen(3) strdup(3) memset(3) memcpy(3)
+#include <errno.h>  /* program_invocation_name program_invocation_short_name */
+#include <sys/param.h> /* os versions */
+#include <sys/types.h> /* freebsd setproctitle(3) */
+#include <unistd.h>    /* freebsd setproctitle(3) */
+
+#if !defined(HAVE_SETPROCTITLE)
+#if (__NetBSD__ || __FreeBSD__ || __OpenBSD__)
+#define HAVE_SETPROCTITLE 1
+#if (__FreeBSD__ && __FreeBSD_version > 1200000)
+#define HAVE_SETPROCTITLE_FAST 1
+#else
+#define HAVE_SETPROCTITLE_FAST 0
+#endif
+#else
+#define HAVE_SETPROCTITLE 0
+#define HAVE_SETPROCTITLE_FAST 0
+#endif
+#endif
+
+
+#if HAVE_SETPROCTITLE
+#define HAVE_SETPROCTITLE_REPLACEMENT 0
+#elif (defined __linux || defined __APPLE__)
+#define HAVE_SETPROCTITLE_REPLACEMENT 1
+#else
+#define HAVE_SETPROCTITLE_REPLACEMENT 0
+#endif
+
+
+#if HAVE_SETPROCTITLE_REPLACEMENT
+
+#ifndef SPT_MAXTITLE
+#define SPT_MAXTITLE 255
+#endif
+
+
+extern char **environ;
+
+
+static struct {
+  // Original value.
+  const char *arg0;
+
+  // First enviroment variable.
+  char* env0;
+
+  // Title space available.
+  char* base;
+  char* end;
+
+  // Pointer to original nul character within base.
+  char *nul;
+
+  int reset;
+} SPT;
+
+
+#ifndef SPT_MIN
+#define SPT_MIN(a, b) (((a) < (b))? (a) : (b))
+#endif
+
+
+static inline size_t spt_min(size_t a, size_t b) {
+  return SPT_MIN(a, b);
+}
+
+static char **spt_find_argv_from_env(int argc, char *arg0) {
+    int i;
+    char **buf = NULL;
+    char *ptr;
+    char *limit;
+
+    if (!(buf = (char **)malloc((argc + 1) * sizeof(char *)))) {
+       return NULL;
+    }
+    buf[argc] = NULL;
+
+    // Walk back from environ until you find argc-1 null-terminated strings.
+    // Don't look for argv[0] as it's probably not preceded by 0.
+    ptr = SPT.env0;
+    limit = ptr - 8192; // TODO: empiric limit: should use MAX_ARG
+    --ptr;
+    for (i = argc - 1; i >= 1; --i) {
+        if (*ptr) {
+          return NULL;
+        }
+        --ptr;
+        while (*ptr && ptr > limit) { --ptr; }
+        if (ptr <= limit) {
+          return NULL;
+        }
+        buf[i] = (ptr + 1);
+    }
+
+    // The first arg has not a zero in front. But what we have is reliable
+    // enough (modulo its encoding). Check if it is exactly what found.
+    //
+    // The check is known to fail on OS X with locale C if there are
+    // non-ascii characters in the executable path.
+    ptr -= strlen(arg0);
+
+    if (ptr <= limit) {
+       return NULL;
+    }
+    if (strcmp(ptr, arg0)) {
+       return NULL;
+    }
+
+    buf[0] = ptr;
+    return buf;
+}
+
+
+static int spt_init1() {
+  // Store a pointer to the first environment variable since go
+  // will overwrite environment.
+  SPT.env0 = environ[0];
+
+  return 2;
+}
+
+static int spt_fast_init1() {
+  return 0;
+}
+
+
+static void spt_init2(int argc, char *arg0) {
+  char **argv = spt_find_argv_from_env(argc, arg0);
+  char **envp = &SPT.env0;
+  char *base, *end, *nul, *tmp;
+  int i;
+
+  if (!argv) {
+    return;
+  }
+
+  if (!(base = argv[0]))
+    return;
+
+  nul = &base[strlen(base)];
+  end = nul + 1;
+
+  for (i = 0; i < argc || (i >= argc && argv[i]); i++) {
+    if (!argv[i] || argv[i] < end)
+      continue;
+
+    end = argv[i] + strlen(argv[i]) + 1;
+  }
+
+  for (i = 0; envp[i]; i++) {
+    if (envp[i] < end)
+      continue;
+
+    end = envp[i] + strlen(envp[i]) + 1;
+  }
+
+  if (!(SPT.arg0 = strdup(argv[0])))
+    return;
+
+#if __GLIBC__
+  if (!(tmp = strdup(program_invocation_name)))
+    return;
+
+  program_invocation_name = tmp;
+
+  if (!(tmp = strdup(program_invocation_short_name)))
+    return;
+
+  program_invocation_short_name = tmp;
+#elif __APPLE__
+  if (!(tmp = strdup(getprogname())))
+    return;
+
+  setprogname(tmp);
+#endif
+
+  memset(base, 0, end - base);
+
+  SPT.nul  = nul;
+  SPT.base = base;
+  SPT.end  = end;
+
+  return;
+}
+
+
+static void setproctitle(const char *fmt, ...) {
+  char buf[SPT_MAXTITLE + 1]; // Use buffer in case argv[0] is passed.
+  va_list ap;
+  char *nul;
+  int len;
+
+  if (!SPT.base)
+    return;
+
+  if (fmt) {
+    va_start(ap, fmt);
+    len = vsnprintf(buf, sizeof buf, fmt, ap);
+    va_end(ap);
+  } else {
+    len = snprintf(buf, sizeof buf, "%s", SPT.arg0);
+  }
+
+  if (len <= 0) {
+    return;
+  }
+
+  if (!SPT.reset) {
+    memset(SPT.base, 0, SPT.end - SPT.base);
+    SPT.reset = 1;
+  } else {
+    memset(SPT.base, 0, spt_min(sizeof buf, SPT.end - SPT.base));
+  }
+
+  len = spt_min(len, spt_min(sizeof buf, SPT.end - SPT.base) - 1);
+  memcpy(SPT.base, buf, len);
+  nul = &SPT.base[len];
+
+  if (nul < SPT.nul) {
+    memset(nul, ' ', SPT.nul - nul);
+  } else if (nul == SPT.nul && &nul[1] < SPT.end) {
+    *SPT.nul = ' ';
+    *++nul = '\0';
+  }
+}
+
+
+#else // HAVE_SETPROCTITLE_REPLACEMENT
+
+static int spt_init1() {
+#if HAVE_SETPROCTITLE
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+static int spt_fast_init1() {
+#if HAVE_SETPROCTITLE_FAST
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+static void spt_init2(int argc, char *arg0) {
+  (void)argc;
+  (void)arg0;
+}
+
+#endif // HAVE_SETPROCTITLE_REPLACEMENT
+
+
+
+static void spt_setproctitle(const char *title) {
+#if HAVE_SETPROCTITLE || HAVE_SETPROCTITLE_REPLACEMENT
+  setproctitle("%s", title);
+#else
+  (void)title;
+#endif
+}
+
+static void spt_setproctitle_fast(const char *title) {
+#if HAVE_SETPROCTITLE_FAST
+  setproctitle_fast("%s", title);
+#else
+  (void)title;
+#endif
+}
+


### PR DESCRIPTION
### Description

This PR [briefly explain what it does]

If the user sets the password with a command-line argument, when gh-ost running, another user can get the password from /proc/{pid}/cmdline file or from `ps` command. It seems to be not secure. As `mysql` client does, it will be more secure to replace the password with several x letters.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
