### PR TITLE
fix data-integrity problem when add unique key

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -222,6 +222,8 @@ type MigrationContext struct {
 	recentBinlogCoordinates mysql.BinlogCoordinates
 
 	Log Logger
+
+	IsAddUniqueKey	bool
 }
 
 type Logger interface {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -267,6 +267,7 @@ func (this *Migrator) validateStatement() (err error) {
 		this.migrationContext.Log.Infof("Alter statement has column(s) renamed. gh-ost finds the following renames: %v; --approve-renamed-columns is given and so migration proceeds.", this.parser.GetNonTrivialRenames())
 	}
 	this.migrationContext.DroppedColumnsMap = this.parser.DroppedColumnsMap()
+	this.migrationContext.IsAddUniqueKey = this.parser.IsAddUniqueKey()
 	return nil
 }
 

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/outbrain/golib/log"
 	test "github.com/outbrain/golib/tests"
+	"fmt"
 )
 
 var (
@@ -39,31 +40,44 @@ func TestEscapeName(t *testing.T) {
 	}
 }
 
+func TestBuildValueComparison(t *testing.T) {
+	{
+		column := "c1"
+		value := "@v1"
+		alias := "a"
+		comparisonSign := LessThanComparisonSign
+		rangeComparison, err := BuildValueComparison(column, value,alias, comparisonSign)
+		fmt.Println(rangeComparison, err)
+	}
+}
+
+
 func TestBuildEqualsComparison(t *testing.T) {
+	alias := "a"
 	{
 		columns := []string{"c1"}
 		values := []string{"@v1"}
-		comparison, err := BuildEqualsComparison(columns, values)
+		comparison, err := BuildEqualsComparison(columns, values, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` = @v1))")
 	}
 	{
 		columns := []string{"c1", "c2"}
 		values := []string{"@v1", "@v2"}
-		comparison, err := BuildEqualsComparison(columns, values)
+		comparison, err := BuildEqualsComparison(columns, values, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` = @v1) and (`c2` = @v2))")
 	}
 	{
 		columns := []string{"c1"}
 		values := []string{"@v1", "@v2"}
-		_, err := BuildEqualsComparison(columns, values)
+		_, err := BuildEqualsComparison(columns, values, alias)
 		test.S(t).ExpectNotNil(err)
 	}
 	{
 		columns := []string{}
 		values := []string{}
-		_, err := BuildEqualsComparison(columns, values)
+		_, err := BuildEqualsComparison(columns, values, alias)
 		test.S(t).ExpectNotNil(err)
 	}
 }
@@ -98,11 +112,12 @@ func TestBuildSetPreparedClause(t *testing.T) {
 }
 
 func TestBuildRangeComparison(t *testing.T) {
+	alias := ""
 	{
 		columns := []string{"c1"}
 		values := []string{"@v1"}
 		args := []interface{}{3}
-		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanComparisonSign)
+		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanComparisonSign, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` < @v1))")
 		test.S(t).ExpectTrue(reflect.DeepEqual(explodedArgs, []interface{}{3}))
@@ -111,7 +126,7 @@ func TestBuildRangeComparison(t *testing.T) {
 		columns := []string{"c1"}
 		values := []string{"@v1"}
 		args := []interface{}{3}
-		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign)
+		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` < @v1) or ((`c1` = @v1)))")
 		test.S(t).ExpectTrue(reflect.DeepEqual(explodedArgs, []interface{}{3, 3}))
@@ -120,7 +135,7 @@ func TestBuildRangeComparison(t *testing.T) {
 		columns := []string{"c1", "c2"}
 		values := []string{"@v1", "@v2"}
 		args := []interface{}{3, 17}
-		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanComparisonSign)
+		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanComparisonSign, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` < @v1) or (((`c1` = @v1)) AND (`c2` < @v2)))")
 		test.S(t).ExpectTrue(reflect.DeepEqual(explodedArgs, []interface{}{3, 3, 17}))
@@ -129,7 +144,7 @@ func TestBuildRangeComparison(t *testing.T) {
 		columns := []string{"c1", "c2"}
 		values := []string{"@v1", "@v2"}
 		args := []interface{}{3, 17}
-		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign)
+		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` < @v1) or (((`c1` = @v1)) AND (`c2` < @v2)) or ((`c1` = @v1) and (`c2` = @v2)))")
 		test.S(t).ExpectTrue(reflect.DeepEqual(explodedArgs, []interface{}{3, 3, 17, 3, 17}))
@@ -138,7 +153,7 @@ func TestBuildRangeComparison(t *testing.T) {
 		columns := []string{"c1", "c2", "c3"}
 		values := []string{"@v1", "@v2", "@v3"}
 		args := []interface{}{3, 17, 22}
-		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign)
+		comparison, explodedArgs, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign, alias)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` < @v1) or (((`c1` = @v1)) AND (`c2` < @v2)) or (((`c1` = @v1) and (`c2` = @v2)) AND (`c3` < @v3)) or ((`c1` = @v1) and (`c2` = @v2) and (`c3` = @v3)))")
 		test.S(t).ExpectTrue(reflect.DeepEqual(explodedArgs, []interface{}{3, 3, 17, 3, 17, 22, 3, 17, 22}))
@@ -147,14 +162,14 @@ func TestBuildRangeComparison(t *testing.T) {
 		columns := []string{"c1"}
 		values := []string{"@v1", "@v2"}
 		args := []interface{}{3, 17}
-		_, _, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign)
+		_, _, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign, alias)
 		test.S(t).ExpectNotNil(err)
 	}
 	{
 		columns := []string{}
 		values := []string{}
 		args := []interface{}{}
-		_, _, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign)
+		_, _, err := BuildRangeComparison(columns, values, args, LessThanOrEqualsComparisonSign, alias)
 		test.S(t).ExpectNotNil(err)
 	}
 }
@@ -172,7 +187,7 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		rangeStartArgs := []interface{}{3}
 		rangeEndArgs := []interface{}{103}
 
-		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false)
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false,false)
 		test.S(t).ExpectNil(err)
 		expected := `
 				insert /* gh-ost mydb.tbl */ ignore into mydb.ghost (id, name, position)
@@ -191,7 +206,7 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		rangeStartArgs := []interface{}{3, 17}
 		rangeEndArgs := []interface{}{103, 117}
 
-		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false)
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false, false)
 		test.S(t).ExpectNil(err)
 		expected := `
 				insert /* gh-ost mydb.tbl */ ignore into mydb.ghost (id, name, position)
@@ -218,7 +233,7 @@ func TestBuildRangeInsertQueryRenameMap(t *testing.T) {
 		rangeStartArgs := []interface{}{3}
 		rangeEndArgs := []interface{}{103}
 
-		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, mappedSharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false)
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, mappedSharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false, false)
 		test.S(t).ExpectNil(err)
 		expected := `
 				insert /* gh-ost mydb.tbl */ ignore into mydb.ghost (id, name, location)
@@ -237,7 +252,7 @@ func TestBuildRangeInsertQueryRenameMap(t *testing.T) {
 		rangeStartArgs := []interface{}{3, 17}
 		rangeEndArgs := []interface{}{103, 117}
 
-		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, mappedSharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false)
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, mappedSharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false, false)
 		test.S(t).ExpectNil(err)
 		expected := `
 				insert /* gh-ost mydb.tbl */ ignore into mydb.ghost (id, name, location)
@@ -261,7 +276,7 @@ func TestBuildRangeInsertPreparedQuery(t *testing.T) {
 		rangeStartArgs := []interface{}{3, 17}
 		rangeEndArgs := []interface{}{103, 117}
 
-		query, explodedArgs, err := BuildRangeInsertPreparedQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, true, true)
+		query, explodedArgs, err := BuildRangeInsertPreparedQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, true, true, false)
 		test.S(t).ExpectNil(err)
 		expected := `
 				insert /* gh-ost mydb.tbl */ ignore into mydb.ghost (id, name, position)
@@ -442,7 +457,7 @@ func TestBuildDMLInsertQuery(t *testing.T) {
 	args := []interface{}{3, "testname", "first", 17, 23}
 	{
 		sharedColumns := NewColumnList([]string{"id", "name", "position", "age"})
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args, false)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -456,7 +471,7 @@ func TestBuildDMLInsertQuery(t *testing.T) {
 	}
 	{
 		sharedColumns := NewColumnList([]string{"position", "name", "age", "id"})
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args, false)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -470,12 +485,12 @@ func TestBuildDMLInsertQuery(t *testing.T) {
 	}
 	{
 		sharedColumns := NewColumnList([]string{"position", "name", "surprise", "id"})
-		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args, false)
 		test.S(t).ExpectNotNil(err)
 	}
 	{
 		sharedColumns := NewColumnList([]string{})
-		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args, false)
 		test.S(t).ExpectNotNil(err)
 	}
 }
@@ -489,7 +504,7 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		// testing signed
 		args := []interface{}{3, "testname", "first", int8(-1), 23}
 		sharedColumns := NewColumnList([]string{"id", "name", "position", "age"})
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args,false)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -505,7 +520,7 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		// testing unsigned
 		args := []interface{}{3, "testname", "first", int8(-1), 23}
 		sharedColumns.SetUnsigned("position")
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args,false)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -521,7 +536,7 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		// testing unsigned
 		args := []interface{}{3, "testname", "first", int32(-1), 23}
 		sharedColumns.SetUnsigned("position")
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args,false)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */

--- a/go/sql/parser.go
+++ b/go/sql/parser.go
@@ -16,6 +16,7 @@ var (
 	renameColumnRegexp                   = regexp.MustCompile(`(?i)\bchange\s+(column\s+|)([\S]+)\s+([\S]+)\s+`)
 	dropColumnRegexp                     = regexp.MustCompile(`(?i)\bdrop\s+(column\s+|)([\S]+)$`)
 	renameTableRegexp                    = regexp.MustCompile(`(?i)\brename\s+(to|as)\s+`)
+	uniqueKeyRegexp 	 				 = regexp.MustCompile(`(?i)\badd\s+unique\s+(key|index)?\s*`)
 	alterTableExplicitSchemaTableRegexps = []*regexp.Regexp{
 		// ALTER TABLE `scm`.`tbl` something
 		regexp.MustCompile(`(?i)\balter\s+table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
@@ -38,6 +39,7 @@ type AlterTableParser struct {
 	columnRenameMap map[string]string
 	droppedColumns  map[string]bool
 	isRenameTable   bool
+	isAddUniqueKey	bool
 
 	alterStatementOptions string
 	alterTokens           []string
@@ -122,6 +124,13 @@ func (this *AlterTableParser) parseAlterToken(alterToken string) (err error) {
 			this.isRenameTable = true
 		}
 	}
+	{
+		// add unique key
+		if uniqueKeyRegexp.MatchString(alterToken) {
+			this.isAddUniqueKey = true
+		}
+	}
+
 	return nil
 }
 
@@ -173,6 +182,12 @@ func (this *AlterTableParser) DroppedColumnsMap() map[string]bool {
 func (this *AlterTableParser) IsRenameTable() bool {
 	return this.isRenameTable
 }
+
+func (this *AlterTableParser) IsAddUniqueKey() bool {
+	return this.isAddUniqueKey
+}
+
+
 func (this *AlterTableParser) GetExplicitSchema() string {
 	return this.explicitSchema
 }


### PR DESCRIPTION
Hi,
Add a PR for #485  #477  #167 . 

Insert syntax in gh-ost will be rewritten with `insert ignore into` (row-copy) and `replace into`(binlog apply goroutine) . if the data in the original table or data after apply would cause conflicts, means does not meet the conditions for adding a unique key, data will be lost in current version. This PR can detect data conflicts and exit, including conflicts in the original table data, and the data after binlog apply. PTAL.

The error looks like the following and is very easy to reproduce：
- original conflict
 >> 2021-01-08 16:58:15 ERROR Error 1062: Duplicate entry 'cenkore' for key 'name'
- apply confict
>> 2021-01-08 16:59:37 ERROR Error 1062: Duplicate entry 'cenkore' for key 'name'; query=
			insert /* gh-ost `adetestdb`.`_testuk_gho` */ into
				`adetestdb`.`_testuk_gho`
					(`id`, `name`, `location`, `inserttime`)
				values
					(?, ?, ?, ?)
		; args=[3 cenkore cn 2021-01-08 16:59:30]


thanks.