### PR TITLE
Run `localtests` via docker

### DIFF
--- a/Dockerfile.itest
+++ b/Dockerfile.itest
@@ -1,0 +1,33 @@
+# See https://gist.github.com/ajm188/9488bc9c2b5b10d645f5e168e94cfb77
+# for why this is xenial
+FROM ubuntu:xenial
+
+ARG DBDEPLOYER_VERSION=1.52.0
+ARG MYSQL_VERSION_APT=5.7
+ARG MYSQL_VERSION=5.7.26
+
+RUN echo ${MYSQL_VERSION} > /mysql_version
+
+# We install mysql-server as a hack to make sure dbdeployer has all libs it
+# needs to run mysqls.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        mysql-server-${MYSQL_VERSION_APT} \
+        wget \
+    && apt-get autoremove
+
+RUN wget https://github.com/datacharmer/dbdeployer/releases/download/v${DBDEPLOYER_VERSION}/dbdeployer-${DBDEPLOYER_VERSION}.linux.tar.gz \
+    && tar -xzvf dbdeployer-${DBDEPLOYER_VERSION}.linux.tar.gz \
+    && chmod +x dbdeployer-${DBDEPLOYER_VERSION}.linux \
+    && mv dbdeployer-${DBDEPLOYER_VERSION}.linux /usr/local/bin/dbdeployer
+
+RUN dbdeployer init --skip-all-downloads --skip-shell-completion \
+    && dbdeployer downloads get-by-version ${MYSQL_VERSION} --minimal \
+    && dbdeployer unpack mysql-${MYSQL_VERSION}.tar.xz --unpack-version ${MYSQL_VERSION}
+
+ADD itest.sh /itest.sh
+ADD bin/gh-ost /usr/local/bin/gh-ost
+ADD localtests /localtests
+
+CMD ["/itest.sh"]

--- a/Dockerfile.itest
+++ b/Dockerfile.itest
@@ -30,4 +30,4 @@ ADD itest.sh /itest.sh
 ADD bin/gh-ost /usr/local/bin/gh-ost
 ADD localtests /localtests
 
-CMD ["/itest.sh"]
+ENTRYPOINT ["/itest.sh", "-b", "/usr/local/bin/gh-ost"]

--- a/itest.sh
+++ b/itest.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+#/ Usage: itest.sh [opts] [test_pattern]
+#/
+#/ Options:
+#/    --gh-ost-binary | -b path to gh-ost binary. defaults to /tmp/gh-ost-test
+
+usage() {
+  code="$1"
+  u="$(grep "^#/" "$0" | cut -c"4-")"
+  if [ "$code" -ne 0 ]; then echo "$u" >&2; else echo "$u"; fi
+
+  exit "$code"
+}
+
+GHOST_BINARY=
+while [ "$#" -gt 0 ];
+do
+  case "$1" in
+    --gh-ost-binary|-b) GHOST_BINARY="$2"; shift 2;;
+    --gh-ost-binary=*) GHOST_BINARY="$(echo "$1" | cut -d"=" -f"2-")"; shift;;
+    --help|-h) usage 0;;
+    -*) usage 1;;
+    *) ;;
+  esac
+done
+
+TEST_PATTERN="${1:-.}"
+
+if [ -f /mysql_version ];
+then
+  MYSQL_VERSION="$(cat /mysql_version)"
+else
+  MYSQL_VERSION="5.7.26"
+fi
+
+echo "Creating replication sandbox"
+dbdeployer deploy replication $MYSQL_VERSION \
+  --my-cnf-options log_slave_updates \
+  --my-cnf-options log_bin \
+  --my-cnf-options binlog_format=ROW \
+  --sandbox-directory gh-ost-test
+
+echo "Creating gh-ost user"
+/root/sandboxes/gh-ost-test/m -uroot -e"CREATE USER IF NOT EXISTS 'gh-ost'@'%' IDENTIFIED BY 'gh-ost'"
+/root/sandboxes/gh-ost-test/m -uroot -e"GRANT ALL ON *.* TO 'gh-ost'@'%'"
+
+echo "Reading database topology"
+master_host="127.0.0.1"
+master_port="$(/root/sandboxes/gh-ost-test/m -e"select @@port" -ss)"
+replica_host="127.0.0.1"
+replica_port="$(/root/sandboxes/gh-ost-test/s1 -e"select @@port" -ss)"
+
+test_path=localtests/trivial
+throttle_flag_file=trivial.trottle-flag
+extra_args=""
+if [ -f $test_path/extra_args ];
+then
+  extra_args="$(cat $test_path/extra_args)"
+fi
+
+echo "Setting up test case"
+/root/sandboxes/gh-ost-test/m -uroot test <$test_path/create.sql
+
+echo "Running gh-ost"
+/usr/local/bin/gh-ost \
+    --user=gh-ost \
+    --password=gh-ost \
+    --host="$replica_host" \
+    --port="$replica_port" \
+    --assume-master-host="${master_host}:${master_port}" \
+    --database=test \
+    --table=gh_ost_test \
+    --alter='engine=innodb' \
+    --exact-rowcount \
+    --assume-rbr \
+    --initially-drop-old-table \
+    --initially-drop-ghost-table \
+    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from _gh_ost_test_ghc' \
+    --throttle-flag-file=$throttle_flag_file \
+    --serve-socket-file=/tmp/gh-ost.test.sock \
+    --initially-drop-socket-file \
+    --test-on-replica \
+    --default-retries=3 \
+    --chunk-size=10 \
+    --verbose \
+    --debug \
+    --stack \
+    --execute "${extra_args[@]}" 1>trivial.log 2>&1
+
+result=$?
+if [ $result -ne 0 ];
+then
+  echo
+  echo "ERROR execution failure"
+  cat trivial.log
+  exit 1
+fi
+
+echo "Success!"

--- a/itest.sh
+++ b/itest.sh
@@ -46,9 +46,17 @@ dbdeployer deploy replication $MYSQL_VERSION \
   --my-cnf-options binlog_format=ROW \
   --sandbox-directory gh-ost-test
 
+echo '#!/bin/bash' > /usr/local/bin/gh-ost-test-mysql-master
+echo '/root/sandboxes/gh-ost-test/m "$@"' >> /usr/local/bin/gh-ost-test-mysql-master
+chmod +x /usr/local/bin/gh-ost-test-mysql-master
+
+echo '#!/bin/bash' > /usr/local/bin/gh-ost-test-mysql-replica
+echo '/root/sandboxes/gh-ost-test/s1 "$@"' > /usr/local/bin/gh-ost-test-mysql-replica
+chmod +x /usr/local/bin/gh-ost-test-mysql-replica
+
 echo "Creating gh-ost user"
-/root/sandboxes/gh-ost-test/m -uroot -e"CREATE USER IF NOT EXISTS 'gh-ost'@'%' IDENTIFIED BY 'gh-ost'"
-/root/sandboxes/gh-ost-test/m -uroot -e"GRANT ALL ON *.* TO 'gh-ost'@'%'"
+gh-ost-test-mysql-master -uroot -e"CREATE USER IF NOT EXISTS 'gh-ost'@'%' IDENTIFIED BY 'gh-ost'"
+gh-ost-test-mysql-master -uroot -e"GRANT ALL PRIVILEGES ON *.* TO 'gh-ost'@'%'"
 
 echo "Reading database topology"
 master_host="127.0.0.1"

--- a/itest.sh
+++ b/itest.sh
@@ -4,6 +4,7 @@
 #/
 #/ Options:
 #/    --gh-ost-binary | -b path to gh-ost binary. defaults to /tmp/gh-ost-test
+#/    --test-dir           path to test directories. defaults to /localtests
 
 usage() {
   code="$1"
@@ -13,15 +14,19 @@ usage() {
   exit "$code"
 }
 
-GHOST_BINARY=
+GHOST_BINARY=/tmp/gh-ost-test
+TEST_DIR=/localtests
+
 while [ "$#" -gt 0 ];
 do
   case "$1" in
     --gh-ost-binary|-b) GHOST_BINARY="$2"; shift 2;;
     --gh-ost-binary=*) GHOST_BINARY="$(echo "$1" | cut -d"=" -f"2-")"; shift;;
+    --test-dir) TEST_DIR="$2"; shift 2;;
+    --test-dir=*) TEST_DIR="$(echo "$1" | cut -d"=" -f"2-")"; shift;;
     --help|-h) usage 0;;
     -*) usage 1;;
-    *) ;;
+    *) break ;;
   esac
 done
 

--- a/itest.sh
+++ b/itest.sh
@@ -46,17 +46,17 @@ dbdeployer deploy replication $MYSQL_VERSION \
   --my-cnf-options binlog_format=ROW \
   --sandbox-directory gh-ost-test
 
-echo '#!/bin/bash' > /usr/local/bin/gh-ost-test-mysql-master
-echo '/root/sandboxes/gh-ost-test/m "$@"' >> /usr/local/bin/gh-ost-test-mysql-master
-chmod +x /usr/local/bin/gh-ost-test-mysql-master
+echo '#!/bin/bash' > /usr/local/bin/gh-ost-test-mysql-primary
+echo '/root/sandboxes/gh-ost-test/m "$@"' >> /usr/local/bin/gh-ost-test-mysql-primary
+chmod +x /usr/local/bin/gh-ost-test-mysql-primary
 
 echo '#!/bin/bash' > /usr/local/bin/gh-ost-test-mysql-replica
 echo '/root/sandboxes/gh-ost-test/s1 "$@"' > /usr/local/bin/gh-ost-test-mysql-replica
 chmod +x /usr/local/bin/gh-ost-test-mysql-replica
 
 echo "Creating gh-ost user"
-gh-ost-test-mysql-master -uroot -e"CREATE USER IF NOT EXISTS 'gh-ost'@'%' IDENTIFIED BY 'gh-ost'"
-gh-ost-test-mysql-master -uroot -e"GRANT ALL PRIVILEGES ON *.* TO 'gh-ost'@'%'"
+gh-ost-test-mysql-primary -uroot -e"CREATE USER IF NOT EXISTS 'gh-ost'@'%' IDENTIFIED BY 'gh-ost'"
+gh-ost-test-mysql-primary -uroot -e"GRANT ALL PRIVILEGES ON *.* TO 'gh-ost'@'%'"
 
 echo "Reading database topology"
 master_host="127.0.0.1"

--- a/localtests/modify-change-case/extra_args
+++ b/localtests/modify-change-case/extra_args
@@ -1,1 +1,1 @@
---alter="modify C2 int not null default 0"
+--alter="modify c2 int not null default 0"

--- a/script/dock
+++ b/script/dock
@@ -3,7 +3,7 @@
 # Usage:
 # dock <test|packages> [arg]
 #   dock test:                build gh-ost & run unit and integration tests
-#   docker pkg [target-path]: build gh-ost release packages and copy to target path (default path: /tmp/gh-ost-release)
+#   dock pkg [target-path]:   build gh-ost release packages and copy to target path (default path: /tmp/gh-ost-release)
 
 command="$1"
 
@@ -15,11 +15,11 @@ case "$command" in
   "pkg")
     packages_path="${2:-/tmp/gh-ost-release}"
     docker_target="gh-ost-packaging"
-    docker build . -f Dockerfile.packaging -t "${docker_target}" && docker run --rm -it -v "${packages_path}:/tmp/pkg" "${docker_target}:latest" bash -c 'find /tmp/gh-ost-release/ -maxdepth 1 -type f | xargs cp -t /tmp/pkg'
+    docker build . -f Dockerfile.packaging -t "${docker_target}" && docker run --rm -it --mount type=bind,source="${packages_path}",target=/tmp/pkg "${docker_target}:latest" bash -c 'find /tmp/gh-ost-release/ -maxdepth 1 -type f | xargs cp -t /tmp/pkg'
     echo "packages generated on ${packages_path}:"
     ls -l "${packages_path}"
     ;;
   *)
-    >&2 echo "Usage: dock dock <test|alpine|packages> [arg]"
+    >&2 echo "Usage: dock <test|pkg> [arg]"
     exit 1
 esac

--- a/script/itest
+++ b/script/itest
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Wrapper for running integration tests in docker.
+
+./script/dock pkg $(pwd)/bin
+
+docker build -t itest -f Dockerfile.itest .
+docker run --rm itest


### PR DESCRIPTION
Related issue: #857 

### Description

This PR adds support for running `localtests` via docker.

It adds:
* Dockerfile.itest -- set up with dbdeployer and ready to run tests
* script/itest -- wrapper that builds gh-ost from source, builds the itest container and runs it
* itest.sh -- thing that actually runs the tests, expects to only be run in the itest container

### Testing

Example output: https://gist.github.com/ajm188/c83312ef82f06d51ca1f182c22b45d28