### PR TITLE
Fix `integer divide by zero` panic in migrator

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1006,7 +1006,8 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	w := io.MultiWriter(writers...)
 	fmt.Fprintln(w, status)
 
-	if elapsedSeconds%this.migrationContext.HooksStatusIntervalSec == 0 {
+	hooksStatusIntervalSec := this.migrationContext.HooksStatusIntervalSec
+	if hooksStatusIntervalSec > 0 && elapsedSeconds%hooksStatusIntervalSec == 0 {
 		this.hooksExecutor.onStatus(status)
 	}
 }


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/1117

### Description

This PR resolves [an `integer divide by zero` panic](https://github.com/github/gh-ost/1117) when `migrationContext.HooksStatusIntervalSec` is zero. After this PR, no status will be printed when the interval is set to zero

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
