### PR TITLE
Use GitHub Actions CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gh-ost
 
-[![build status](https://travis-ci.org/github/gh-ost.svg)](https://travis-ci.org/github/gh-ost) [![downloads](https://img.shields.io/github/downloads/github/gh-ost/total.svg)](https://github.com/github/gh-ost/releases) [![release](https://img.shields.io/github/release/github/gh-ost.svg)](https://github.com/github/gh-ost/releases)
+[![ci](https://github.com/github/gh-ost/actions/workflows/ci.yml/badge.svg)](https://github.com/github/gh-ost/actions/workflows/ci.yml) [![replica-tests](https://github.com/github/gh-ost/actions/workflows/replica-tests.yml/badge.svg)](https://github.com/github/gh-ost/actions/workflows/replica-tests.yml) [![downloads](https://img.shields.io/github/downloads/github/gh-ost/total.svg)](https://github.com/github/gh-ost/releases) [![release](https://img.shields.io/github/release/github/gh-ost.svg)](https://github.com/github/gh-ost/releases)
 
 #### GitHub's online schema migration for MySQL <img src="doc/images/gh-ost-logo-light-160.png" align="right">
 


### PR DESCRIPTION
### Description

This PR updates the CI status badges in `README.md` to use the build status from the GitHub Actions-based CI workflows

Example:
<img width="656" alt="Screen Shot 2021-05-18 at 22 27 18" src="https://user-images.githubusercontent.com/3202797/118719040-402fa900-b828-11eb-991b-cfbe6af70b99.png">
