### PR TITLE
A data-loss case occurs when chunk-key contains decimal-column #1119

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -573,6 +573,7 @@ func (this *Inspector) applyColumnTypes(databaseName, tableName string, columnsL
 				continue
 			}
 
+			column.TypeDesc = columnType
 			if strings.Contains(columnType, "unsigned") {
 				column.IsUnsigned = true
 			}
@@ -601,6 +602,9 @@ func (this *Inspector) applyColumnTypes(databaseName, tableName string, columnsL
 			}
 			if charset := m.GetString("CHARACTER_SET_NAME"); charset != "" {
 				column.Charset = charset
+			}
+			if strings.HasPrefix(columnType, "decimal") {
+				column.Type = sql.DecimalColumnType
 			}
 		}
 		return nil

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -71,9 +71,19 @@ func TestBuildEqualsComparison(t *testing.T) {
 func TestBuildEqualsPreparedComparison(t *testing.T) {
 	{
 		columns := []string{"c1", "c2"}
-		comparison, err := BuildEqualsPreparedComparison(columns)
+		cols := NewColumnList(columns)
+		comparison, err := BuildEqualsPreparedComparison(cols)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(comparison, "((`c1` = ?) and (`c2` = ?))")
+	}
+	{
+		columns := []string{"c1", "c2"}
+		cols := NewColumnList(columns)
+		cols.SetColumnType("c1", DecimalColumnType)
+		cols.SetTypeDesc("c1", "decimal(30,0)")
+		comparison, err := BuildEqualsPreparedComparison(cols)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(comparison, "((`c1` = cast(? as decimal(30,0))) and (`c2` = ?))")
 	}
 }
 
@@ -83,6 +93,14 @@ func TestBuildSetPreparedClause(t *testing.T) {
 		clause, err := BuildSetPreparedClause(columns)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(clause, "`c1`=?")
+	}
+	{
+		columns := NewColumnList([]string{"c1"})
+		columns.SetColumnType("c1", DecimalColumnType)
+		columns.SetTypeDesc("c1", "decimal(30,0)")
+		clause, err := BuildSetPreparedClause(columns)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(clause, "`c1`=cast(? as decimal(30,0))")
 	}
 	{
 		columns := NewColumnList([]string{"c1", "c2"})
@@ -435,6 +453,71 @@ func TestBuildDMLDeleteQuerySignedUnsigned(t *testing.T) {
 	}
 }
 
+func TestBuildDMLDeleteQueryDecimal(t *testing.T) {
+	databaseName := "mydb"
+	tableName := "tbl"
+	tableColumns := NewColumnList([]string{"id", "name", "rank", "position", "age"})
+	args := []interface{}{3, "testname", "first", []byte("70610020200305193000"), 23}
+	{
+		uniqueKeyColumns := NewColumnList([]string{"position"})
+		uniqueKeyColumns.SetColumnType("position", DecimalColumnType)
+		uniqueKeyColumns.SetTypeDesc("position", "decimal(30,0)")
+
+		query, uniqueKeyArgs, err := BuildDMLDeleteQuery(databaseName, tableName, tableColumns, uniqueKeyColumns, args)
+		test.S(t).ExpectNil(err)
+		expected := `
+			delete /* gh-ost mydb.tbl */
+				from
+					mydb.tbl
+				where
+					((position = cast(? as decimal(30,0))))
+		`
+		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{[]byte("70610020200305193000")}))
+	}
+	{
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKeyColumns.SetColumnType("position", DecimalColumnType)
+		uniqueKeyColumns.SetTypeDesc("position", "decimal(30,0)")
+
+		query, uniqueKeyArgs, err := BuildDMLDeleteQuery(databaseName, tableName, tableColumns, uniqueKeyColumns, args)
+		test.S(t).ExpectNil(err)
+		expected := `
+			delete /* gh-ost mydb.tbl */
+				from
+					mydb.tbl
+				where
+					((name = ?) and (position = cast(? as decimal(30,0))))
+		`
+		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{"testname", []byte("70610020200305193000")}))
+	}
+	{
+		uniqueKeyColumns := NewColumnList([]string{"position", "name"})
+		uniqueKeyColumns.SetColumnType("position", DecimalColumnType)
+		uniqueKeyColumns.SetTypeDesc("position", "decimal(30,0)")
+
+		query, uniqueKeyArgs, err := BuildDMLDeleteQuery(databaseName, tableName, tableColumns, uniqueKeyColumns, args)
+		test.S(t).ExpectNil(err)
+		expected := `
+			delete /* gh-ost mydb.tbl */
+				from
+					mydb.tbl
+				where
+					((position = cast(? as decimal(30,0))) and (name = ?))
+		`
+		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{[]byte("70610020200305193000"), "testname"}))
+	}
+	{
+		uniqueKeyColumns := NewColumnList([]string{"position", "name"})
+		args := []interface{}{"first", 17}
+
+		_, _, err := BuildDMLDeleteQuery(databaseName, tableName, tableColumns, uniqueKeyColumns, args)
+		test.S(t).ExpectNotNil(err)
+	}
+}
+
 func TestBuildDMLInsertQuery(t *testing.T) {
 	databaseName := "mydb"
 	tableName := "tbl"
@@ -532,6 +615,55 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		`
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", uint32(4294967295), 23}))
+	}
+}
+
+func TestBuildDMLInsertQueryDecimal(t *testing.T) {
+	databaseName := "mydb"
+	tableName := "tbl"
+	tableColumns := NewColumnList([]string{"id", "name", "rank", "position", "age"})
+	args := []interface{}{3, "testname", "first", []byte("70610020200305193000"), 23}
+	{
+		sharedColumns := NewColumnList([]string{"id", "name", "position", "age"})
+		sharedColumns.SetColumnType("position", DecimalColumnType)
+		sharedColumns.SetTypeDesc("position", "decimal(30,0)")
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		test.S(t).ExpectNil(err)
+		expected := `
+			replace /* gh-ost mydb.tbl */
+				into mydb.tbl
+					(id, name, position, age)
+				values
+					(?, ?, cast(? as decimal(30,0)), ?)
+		`
+		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
+		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", []byte("70610020200305193000"), 23}))
+	}
+	{
+		sharedColumns := NewColumnList([]string{"position", "name", "age", "id"})
+		sharedColumns.SetColumnType("position", DecimalColumnType)
+		sharedColumns.SetTypeDesc("position", "decimal(30,0)")
+		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		test.S(t).ExpectNil(err)
+		expected := `
+			replace /* gh-ost mydb.tbl */
+				into mydb.tbl
+					(position, name, age, id)
+				values
+					(cast(? as decimal(30,0)), ?, ?, ?)
+		`
+		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
+		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{[]byte("70610020200305193000"), "testname", 23, 3}))
+	}
+	{
+		sharedColumns := NewColumnList([]string{"position", "name", "surprise", "id"})
+		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		sharedColumns := NewColumnList([]string{})
+		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		test.S(t).ExpectNotNil(err)
 	}
 }
 
@@ -675,5 +807,34 @@ func TestBuildDMLUpdateQuerySignedUnsigned(t *testing.T) {
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", int8(-17), uint8(254)}))
 		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{uint8(253)}))
+	}
+}
+
+func TestBuildDMLUpdateQueryDecimal(t *testing.T) {
+	databaseName := "mydb"
+	tableName := "tbl"
+	tableColumns := NewColumnList([]string{"id", "name", "rank", "position", "age"})
+	valueArgs := []interface{}{3, "testname", "newval", []byte("70610020200305193000"), int8(-2)}
+	whereArgs := []interface{}{3, "testname", "findme", []byte("70610020200305193001"), 56}
+	sharedColumns := NewColumnList([]string{"id", "name", "position", "age"})
+	uniqueKeyColumns := NewColumnList([]string{"position"})
+	{
+		// set uniqueKeyColumns and sharedColumns
+		uniqueKeyColumns.SetColumnType("position", DecimalColumnType)
+		uniqueKeyColumns.SetTypeDesc("position", "decimal(30,0)")
+		sharedColumns.SetColumnType("position", DecimalColumnType)
+		sharedColumns.SetTypeDesc("position", "decimal(30,0)")
+		query, sharedArgs, uniqueKeyArgs, err := BuildDMLUpdateQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, valueArgs, whereArgs)
+		test.S(t).ExpectNil(err)
+		expected := `
+			update /* gh-ost mydb.tbl */
+			  mydb.tbl
+					set id=?, name=?, position=cast(? as decimal(30,0)), age=?
+				where
+					((position = cast(? as decimal(30,0))))
+		`
+		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
+		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", []byte("70610020200305193000"), int8(-2)}))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{[]byte("70610020200305193001")}))
 	}
 }

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -24,6 +24,7 @@ const (
 	JSONColumnType
 	FloatColumnType
 	BinaryColumnType
+	DecimalColumnType
 )
 
 const maxMediumintUnsigned int32 = 16777215
@@ -37,6 +38,7 @@ type Column struct {
 	IsUnsigned           bool
 	Charset              string
 	Type                 ColumnType
+	TypeDesc             string // for example: decimal(32,0)
 	EnumValues           string
 	timezoneConversion   *TimezoneConversion
 	enumToTextConversion bool
@@ -189,6 +191,14 @@ func (this *ColumnList) SetColumnType(columnName string, columnType ColumnType) 
 
 func (this *ColumnList) GetColumnType(columnName string) ColumnType {
 	return this.GetColumn(columnName).Type
+}
+
+func (this *ColumnList) SetTypeDesc(columnName string, desc string) {
+	this.GetColumn(columnName).TypeDesc = desc
+}
+
+func (this *ColumnList) GetTypeDesc(columnName string) string {
+	return this.GetColumn(columnName).TypeDesc
 }
 
 func (this *ColumnList) SetConvertDatetimeToTimestamp(columnName string, toTimezone string) {


### PR DESCRIPTION
## Issue

Related issue: https://github.com/github/gh-ost/issues/1119

That's is an issue, describing a data-loss case caused by decimal-type column in chunk-key.
We also describe how to reproduce the case and how to fix it.

### Description

This PR solves the bug by adding `cast` to decimal-type-column in values-stmt\set-stmt\where-stmt 
for example:  If type of column (`InstanceID` ) is `decimal(30, 0)` , the corresponding set-stmt and where-stmt as follows:
```
# where stmt in insert-select/select/delete sql
# ---- before commit----
where (((`InstanceID` > _binary'2708201202204012300000012')) and ((`InstanceID` < _binary'2708201202204062200000015') or ((`InstanceID` = _binary'2708201202204062200000015'))))

# -- after commit ----
where (((`InstanceID` > cast(_binary'2708201202204012300000012' as decimal(30, 0)))) and ((`InstanceID` < cast(_binary'2708201202204062200000015' as decimal(30, 0))) or ((`InstanceID` = cast(_binary'2708201202204062200000015' as decimal(30, 0))))))

# set stmt in update sql
# ---- before commit ----
set `InstanceID`=_binary'2708201202204062200000015'

# -- after commit ----
set `InstanceID`=cast(_binary'2708201202204062200000015' as decimal(30, 0))

# values stmt in replace-sql
# ---- before commit ----
values(_binary'2708201202204062200000015')

# -- after commit ----
values(cast(_binary'2708201202204062200000015' as decimal(30, 0)))
```
 

> In case this PR introduced Go code changes:

- [ ok ] contributed code is using same conventions as original code
- [ ok ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
