### PR TITLE
Remove unused code in `go/mysql/binlog.go`

### DIFF
--- a/go/mysql/binlog.go
+++ b/go/mysql/binlog.go
@@ -1,5 +1,6 @@
 /*
    Copyright 2015 Shlomi Noach, courtesy Booking.com
+   Copyright 2022 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -7,29 +8,14 @@ package mysql
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
-)
-
-var detachPattern *regexp.Regexp
-
-func init() {
-	detachPattern, _ = regexp.Compile(`//([^/:]+):([\d]+)`) // e.g. `//binlog.01234:567890`
-}
-
-type BinlogType int
-
-const (
-	BinaryLog BinlogType = iota
-	RelayLog
 )
 
 // BinlogCoordinates described binary log coordinates in the form of log file & log position.
 type BinlogCoordinates struct {
 	LogFile string
 	LogPos  int64
-	Type    BinlogType
 }
 
 // ParseInstanceKey will parse an InstanceKey from a string representation such as 127.0.0.1:3306
@@ -61,7 +47,7 @@ func (this *BinlogCoordinates) Equals(other *BinlogCoordinates) bool {
 	if other == nil {
 		return false
 	}
-	return this.LogFile == other.LogFile && this.LogPos == other.LogPos && this.Type == other.Type
+	return this.LogFile == other.LogFile && this.LogPos == other.LogPos
 }
 
 // IsEmpty returns true if the log file is empty, unnamed
@@ -86,5 +72,5 @@ func (this *BinlogCoordinates) SmallerThanOrEquals(other *BinlogCoordinates) boo
 	if this.SmallerThan(other) {
 		return true
 	}
-	return this.LogFile == other.LogFile && this.LogPos == other.LogPos // No Type comparison
+	return this.LogFile == other.LogFile && this.LogPos == other.LogPos
 }

--- a/go/mysql/binlog.go
+++ b/go/mysql/binlog.go
@@ -6,7 +6,6 @@
 package mysql
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -88,75 +87,4 @@ func (this *BinlogCoordinates) SmallerThanOrEquals(other *BinlogCoordinates) boo
 		return true
 	}
 	return this.LogFile == other.LogFile && this.LogPos == other.LogPos // No Type comparison
-}
-
-// FileSmallerThan returns true if this coordinate's file is strictly smaller than the other's.
-func (this *BinlogCoordinates) FileSmallerThan(other *BinlogCoordinates) bool {
-	return this.LogFile < other.LogFile
-}
-
-// FileNumberDistance returns the numeric distance between this coordinate's file number and the other's.
-// Effectively it means "how many rotates/FLUSHes would make these coordinates's file reach the other's"
-func (this *BinlogCoordinates) FileNumberDistance(other *BinlogCoordinates) int {
-	thisNumber, _ := this.FileNumber()
-	otherNumber, _ := other.FileNumber()
-	return otherNumber - thisNumber
-}
-
-// FileNumber returns the numeric value of the file, and the length in characters representing the number in the filename.
-// Example: FileNumber() of mysqld.log.000789 is (789, 6)
-func (this *BinlogCoordinates) FileNumber() (int, int) {
-	tokens := strings.Split(this.LogFile, ".")
-	numPart := tokens[len(tokens)-1]
-	numLen := len(numPart)
-	fileNum, err := strconv.Atoi(numPart)
-	if err != nil {
-		return 0, 0
-	}
-	return fileNum, numLen
-}
-
-// PreviousFileCoordinatesBy guesses the filename of the previous binlog/relaylog, by given offset (number of files back)
-func (this *BinlogCoordinates) PreviousFileCoordinatesBy(offset int) (BinlogCoordinates, error) {
-	result := BinlogCoordinates{LogPos: 0, Type: this.Type}
-
-	fileNum, numLen := this.FileNumber()
-	if fileNum == 0 {
-		return result, errors.New("Log file number is zero, cannot detect previous file")
-	}
-	newNumStr := fmt.Sprintf("%d", (fileNum - offset))
-	newNumStr = strings.Repeat("0", numLen-len(newNumStr)) + newNumStr
-
-	tokens := strings.Split(this.LogFile, ".")
-	tokens[len(tokens)-1] = newNumStr
-	result.LogFile = strings.Join(tokens, ".")
-	return result, nil
-}
-
-// PreviousFileCoordinates guesses the filename of the previous binlog/relaylog
-func (this *BinlogCoordinates) PreviousFileCoordinates() (BinlogCoordinates, error) {
-	return this.PreviousFileCoordinatesBy(1)
-}
-
-// PreviousFileCoordinates guesses the filename of the previous binlog/relaylog
-func (this *BinlogCoordinates) NextFileCoordinates() (BinlogCoordinates, error) {
-	result := BinlogCoordinates{LogPos: 0, Type: this.Type}
-
-	fileNum, numLen := this.FileNumber()
-	newNumStr := fmt.Sprintf("%d", (fileNum + 1))
-	newNumStr = strings.Repeat("0", numLen-len(newNumStr)) + newNumStr
-
-	tokens := strings.Split(this.LogFile, ".")
-	tokens[len(tokens)-1] = newNumStr
-	result.LogFile = strings.Join(tokens, ".")
-	return result, nil
-}
-
-// FileSmallerThan returns true if this coordinate's file is strictly smaller than the other's.
-func (this *BinlogCoordinates) DetachedCoordinates() (isDetached bool, detachedLogFile string, detachedLogPos string) {
-	detachedCoordinatesSubmatch := detachPattern.FindStringSubmatch(this.LogFile)
-	if len(detachedCoordinatesSubmatch) == 0 {
-		return false, "", ""
-	}
-	return true, detachedCoordinatesSubmatch[1], detachedCoordinatesSubmatch[2]
 }

--- a/go/mysql/binlog_test.go
+++ b/go/mysql/binlog_test.go
@@ -37,57 +37,6 @@ func TestBinlogCoordinates(t *testing.T) {
 	test.S(t).ExpectTrue(c1.SmallerThanOrEquals(&c3))
 }
 
-func TestBinlogNext(t *testing.T) {
-	c1 := BinlogCoordinates{LogFile: "mysql-bin.00017", LogPos: 104}
-	cres, err := c1.NextFileCoordinates()
-
-	test.S(t).ExpectNil(err)
-	test.S(t).ExpectEquals(c1.Type, cres.Type)
-	test.S(t).ExpectEquals(cres.LogFile, "mysql-bin.00018")
-
-	c2 := BinlogCoordinates{LogFile: "mysql-bin.00099", LogPos: 104}
-	cres, err = c2.NextFileCoordinates()
-
-	test.S(t).ExpectNil(err)
-	test.S(t).ExpectEquals(c1.Type, cres.Type)
-	test.S(t).ExpectEquals(cres.LogFile, "mysql-bin.00100")
-
-	c3 := BinlogCoordinates{LogFile: "mysql.00.prod.com.00099", LogPos: 104}
-	cres, err = c3.NextFileCoordinates()
-
-	test.S(t).ExpectNil(err)
-	test.S(t).ExpectEquals(c1.Type, cres.Type)
-	test.S(t).ExpectEquals(cres.LogFile, "mysql.00.prod.com.00100")
-}
-
-func TestBinlogPrevious(t *testing.T) {
-	c1 := BinlogCoordinates{LogFile: "mysql-bin.00017", LogPos: 104}
-	cres, err := c1.PreviousFileCoordinates()
-
-	test.S(t).ExpectNil(err)
-	test.S(t).ExpectEquals(c1.Type, cres.Type)
-	test.S(t).ExpectEquals(cres.LogFile, "mysql-bin.00016")
-
-	c2 := BinlogCoordinates{LogFile: "mysql-bin.00100", LogPos: 104}
-	cres, err = c2.PreviousFileCoordinates()
-
-	test.S(t).ExpectNil(err)
-	test.S(t).ExpectEquals(c1.Type, cres.Type)
-	test.S(t).ExpectEquals(cres.LogFile, "mysql-bin.00099")
-
-	c3 := BinlogCoordinates{LogFile: "mysql.00.prod.com.00100", LogPos: 104}
-	cres, err = c3.PreviousFileCoordinates()
-
-	test.S(t).ExpectNil(err)
-	test.S(t).ExpectEquals(c1.Type, cres.Type)
-	test.S(t).ExpectEquals(cres.LogFile, "mysql.00.prod.com.00099")
-
-	c4 := BinlogCoordinates{LogFile: "mysql.00.prod.com.00000", LogPos: 104}
-	_, err = c4.PreviousFileCoordinates()
-
-	test.S(t).ExpectNotNil(err)
-}
-
 func TestBinlogCoordinatesAsKey(t *testing.T) {
 	m := make(map[BinlogCoordinates]bool)
 
@@ -102,21 +51,4 @@ func TestBinlogCoordinatesAsKey(t *testing.T) {
 	m[c4] = true
 
 	test.S(t).ExpectEquals(len(m), 3)
-}
-
-func TestBinlogFileNumber(t *testing.T) {
-	c1 := BinlogCoordinates{LogFile: "mysql-bin.00017", LogPos: 104}
-	c2 := BinlogCoordinates{LogFile: "mysql-bin.00022", LogPos: 104}
-
-	test.S(t).ExpectEquals(c1.FileNumberDistance(&c1), 0)
-	test.S(t).ExpectEquals(c1.FileNumberDistance(&c2), 5)
-	test.S(t).ExpectEquals(c2.FileNumberDistance(&c1), -5)
-}
-
-func TestBinlogFileNumberDistance(t *testing.T) {
-	c1 := BinlogCoordinates{LogFile: "mysql-bin.00017", LogPos: 104}
-	fileNum, numLen := c1.FileNumber()
-
-	test.S(t).ExpectEquals(fileNum, 17)
-	test.S(t).ExpectEquals(numLen, 5)
 }


### PR DESCRIPTION
### Description

This PR removes unused code in `go/mysql/binlog.go` to simplify maintenance a future move of `BinlogCoordinates` to an interface to facilitate adding GTID support to `gh-ost`

Details:
- Remove unused funcs (and unit tests):
    - `.FileSmallerThan()`
    - `.FileNumberDistance()`
    - `.FileNumber()`
    - `.PreviousFileCoordinatesBy()`
    - `.PreviousFileCoordinates()`
    - `.NextFileCoordinates()`
    - `.DetachedCoordinates()`
- Remove unused `Type` field from `BinlogCoordinates` struct 

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
