### PR TITLE
fix: issue 909

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -553,6 +553,7 @@ func (this *Inspector) applyColumnTypes(databaseName, tableName string, columnsL
 	err := sqlutils.QueryRowsMap(this.db, query, func(m sqlutils.RowMap) error {
 		columnName := m.GetString("COLUMN_NAME")
 		columnType := m.GetString("COLUMN_TYPE")
+		columnOctetLength := m.GetUint("CHARACTER_OCTET_LENGTH")
 		for _, columnsList := range columnsLists {
 			column := columnsList.GetColumn(columnName)
 			if column == nil {
@@ -579,6 +580,10 @@ func (this *Inspector) applyColumnTypes(databaseName, tableName string, columnsL
 			}
 			if strings.HasPrefix(columnType, "enum") {
 				column.Type = sql.EnumColumnType
+			}
+			if strings.HasPrefix(columnType, "binary") {
+				column.Type = sql.BinaryColumnType
+				column.BinaryOctetLength = columnOctetLength
 			}
 			if charset := m.GetString("CHARACTER_SET_NAME"); charset != "" {
 				column.Charset = charset

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -396,7 +396,7 @@ func BuildDMLDeleteQuery(databaseName, tableName string, tableColumns, uniqueKey
 	}
 	for _, column := range uniqueKeyColumns.Columns() {
 		tableOrdinal := tableColumns.Ordinals[column.Name]
-		arg := column.convertArg(args[tableOrdinal])
+		arg := column.convertArg(args[tableOrdinal], true)
 		uniqueKeyArgs = append(uniqueKeyArgs, arg)
 	}
 	databaseName = EscapeName(databaseName)
@@ -433,7 +433,7 @@ func BuildDMLInsertQuery(databaseName, tableName string, tableColumns, sharedCol
 
 	for _, column := range sharedColumns.Columns() {
 		tableOrdinal := tableColumns.Ordinals[column.Name]
-		arg := column.convertArg(args[tableOrdinal])
+		arg := column.convertArg(args[tableOrdinal], false)
 		sharedArgs = append(sharedArgs, arg)
 	}
 
@@ -481,13 +481,13 @@ func BuildDMLUpdateQuery(databaseName, tableName string, tableColumns, sharedCol
 
 	for _, column := range sharedColumns.Columns() {
 		tableOrdinal := tableColumns.Ordinals[column.Name]
-		arg := column.convertArg(valueArgs[tableOrdinal])
+		arg := column.convertArg(valueArgs[tableOrdinal], false)
 		sharedArgs = append(sharedArgs, arg)
 	}
 
 	for _, column := range uniqueKeyColumns.Columns() {
 		tableOrdinal := tableColumns.Ordinals[column.Name]
-		arg := column.convertArg(whereArgs[tableOrdinal])
+		arg := column.convertArg(whereArgs[tableOrdinal], true)
 		uniqueKeyArgs = append(uniqueKeyArgs, arg)
 	}
 

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -44,14 +44,14 @@ type Column struct {
 	timezoneConversion *TimezoneConversion
 }
 
-func (this *Column) convertArg(arg interface{}) interface{} {
+func (this *Column) convertArg(arg interface{}, isUniqueKeyColumn bool) interface{} {
 	if s, ok := arg.(string); ok {
 		// string, charset conversion
 		if encoding, ok := charsetEncodingMap[this.Charset]; ok {
 			arg, _ = encoding.NewDecoder().String(s)
 		}
 
-		if this.Type == BinaryColumnType {
+		if this.Type == BinaryColumnType && isUniqueKeyColumn {
 			arg2Bytes := []byte(arg.(string))
 			size := len(arg2Bytes)
 			if uint(size) < this.BinaryOctetLength {

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -6,11 +6,11 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
-	"bytes"
 )
 
 type ColumnType int
@@ -33,10 +33,10 @@ type TimezoneConversion struct {
 }
 
 type Column struct {
-	Name               string
-	IsUnsigned         bool
-	Charset            string
-	Type               ColumnType
+	Name       string
+	IsUnsigned bool
+	Charset    string
+	Type       ColumnType
 
 	// add Octet length for binary type, fix bytes with suffix "00" get clipped in mysql binlog.
 	// https://github.com/github/gh-ost/issues/909

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -52,9 +52,10 @@ func (this *Column) convertArg(arg interface{}) interface{} {
 		}
 
 		if this.Type == BinaryColumnType {
-			size := len([]byte(arg.(string)))
+			arg2Bytes := []byte(arg.(string))
+			size := len(arg2Bytes)
 			if uint(size) < this.BinaryOctetLength {
-				buf := bytes.NewBuffer([]byte(arg.(string)))
+				buf := bytes.NewBuffer(arg2Bytes)
 				for i := uint(0); i < (this.BinaryOctetLength - uint(size)); i++ {
 					buf.Write([]byte{0})
 				}


### PR DESCRIPTION
Add a PR for #909 

The reason is that the last byte of 0x00 was truncated when mysql wrote Binlog, so the data obtained when gh-ost parsed binlog through go-mysql was already truncated

you can read binlog with hexdump as follows, or debug at [here](https://github.com/siddontang/go-mysql/blob/master/replication/row_event.go#L1169) , you will get the actual length is 15

> Position  Timestamp   Type   Master ID        Size      Master Pos    Flags     
     c86 60 14 fc 5f   20   35 23 00 00   7f 00 00 00   05 0d 00 00   00 00    
     c99 99 5e 00 00 00 00 01 00  02 00 05 ff f0 10 00 2e |................|    
     ca9 36 3f 30 50 44 de 79 e9  b3 d0 10 5b c2 3e 01 00 |6.0PD.y.........|    
     cb9 00 00 10 e5 3c 11 1a fe  f8 a2 d3 b9 a3 48 41 08 |.............HA.|    
     cc9 d0 8f 2e 99 a8 3e 74 c0  e0 0f **15 0b 7b 5b 51 6f** |......t.......Qo|    
     cd9 **87 12 5e 85 97 ff b4 4b  f2** 02 00 00 00 10 e5 3c |.......K........|    
     ce9 11 1a fe f8 a2 d3 b9 a3  48 41 08 d0 8f 2b 99 a8 |........HA......|    
     cf9 3e 74 80 99 a8 3e 75 00  43 17 a8 3b             |.t....u.C...|    
      Delete_rows: table id 24217 flags: STMT_END_F    

