### PR TITLE
Fix buster tarball build

### DIFF
--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -28,8 +28,10 @@ gzip $tarball
 mkdir -p "$BUILD_ARTIFACT_DIR"/gh-ost
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/gh-ost/
 
-### HACK HACK HACK ###
-# blame @carlosmn and @mattr-
-# Allow builds on stretch to also be used for jessie
+### HACK HACK HACK HACK ###
+# blame @carlosmn, @mattr and @timvaillancourt-
+# Allow builds on buster to also be used for streth + jessie
+stretch_tarball_name=$(echo $(basename "${tarball}") | sed s/-buster-/-stretch-/)
 jessie_tarball_name=$(echo $(basename "${tarball}") | sed s/-stretch-/-jessie-/)
+cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${stretch_tarball_name}.gz"
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${jessie_tarball_name}.gz"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -32,6 +32,6 @@ cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/gh-ost/
 # blame @carlosmn, @mattr and @timvaillancourt-
 # Allow builds on buster to also be used for streth + jessie
 stretch_tarball_name=$(echo $(basename "${tarball}") | sed s/-buster-/-stretch-/)
-jessie_tarball_name=$(echo $(basename "${tarball}") | sed s/-stretch-/-jessie-/)
+jessie_tarball_name=$(echo $(basename "${stretch_tarball_name}") | sed s/-stretch-/-jessie-/)
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${stretch_tarball_name}.gz"
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${jessie_tarball_name}.gz"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -30,7 +30,7 @@ cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/gh-ost/
 
 ### HACK HACK HACK HACK ###
 # blame @carlosmn, @mattr and @timvaillancourt-
-# Allow builds on buster to also be used for streth + jessie
+# Allow builds on buster to also be used for stretch + jessie
 stretch_tarball_name=$(echo $(basename "${tarball}") | sed s/-buster-/-stretch-/)
 jessie_tarball_name=$(echo $(basename "${stretch_tarball_name}") | sed s/-stretch-/-jessie-/)
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${stretch_tarball_name}.gz"


### PR DESCRIPTION
### Description

The `gh-ost-build-deploy-tarball` CI job is now running under Debian `buster` and is no longer creating `stretch` and `jessie` tarballs like before

This PR continues a hack that was previously added for `jessie`/`stretch` until a better solution emerges

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
