### PR TITLE
Ensure mysql rows responses are closed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,4 +9,6 @@ linters:
   enable:
     - gosimple
     - govet
+    - rowserrcheck
+    - sqlclosecheck
     - unused

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -382,10 +382,13 @@ func (this *Applier) ReadMigrationMinValues(uniqueKey *sql.UniqueKey) error {
 	if err != nil {
 		return err
 	}
+
 	rows, err := this.db.Query(query)
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		this.migrationContext.MigrationRangeMinValues = sql.NewColumnValues(uniqueKey.Len())
 		if err = rows.Scan(this.migrationContext.MigrationRangeMinValues.ValuesPointers...); err != nil {
@@ -394,8 +397,7 @@ func (this *Applier) ReadMigrationMinValues(uniqueKey *sql.UniqueKey) error {
 	}
 	this.migrationContext.Log.Infof("Migration min values: [%s]", this.migrationContext.MigrationRangeMinValues)
 
-	err = rows.Err()
-	return err
+	return rows.Err()
 }
 
 // ReadMigrationMaxValues returns the maximum values to be iterated on rowcopy
@@ -405,10 +407,13 @@ func (this *Applier) ReadMigrationMaxValues(uniqueKey *sql.UniqueKey) error {
 	if err != nil {
 		return err
 	}
+
 	rows, err := this.db.Query(query)
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		this.migrationContext.MigrationRangeMaxValues = sql.NewColumnValues(uniqueKey.Len())
 		if err = rows.Scan(this.migrationContext.MigrationRangeMaxValues.ValuesPointers...); err != nil {
@@ -417,8 +422,7 @@ func (this *Applier) ReadMigrationMaxValues(uniqueKey *sql.UniqueKey) error {
 	}
 	this.migrationContext.Log.Infof("Migration max values: [%s]", this.migrationContext.MigrationRangeMaxValues)
 
-	err = rows.Err()
-	return err
+	return rows.Err()
 }
 
 // ReadMigrationRangeValues reads min/max values that will be used for rowcopy
@@ -459,10 +463,13 @@ func (this *Applier) CalculateNextIterationRangeEndValues() (hasFurtherRange boo
 		if err != nil {
 			return hasFurtherRange, err
 		}
+
 		rows, err := this.db.Query(query, explodedArgs...)
 		if err != nil {
 			return hasFurtherRange, err
 		}
+		defer rows.Close()
+
 		iterationRangeMaxValues := sql.NewColumnValues(this.migrationContext.UniqueKey.Len())
 		for rows.Next() {
 			if err = rows.Scan(iterationRangeMaxValues.ValuesPointers...); err != nil {


### PR DESCRIPTION
### Description

This PR ensures the rows-responses from the MySQL driver are closed by using a `defer rows.Close()`, in order to follow [`database/sql` best practices](https://orangematter.solarwinds.com/2017/03/23/common-pitfalls-when-using-database-sql-in-go/)

Also, these linters are introduced to ensure we don't have this problem again:
1. [`rowserrcheck`](https://github.com/jingyugao/rowserrcheck)
    > checks whether Err of rows is checked successfully
2. [`sqlclosecheck`](https://github.com/ryanrolds/sqlclosecheck)
    > Checks that sql.Rows and sql.Stmt are closed

This PR resolves these linter errors:
    <img width="560" alt="Screen Shot 2022-06-01 at 01 25 56" src="https://user-images.githubusercontent.com/3202797/171300901-a4a5e18a-0dfc-4b84-852a-6cfbbc355a02.png">

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
