### PR TITLE
Add MySQL GTID support

### DIFF
--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -133,7 +133,7 @@ Add this flag when executing on a 1st generation Google Cloud Platform (GCP).
 
 ### gtid
 
-Add this flag to enable support for [MySQL GTIDs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-concepts.html) for replication binlog positioning. This requires `gtid_mode` to be set to `ON`.
+Add this flag to enable support for [MySQL GTIDs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-concepts.html) for replication binlog positioning. This requires `gtid_mode` and `enforce_gtid_consistency` to be set to `ON`.
 
 ### heartbeat-interval-millis
 

--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -133,7 +133,7 @@ Add this flag when executing on a 1st generation Google Cloud Platform (GCP).
 
 ### gtid
 
-Add this flag to enable support for [MySQL GTIDs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-concepts.html) for replication binlog positioning.
+Add this flag to enable support for [MySQL GTIDs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-concepts.html) for replication binlog positioning. This requires `gtid_mode` to be set to `ON`.
 
 ### heartbeat-interval-millis
 

--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -131,6 +131,10 @@ Table name prefix to be used on the temporary tables.
 
 Add this flag when executing on a 1st generation Google Cloud Platform (GCP).
 
+### gtid
+
+Add this flag to enable support for [MySQL GTIDs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-concepts.html) for replication binlog positioning.
+
 ### heartbeat-interval-millis
 
 Default 100. See [`subsecond-lag`](subsecond-lag.md) for details.

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -98,7 +98,7 @@ type MigrationContext struct {
 	AliyunRDS                bool
 	GoogleCloudPlatform      bool
 	AzureMySQL               bool
-	UseGTID                  bool
+	UseGTIDs                 bool
 
 	config            ContextConfig
 	configMutex       *sync.Mutex

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -98,6 +98,7 @@ type MigrationContext struct {
 	AliyunRDS                bool
 	GoogleCloudPlatform      bool
 	AzureMySQL               bool
+	UseGTID                  bool
 
 	config            ContextConfig
 	configMutex       *sync.Mutex

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 

--- a/go/binlog/binlog_entry.go
+++ b/go/binlog/binlog_entry.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -22,7 +22,7 @@ type BinlogEntry struct {
 // NewBinlogEntry creates an empty, ready to go BinlogEntry object
 func NewBinlogEntry(logFile string, logPos uint64, gtidSet gomysql.GTIDSet) *BinlogEntry {
 	binlogEntry := &BinlogEntry{
-		Coordinates: mysql.BinlogCoordinates{LogFile: logFile, LogPos: int64(logPos), ExecutedGTIDSet: gtidSet},
+		Coordinates: mysql.BinlogCoordinates{LogFile: logFile, LogPos: int64(logPos), GTIDSet: gtidSet},
 	}
 	return binlogEntry
 }
@@ -37,7 +37,7 @@ func NewBinlogEntryAt(coordinates mysql.BinlogCoordinates) *BinlogEntry {
 
 // Duplicate creates and returns a new binlog entry, with some of the attributes pre-assigned
 func (this *BinlogEntry) Duplicate() *BinlogEntry {
-	return NewBinlogEntry(this.Coordinates.LogFile, uint64(this.Coordinates.LogPos), this.Coordinates.ExecutedGTIDSet)
+	return NewBinlogEntry(this.Coordinates.LogFile, uint64(this.Coordinates.LogPos), this.Coordinates.GTIDSet)
 }
 
 // String() returns a string representation of this binlog entry

--- a/go/binlog/binlog_entry.go
+++ b/go/binlog/binlog_entry.go
@@ -7,21 +7,22 @@ package binlog
 
 import (
 	"fmt"
+
 	"github.com/github/gh-ost/go/mysql"
+
+	gomysql "github.com/siddontang/go-mysql/mysql"
 )
 
 // BinlogEntry describes an entry in the binary log
 type BinlogEntry struct {
 	Coordinates mysql.BinlogCoordinates
-	EndLogPos   uint64
-
-	DmlEvent *BinlogDMLEvent
+	DmlEvent    *BinlogDMLEvent
 }
 
 // NewBinlogEntry creates an empty, ready to go BinlogEntry object
-func NewBinlogEntry(logFile string, logPos uint64) *BinlogEntry {
+func NewBinlogEntry(logFile string, logPos uint64, gtidSet gomysql.GTIDSet) *BinlogEntry {
 	binlogEntry := &BinlogEntry{
-		Coordinates: mysql.BinlogCoordinates{LogFile: logFile, LogPos: int64(logPos)},
+		Coordinates: mysql.BinlogCoordinates{LogFile: logFile, LogPos: int64(logPos), ExecutedGTIDSet: gtidSet},
 	}
 	return binlogEntry
 }
@@ -36,9 +37,7 @@ func NewBinlogEntryAt(coordinates mysql.BinlogCoordinates) *BinlogEntry {
 
 // Duplicate creates and returns a new binlog entry, with some of the attributes pre-assigned
 func (this *BinlogEntry) Duplicate() *BinlogEntry {
-	binlogEntry := NewBinlogEntry(this.Coordinates.LogFile, uint64(this.Coordinates.LogPos))
-	binlogEntry.EndLogPos = this.EndLogPos
-	return binlogEntry
+	return NewBinlogEntry(this.Coordinates.LogFile, uint64(this.Coordinates.LogPos), this.Coordinates.ExecutedGTIDSet)
 }
 
 // String() returns a string representation of this binlog entry

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -65,7 +65,7 @@ func (this *GoMySQLReader) ConnectBinlogStreamer(coordinates mysql.BinlogCoordin
 	this.migrationContext.Log.Infof("Connecting binlog streamer at %+v", this.currentCoordinates)
 	// Start sync with specified GTID set or binlog file and position
 	if this.migrationContext.UseGTID {
-		this.binlogStreamer, err = this.binlogSyncer.StartSyncGTID(this.currentCoordinates.ExecutedGTIDSet)
+		this.binlogStreamer, err = this.binlogSyncer.StartSyncGTID(this.currentCoordinates.GTIDSet)
 	} else {
 		this.binlogStreamer, err = this.binlogSyncer.StartSync(gomysql.Position{this.currentCoordinates.LogFile, uint32(this.currentCoordinates.LogPos)})
 	}

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -25,7 +25,6 @@ type GoMySQLReader struct {
 	binlogStreamer           *replication.BinlogStreamer
 	currentCoordinates       mysql.BinlogCoordinates
 	currentCoordinatesMutex  *sync.Mutex
-	useGTID                  bool
 	LastAppliedRowsEventHint mysql.BinlogCoordinates
 }
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -80,7 +80,7 @@ func main() {
 	flag.BoolVar(&migrationContext.AliyunRDS, "aliyun-rds", false, "set to 'true' when you execute on Aliyun RDS.")
 	flag.BoolVar(&migrationContext.GoogleCloudPlatform, "gcp", false, "set to 'true' when you execute on a 1st generation Google Cloud Platform (GCP).")
 	flag.BoolVar(&migrationContext.AzureMySQL, "azure", false, "set to 'true' when you execute on Azure Database on MySQL.")
-	flag.BoolVar(&migrationContext.UseGTID, "gtid", false, "set to 'true' to enable MySQL GTIDs for replication binlog positioning.")
+	flag.BoolVar(&migrationContext.UseGTIDs, "gtid", false, "set to 'true' to enable MySQL GTIDs for replication binlog positioning.")
 
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration replication is stopped, and tables are swapped and immediately swap-revert. Replication remains stopped and you can compare the two tables for building trust")

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -80,7 +80,7 @@ func main() {
 	flag.BoolVar(&migrationContext.AliyunRDS, "aliyun-rds", false, "set to 'true' when you execute on Aliyun RDS.")
 	flag.BoolVar(&migrationContext.GoogleCloudPlatform, "gcp", false, "set to 'true' when you execute on a 1st generation Google Cloud Platform (GCP).")
 	flag.BoolVar(&migrationContext.AzureMySQL, "azure", false, "set to 'true' when you execute on Azure Database on MySQL.")
-	flag.BoolVar(&migrationContext.UseGTID, "gtid", false, "set to 'true' to use MySQL GTIDs for binlog positioning")
+	flag.BoolVar(&migrationContext.UseGTID, "gtid", false, "set to 'true' to enable MySQL GTIDs for replication binlog positioning.")
 
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration replication is stopped, and tables are swapped and immediately swap-revert. Replication remains stopped and you can compare the two tables for building trust")

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -80,6 +80,7 @@ func main() {
 	flag.BoolVar(&migrationContext.AliyunRDS, "aliyun-rds", false, "set to 'true' when you execute on Aliyun RDS.")
 	flag.BoolVar(&migrationContext.GoogleCloudPlatform, "gcp", false, "set to 'true' when you execute on a 1st generation Google Cloud Platform (GCP).")
 	flag.BoolVar(&migrationContext.AzureMySQL, "azure", false, "set to 'true' when you execute on Azure Database on MySQL.")
+	flag.BoolVar(&migrationContext.UseGTID, "gtid", false, "set to 'true' to use MySQL GTIDs for binlog positioning")
 
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration replication is stopped, and tables are swapped and immediately swap-revert. Replication remains stopped and you can compare the two tables for building trust")

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -322,10 +322,21 @@ func (this *Inspector) applyBinlogFormat() error {
 
 // validateBinlogs checks that binary log configuration is good to go
 func (this *Inspector) validateBinlogs() error {
-	query := `select @@global.log_bin, @@global.binlog_format`
+	var gtidMode string
 	var hasBinaryLogs bool
-	if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat); err != nil {
-		return err
+	if this.migrationContext.UseGTIDs {
+		query := `select @@global.log_bin, @@global.binlog_format, @@global.gtid_mode`
+		if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat, &gtidMode); err != nil {
+			return err
+		}
+		if gtidMode != "ON" {
+			return fmt.Errorf("%s:%d must have gtid_mode=ON to use GTID support", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
+		}
+	} else {
+		query := `select @@global.log_bin, @@global.binlog_format`
+		if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat); err != nil {
+			return err
+		}
 	}
 	if !hasBinaryLogs {
 		return fmt.Errorf("%s:%d must have binary logs enabled", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
@@ -348,7 +359,7 @@ func (this *Inspector) validateBinlogs() error {
 		}
 		this.migrationContext.Log.Infof("%s:%d has %s binlog_format. I will change it to ROW, and will NOT change it back, even in the event of failure.", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port, this.migrationContext.OriginalBinlogFormat)
 	}
-	query = `select @@global.binlog_row_image`
+	query := `select @@global.binlog_row_image`
 	if err := this.db.QueryRow(query).Scan(&this.migrationContext.OriginalBinlogRowImage); err != nil {
 		// Only as of 5.6. We wish to support 5.5 as well
 		this.migrationContext.OriginalBinlogRowImage = "FULL"

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -322,9 +322,9 @@ func (this *Inspector) applyBinlogFormat() error {
 
 // validateBinlogs checks that binary log configuration is good to go
 func (this *Inspector) validateBinlogs() error {
-	var gtidMode string
 	var hasBinaryLogs bool
 	if this.migrationContext.UseGTIDs {
+		var gtidMode string
 		query := `select @@global.log_bin, @@global.binlog_format, @@global.gtid_mode`
 		if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat, &gtidMode); err != nil {
 			return err

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -62,7 +62,7 @@ func (this *Inspector) InitDBConnections() (err error) {
 	if err := this.validateGrants(); err != nil {
 		return err
 	}
-	if err := this.validateBinlogs(); err != nil {
+	if err := this.validateBinlogsAndGTID(); err != nil {
 		return err
 	}
 	if err := this.applyBinlogFormat(); err != nil {
@@ -320,8 +320,8 @@ func (this *Inspector) applyBinlogFormat() error {
 	return nil
 }
 
-// validateBinlogs checks that binary log configuration is good to go
-func (this *Inspector) validateBinlogs() error {
+// validateBinlogsAndGTID checks that binary log and optional GTID configuration is good to go
+func (this *Inspector) validateBinlogsAndGTID() error {
 	var hasBinaryLogs bool
 	if this.migrationContext.UseGTIDs {
 		var gtidMode, enforceGtidConsistency string

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -329,11 +329,8 @@ func (this *Inspector) validateBinlogsAndGTID() error {
 		if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat, &gtidMode, &enforceGtidConsistency); err != nil {
 			return err
 		}
-		if gtidMode != "ON" {
-			return fmt.Errorf("%s:%d must have gtid_mode=ON to use GTID support", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
-		}
-		if enforceGtidConsistency != "ON" {
-			return fmt.Errorf("%s:%d must have enforce_gtid_consistency=ON to use GTID support", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
+		if gtidMode != "ON" || enforceGtidConsistency != "ON" {
+			return fmt.Errorf("%s:%d must have gtid_mode=ON and enforce_gtid_consistency=ON to use GTID support", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
 		}
 	} else {
 		query := `select @@global.log_bin, @@global.binlog_format`

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -324,13 +324,16 @@ func (this *Inspector) applyBinlogFormat() error {
 func (this *Inspector) validateBinlogs() error {
 	var hasBinaryLogs bool
 	if this.migrationContext.UseGTIDs {
-		var gtidMode string
-		query := `select @@global.log_bin, @@global.binlog_format, @@global.gtid_mode`
-		if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat, &gtidMode); err != nil {
+		var gtidMode, enforceGtidConsistency string
+		query := `select @@global.log_bin, @@global.binlog_format, @@global.gtid_mode, @@global.enforce_gtid_consistency`
+		if err := this.db.QueryRow(query).Scan(&hasBinaryLogs, &this.migrationContext.OriginalBinlogFormat, &gtidMode, &enforceGtidConsistency); err != nil {
 			return err
 		}
 		if gtidMode != "ON" {
 			return fmt.Errorf("%s:%d must have gtid_mode=ON to use GTID support", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
+		}
+		if enforceGtidConsistency != "ON" {
+			return fmt.Errorf("%s:%d must have enforce_gtid_consistency=ON to use GTID support", this.connectionConfig.Key.Hostname, this.connectionConfig.Key.Port)
 		}
 	} else {
 		query := `select @@global.log_bin, @@global.binlog_format`

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -150,9 +150,9 @@ func (this *EventsStreamer) readCurrentBinlogCoordinates() error {
 			LogFile: m.GetString("File"),
 			LogPos:  m.GetInt64("Position"),
 		}
-		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" {
+		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" && this.migrationContext.UseGTID {
 			var err error
-			this.initialBinlogCoordinates.ExecutedGTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
+			this.initialBinlogCoordinates.GTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
 			if err != nil {
 				return err
 			}

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/github/gh-ost/go/mysql"
 
 	"github.com/outbrain/golib/sqlutils"
+	gomysql "github.com/siddontang/go-mysql/mysql"
 )
 
 type BinlogEventListener struct {
@@ -148,6 +149,13 @@ func (this *EventsStreamer) readCurrentBinlogCoordinates() error {
 		this.initialBinlogCoordinates = &mysql.BinlogCoordinates{
 			LogFile: m.GetString("File"),
 			LogPos:  m.GetInt64("Position"),
+		}
+		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" {
+			var err error
+			this.initialBinlogCoordinates.ExecutedGTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
+			if err != nil {
+				return err
+			}
 		}
 		foundMasterStatus = true
 

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -150,7 +150,7 @@ func (this *EventsStreamer) readCurrentBinlogCoordinates() error {
 			LogFile: m.GetString("File"),
 			LogPos:  m.GetInt64("Position"),
 		}
-		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" && this.migrationContext.UseGTID {
+		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" && this.migrationContext.UseGTIDs {
 			var err error
 			this.initialBinlogCoordinates.GTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
 			if err != nil {

--- a/go/mysql/binlog.go
+++ b/go/mysql/binlog.go
@@ -28,7 +28,7 @@ const (
 	RelayLog
 )
 
-// BinlogCoordinates described binary log coordinates in the form of log file & log position.
+// BinlogCoordinates described binary log coordinates in the form of log file & log position or GTID set.
 type BinlogCoordinates struct {
 	ExecutedGTIDSet gomysql.GTIDSet
 	LogFile         string

--- a/go/mysql/binlog.go
+++ b/go/mysql/binlog.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	gomysql "github.com/siddontang/go-mysql/mysql"
 )
 
 var detachPattern *regexp.Regexp
@@ -28,9 +30,10 @@ const (
 
 // BinlogCoordinates described binary log coordinates in the form of log file & log position.
 type BinlogCoordinates struct {
-	LogFile string
-	LogPos  int64
-	Type    BinlogType
+	ExecutedGTIDSet gomysql.GTIDSet
+	LogFile         string
+	LogPos          int64
+	Type            BinlogType
 }
 
 // ParseInstanceKey will parse an InstanceKey from a string representation such as 127.0.0.1:3306

--- a/go/mysql/binlog.go
+++ b/go/mysql/binlog.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015 Shlomi Noach, courtesy Booking.com
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -28,12 +28,12 @@ const (
 	RelayLog
 )
 
-// BinlogCoordinates described binary log coordinates in the form of log file & log position or GTID set.
+// BinlogCoordinates described binary log coordinates in the form of a GTID set and/or log file & log position.
 type BinlogCoordinates struct {
-	ExecutedGTIDSet gomysql.GTIDSet
-	LogFile         string
-	LogPos          int64
-	Type            BinlogType
+	GTIDSet gomysql.GTIDSet
+	LogFile string
+	LogPos  int64
+	Type    BinlogType
 }
 
 // ParseInstanceKey will parse an InstanceKey from a string representation such as 127.0.0.1:3306
@@ -52,6 +52,10 @@ func ParseBinlogCoordinates(logFileLogPos string) (*BinlogCoordinates, error) {
 
 // DisplayString returns a user-friendly string representation of these coordinates
 func (this *BinlogCoordinates) DisplayString() string {
+	if this.GTIDSet != nil {
+		return this.GTIDSet.String()
+
+	}
 	return fmt.Sprintf("%s:%d", this.LogFile, this.LogPos)
 }
 

--- a/go/mysql/binlog.go
+++ b/go/mysql/binlog.go
@@ -54,7 +54,6 @@ func ParseBinlogCoordinates(logFileLogPos string) (*BinlogCoordinates, error) {
 func (this *BinlogCoordinates) DisplayString() string {
 	if this.GTIDSet != nil {
 		return this.GTIDSet.String()
-
 	}
 	return fmt.Sprintf("%s:%d", this.LogFile, this.LogPos)
 }

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/sqlutils"
+	gomysql "github.com/siddontang/go-mysql/mysql"
 )
 
 const MaxTableNameLength = 64
@@ -160,6 +161,12 @@ func GetSelfBinlogCoordinates(db *gosql.DB) (selfBinlogCoordinates *BinlogCoordi
 		selfBinlogCoordinates = &BinlogCoordinates{
 			LogFile: m.GetString("File"),
 			LogPos:  m.GetInt64("Position"),
+		}
+		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" {
+			selfBinlogCoordinates.ExecutedGTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -163,7 +163,7 @@ func GetSelfBinlogCoordinates(db *gosql.DB) (selfBinlogCoordinates *BinlogCoordi
 			LogPos:  m.GetInt64("Position"),
 		}
 		if execGtidSet := m.GetString("Executed_Gtid_Set"); execGtidSet != "" {
-			selfBinlogCoordinates.ExecutedGTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
+			selfBinlogCoordinates.GTIDSet, err = gomysql.ParseMysqlGTIDSet(execGtidSet)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

This PR adds support for [MySQL GTIDs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-concepts.html) for replication binlog positioning

This new support is enabled using the flag `-gtid` and it requires that `gtid_mode=ON` and `enforce_gtid_consitency=ON` is set

**NOTE: after I get some feedback on the approach and have proven it works I will add some unit testing**

cc @shlomi-noach 

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [] `script/cibuild` returns with no formatting errors, build errors or unit test errors.