### PR TITLE
Use golang:1.15.x, remove jessie tarball build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
 
     - name: Build
       run: script/cibuild

--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -1,6 +1,6 @@
 #
 
-FROM golang:1.14.7
+FROM golang:1.15.6
 
 RUN apt-get update
 RUN apt-get install -y ruby ruby-dev rubygems build-essential

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.14.7
+FROM golang:1.15.6
 LABEL maintainer="github@github.com"
 
 RUN apt-get update

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -32,6 +32,4 @@ cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/gh-ost/
 # blame @carlosmn, @mattr and @timvaillancourt-
 # Allow builds on buster to also be used for stretch + jessie
 stretch_tarball_name=$(echo $(basename "${tarball}") | sed s/-buster-/-stretch-/)
-jessie_tarball_name=$(echo $(basename "${stretch_tarball_name}") | sed s/-stretch-/-jessie-/)
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${stretch_tarball_name}.gz"
-cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${jessie_tarball_name}.gz"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -30,6 +30,6 @@ cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/gh-ost/
 
 ### HACK HACK HACK HACK ###
 # blame @carlosmn, @mattr and @timvaillancourt-
-# Allow builds on buster to also be used for stretch + jessie
+# Allow builds on buster to also be used for stretch
 stretch_tarball_name=$(echo $(basename "${tarball}") | sed s/-buster-/-stretch-/)
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/gh-ost/${stretch_tarball_name}.gz"


### PR DESCRIPTION
### Description

This PR updates builds/tests to use Golang 1.15. Also the Debian `jessie` tarball build is deprecated because `jessie` is end-of-life