### PR TITLE
Dummy change: testing timestamp-to-datetime CI failure

### DIFF
--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -188,7 +188,7 @@ func GetTableColumns(db *gosql.DB, databaseName, tableName string) (*sql.ColumnL
 	err := sqlutils.QueryRowsMap(db, query, func(rowMap sqlutils.RowMap) error {
 		columnName := rowMap.GetString("Field")
 		columnNames = append(columnNames, columnName)
-		if strings.Contains(rowMap.GetString("Extra"), " GENERATED") {
+		if strings.Contains(rowMap.GetString("Extra"), "GENERATED") || strings.Contains(rowMap.GetString("Extra"), "VIRTUAL") {
 			log.Debugf("%s is a generated column", columnName)
 			virtualColumnNames = append(virtualColumnNames, columnName)
 		}

--- a/localtests/timestamp-to-datetime/create.sql
+++ b/localtests/timestamp-to-datetime/create.sql
@@ -11,6 +11,7 @@ create table gh_ost_test (
   key i_idx(i)
 ) auto_increment=1;
 
+
 drop event if exists gh_ost_test;
 delimiter ;;
 create event gh_ost_test


### PR DESCRIPTION

This PR looks into https://github.com/github/gh-ost/issues/1001
There isn't any real change here. This branch was checked out from current `upstream/master` ie fro m`github/gh-ost` current `master` ref. 

The experiment is to see whether `timestamp-to-datetime` fails in this PR. If it does, then we need to backtrack the exact commit where the CI failure was introduced.

cc @timvaillancourt 