### PR TITLE
Set the ServerName for TLS configuration

### DIFF
--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -92,6 +92,7 @@ func (this *ConnectionConfig) UseTLS(caCertificatePath, clientCertificate, clien
 	}
 
 	this.tlsConfig = &tls.Config{
+		ServerName:         this.Key.Hostname,
 		Certificates:       certs,
 		RootCAs:            rootCertPool,
 		InsecureSkipVerify: allowInsecure,


### PR DESCRIPTION
When TLS hostname validation used for the MySQL connection, the ServerName property needs to be set so that it knows which name to validate on the certificate.

Without this option and with InsecureSkipVerify set to false, validation will error here with a fatal error otherwise:

```
FATAL tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```

I'm not sure if there's a good way to additional test this specific change, as there's not a lot of extensive tests around the TLS handling and setup methods like `UseTLS` for example. 

I think this change is also necessary to be able to complete #521. 