### PR TITLE
Add 'applier' and 'inspector' commands to server

### DIFF
--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -18,6 +18,8 @@ Both interfaces may serve at the same time. Both respond to simple text command,
 - `status`: returns a detailed status summary of migration progress and configuration
 - `sup`: returns a brief status summary of migration progress
 - `coordinates`: returns recent (though not exactly up to date) binary log coordinates of the inspected server
+- `applier`: returns the hostname of the applier
+- `inspector`: returns the hostname of the inspector
 - `chunk-size=<newsize>`: modify the `chunk-size`; applies on next running copy-iteration
 - `dml-batch-size=<newsize>`: modify the `dml-batch-size`; applies on next applying of binary log events
 - `max-lag-millis=<max-lag>`: modify the maximum replication lag threshold (milliseconds, minimum value is `100`, i.e. `0.1` second)

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -180,10 +180,10 @@ help                                 # This message
 			return NoPrintStatusRule, fmt.Errorf("coordinates are read-only")
 		}
 	case "applier":
-		fmt.Fprintln(writer, this.migrationContext.GetApplierHostname())
+		fmt.Fprintf(writer, "Hostname: %s\n", this.migrationContext.GetApplierHostname())
 		return NoPrintStatusRule, nil
 	case "inspector":
-		fmt.Fprintln(writer, this.migrationContext.GetInspectorHostname())
+		fmt.Fprintf(writer, "Hostname: %s\n", this.migrationContext.GetInspectorHostname())
 		return NoPrintStatusRule, nil
 	case "chunk-size":
 		{

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -147,7 +147,7 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 status                               # Print a detailed status message
 sup                                  # Print a short status message
 coordinates                          # Print the currently inspected coordinates
-hosts                                # Print the list of hosts used to perform the migration (hostname, applier and migrator)
+hosts                                # Print the list of hosts used to perform the migration (hostname, applier and inspector)
 chunk-size=<newsize>                 # Set a new chunk-size
 dml-batch-size=<newsize>             # Set a new dml-batch-size
 nice-ratio=<ratio>                   # Set a new nice-ratio, immediate sleep after each row-copy operation, float (examples: 0 is aggressive, 0.7 adds 70% runtime, 1.0 doubles runtime, 2.0 triples runtime, ...)

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -180,8 +180,8 @@ help                                 # This message
 		}
 	case "hosts":
 		fmt.Fprintf(writer, "Hostname: %s, Applier: %s, Inspector: %s\n",
-			this.migrationContext.GetApplierHostname(),
 			this.migrationContext.Hostname,
+			this.migrationContext.GetApplierHostname(),
 			this.migrationContext.GetInspectorHostname(),
 		)
 		return NoPrintStatusRule, nil

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 GitHub Inc.
+   Copyright 2021 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -146,7 +146,8 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 			fmt.Fprint(writer, `available commands:
 status                               # Print a detailed status message
 sup                                  # Print a short status message
-coordinates													 # Print the currently inspected coordinates
+coordinates                          # Print the currently inspected coordinates
+hosts                                # Print the list of hosts used to perform the migration (hostname, applier and migrator)
 chunk-size=<newsize>                 # Set a new chunk-size
 dml-batch-size=<newsize>             # Set a new dml-batch-size
 nice-ratio=<ratio>                   # Set a new nice-ratio, immediate sleep after each row-copy operation, float (examples: 0 is aggressive, 0.7 adds 70% runtime, 1.0 doubles runtime, 2.0 triples runtime, ...)
@@ -177,6 +178,16 @@ help                                 # This message
 			}
 			return NoPrintStatusRule, fmt.Errorf("coordinates are read-only")
 		}
+	case "hosts":
+		fields := map[string]interface{}{
+			"Applier":   this.migrationContext.GetApplierHostname(),
+			"Hostname":  this.migrationContext.Hostname,
+			"Inspector": this.migrationContext.GetInspectorHostname(),
+		}
+		for key, val := range fields {
+			fmt.Fprintf(writer, "%s: %v", key, val)
+		}
+		return NoPrintStatusRule, nil
 	case "chunk-size":
 		{
 			if argIsQuestion {

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -147,7 +147,8 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 status                               # Print a detailed status message
 sup                                  # Print a short status message
 coordinates                          # Print the currently inspected coordinates
-hosts                                # Print the list of hosts used to perform the migration (hostname, applier and inspector)
+applier                              # Print the hostname of the applier
+inspector                            # Print the hostname of the inspector
 chunk-size=<newsize>                 # Set a new chunk-size
 dml-batch-size=<newsize>             # Set a new dml-batch-size
 nice-ratio=<ratio>                   # Set a new nice-ratio, immediate sleep after each row-copy operation, float (examples: 0 is aggressive, 0.7 adds 70% runtime, 1.0 doubles runtime, 2.0 triples runtime, ...)
@@ -178,12 +179,11 @@ help                                 # This message
 			}
 			return NoPrintStatusRule, fmt.Errorf("coordinates are read-only")
 		}
-	case "hosts":
-		fmt.Fprintf(writer, "Hostname: %s, Applier: %s, Inspector: %s\n",
-			this.migrationContext.Hostname,
-			this.migrationContext.GetApplierHostname(),
-			this.migrationContext.GetInspectorHostname(),
-		)
+	case "applier":
+		fmt.Fprintln(writer, this.migrationContext.GetApplierHostname())
+		return NoPrintStatusRule, nil
+	case "inspector":
+		fmt.Fprintln(writer, this.migrationContext.GetInspectorHostname())
 		return NoPrintStatusRule, nil
 	case "chunk-size":
 		{

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -180,10 +180,20 @@ help                                 # This message
 			return NoPrintStatusRule, fmt.Errorf("coordinates are read-only")
 		}
 	case "applier":
-		fmt.Fprintf(writer, "Hostname: %s\n", this.migrationContext.GetApplierHostname())
+		if this.migrationContext.ApplierConnectionConfig != nil && this.migrationContext.ApplierConnectionConfig.ImpliedKey != nil {
+			fmt.Fprintf(writer, "Host: %s, Version: %s\n",
+				this.migrationContext.ApplierConnectionConfig.ImpliedKey.String(),
+				this.migrationContext.ApplierMySQLVersion,
+			)
+		}
 		return NoPrintStatusRule, nil
 	case "inspector":
-		fmt.Fprintf(writer, "Hostname: %s\n", this.migrationContext.GetInspectorHostname())
+		if this.migrationContext.InspectorConnectionConfig != nil && this.migrationContext.InspectorConnectionConfig.ImpliedKey != nil {
+			fmt.Fprintf(writer, "Host: %s, Version: %s\n",
+				this.migrationContext.InspectorConnectionConfig.ImpliedKey.String(),
+				this.migrationContext.InspectorMySQLVersion,
+			)
+		}
 		return NoPrintStatusRule, nil
 	case "chunk-size":
 		{

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -179,14 +179,11 @@ help                                 # This message
 			return NoPrintStatusRule, fmt.Errorf("coordinates are read-only")
 		}
 	case "hosts":
-		fields := map[string]interface{}{
-			"Applier":   this.migrationContext.GetApplierHostname(),
-			"Hostname":  this.migrationContext.Hostname,
-			"Inspector": this.migrationContext.GetInspectorHostname(),
-		}
-		for key, val := range fields {
-			fmt.Fprintf(writer, "%s: %v", key, val)
-		}
+		fmt.Fprintf(writer, "Hostname: %s, Applier: %s, Inspector: %s\n",
+			this.migrationContext.GetApplierHostname(),
+			this.migrationContext.Hostname,
+			this.migrationContext.GetInspectorHostname(),
+		)
 		return NoPrintStatusRule, nil
 	case "chunk-size":
 		{


### PR DESCRIPTION
### Description

This PR introduces two new commands for the unix-socket/TCP server:
1. `applier` - list the MySQL hostname of the applier
1. `inspector` - list the MySQL hostname of the inspector

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.

cc @gtowey / @TeeKraken / @shlomi-noach 