### PR TITLE
Update hook environment variable docs

### DIFF
--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -68,6 +68,7 @@ The following variables are available on all hooks:
 - `GH_OST_INSPECTED_LAG` - lag in seconds (floating point) of inspected server
 - `GH_OST_HEARTBEAT_LAG` - lag in seconds (floating point) of heartbeat
 - `GH_OST_PROGRESS` - progress pct ([0..100], floating point) of migration
+- `GH_OST_ETA_SECONDS` - estimated duration until migration finishes in seconds
 - `GH_OST_MIGRATED_HOST`
 - `GH_OST_INSPECTED_HOST`
 - `GH_OST_EXECUTING_HOST`


### PR DESCRIPTION

### Description

`GH_OST_ETA_SECONDS` is an environment variable available to gh-ost hooks, exposing the ETA for the migration in seconds. It's defined [here](https://github.com/github/gh-ost/blob/47d49c6b92c231b8dd7d5a106455ca1b859d4cb4/go/logic/hooks.go#L69).