### PR TITLE
Add http server for pprof

### DIFF
--- a/go/base/http.go
+++ b/go/base/http.go
@@ -1,0 +1,25 @@
+package base
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/openark/golib/log"
+)
+
+// HttpConfig contains the configuration of the http server
+type HttpConfig struct {
+	ListenAddr string
+}
+
+// handleHttpPing handles a ping request
+func handleHttpPing(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "OK")
+}
+
+// NewHttpServer runs the http server
+func NewHttpServer(config HttpConfig) {
+	http.HandleFunc("/_ping", handleHttpPing)
+	log.Errore(http.ListenAndServe(config.ListenAddr, nil))
+}

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -45,6 +45,9 @@ func acceptSignals(migrationContext *base.MigrationContext) {
 
 // main is the application's entry point. It will either spawn a CLI or HTTP interfaces.
 func main() {
+	httpConfig := base.HttpConfig{}
+	flag.StringVar(&httpConfig.ListenAddr, "http-addr", "", "http server listen address (default: http server disabled)")
+
 	migrationContext := base.NewMigrationContext()
 	flag.StringVar(&migrationContext.InspectorConnectionConfig.Key.Hostname, "host", "127.0.0.1", "MySQL hostname (preferably a replica, not the master)")
 	flag.StringVar(&migrationContext.AssumeMasterHostname, "assume-master-host", "", "(optional) explicitly tell gh-ost the identity of the master. Format: some.host.com[:port] This is useful in master-master setups where you wish to pick an explicit master, or in a tungsten-replicator where gh-ost is unable to determine the master")
@@ -289,6 +292,10 @@ func main() {
 
 	log.Infof("starting gh-ost %+v", AppVersion)
 	acceptSignals(migrationContext)
+	if httpConfig.ListenAddr != "" {
+		log.Infof("starting http server at %+v", httpConfig.ListenAddr)
+		go base.NewHttpServer(httpConfig)
+	}
 
 	migrator := logic.NewMigrator(migrationContext)
 	err := migrator.Migrate()


### PR DESCRIPTION
### Description

In order to understand a performance issue with the inspector, this PR adds an http server to support [pprof profiling](https://golang.org/pkg/net/http/pprof/) of `gh-ost`

This is disabled by default and enabled by passing `--http-listen-addr 10.11.12.13:8080`

Endpoints:
- `GET /_ping` - returns `OK`
- `GET /debug/pprof` - returns [pprof profile data](https://golang.org/pkg/net/http/pprof/)

cc @shlomi-noach for any style thoughts

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
