### PR TITLE
`golang-ci`: enable/fix `staticcheck` lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,7 @@ run:
 linters:
   disable:
     - errcheck
-    - staticcheck
   enable:
-    - gosimple
-    - govet
     - noctx
     - rowserrcheck
     - sqlclosecheck

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -846,30 +846,30 @@ func (this *MigrationContext) ReadConfigFile() error {
 		return err
 	}
 
-	if cfg.Section("client").Haskey("user") {
+	if cfg.Section("client").HasKey("user") {
 		this.config.Client.User = cfg.Section("client").Key("user").String()
 	}
 
-	if cfg.Section("client").Haskey("password") {
+	if cfg.Section("client").HasKey("password") {
 		this.config.Client.Password = cfg.Section("client").Key("password").String()
 	}
 
-	if cfg.Section("osc").Haskey("chunk_size") {
+	if cfg.Section("osc").HasKey("chunk_size") {
 		this.config.Osc.Chunk_Size, err = cfg.Section("osc").Key("chunk_size").Int64()
 		if err != nil {
 			return fmt.Errorf("Unable to read osc chunk size: %s", err.Error())
 		}
 	}
 
-	if cfg.Section("osc").Haskey("max_load") {
+	if cfg.Section("osc").HasKey("max_load") {
 		this.config.Osc.Max_Load = cfg.Section("osc").Key("max_load").String()
 	}
 
-	if cfg.Section("osc").Haskey("replication_lag_query") {
+	if cfg.Section("osc").HasKey("replication_lag_query") {
 		this.config.Osc.Replication_Lag_Query = cfg.Section("osc").Key("replication_lag_query").String()
 	}
 
-	if cfg.Section("osc").Haskey("max_lag_millis") {
+	if cfg.Section("osc").HasKey("max_lag_millis") {
 		this.config.Osc.Max_Lag_Millis, err = cfg.Section("osc").Key("max_lag_millis").Int64()
 		if err != nil {
 			return fmt.Errorf("Unable to read max lag millis: %s", err.Error())

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -69,7 +69,7 @@ func ValidateConnection(db *gosql.DB, connectionConfig *mysql.ConnectionConfig, 
 		return "", err
 	}
 	extraPortQuery := `select @@global.extra_port`
-	if err := db.QueryRow(extraPortQuery).Scan(&extraPort); err != nil {
+	if err := db.QueryRow(extraPortQuery).Scan(&extraPort); err != nil { // nolint:staticcheck
 		// swallow this error. not all servers support extra_port
 	}
 	// AliyunRDS set users port to "NULL", replace it by gh-ost param

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -19,7 +19,8 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/openark/golib/log"
 
-	"golang.org/x/crypto/ssh/terminal"
+	// TODO: move to golang.org/x/term
+	"golang.org/x/crypto/ssh/terminal" // nolint:staticcheck
 )
 
 var AppVersion string

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 GitHub Inc.
+   Copyright 2022 GitHub Inc.
 	 See https://github.com/github/gh-ost/blob/master/LICENSE
 */
 
@@ -71,7 +71,6 @@ func NewApplier(migrationContext *base.MigrationContext) *Applier {
 }
 
 func (this *Applier) InitDBConnections() (err error) {
-
 	applierUri := this.connectionConfig.GetDBUri(this.migrationContext.DatabaseName)
 	if this.db, _, err = mysql.GetDB(this.migrationContext.Uuid, applierUri); err != nil {
 		return err
@@ -344,8 +343,10 @@ func (this *Applier) InitiateHeartbeat() {
 	}
 	injectHeartbeat()
 
-	heartbeatTick := time.Tick(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
-	for range heartbeatTick {
+	ticker := time.NewTicker(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		<-ticker.C
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -345,8 +345,7 @@ func (this *Applier) InitiateHeartbeat() {
 
 	ticker := time.NewTicker(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
 	defer ticker.Stop()
-	for {
-		<-ticker.C
+	for range ticker.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -811,7 +811,7 @@ func (this *Migrator) initiateInspector() (err error) {
 // initiateStatus sets and activates the printStatus() ticker
 func (this *Migrator) initiateStatus() {
 	this.printStatus(ForcePrintStatusAndHintRule)
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
 		<-ticker.C
@@ -1052,7 +1052,7 @@ func (this *Migrator) initiateStreaming() error {
 	}()
 
 	go func() {
-		ticker := time.NewTicker(1 * time.Second)
+		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 		for {
 			<-ticker.C

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -813,8 +813,7 @@ func (this *Migrator) initiateStatus() {
 	this.printStatus(ForcePrintStatusAndHintRule)
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	for {
-		<-ticker.C
+	for range ticker.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}
@@ -1054,8 +1053,7 @@ func (this *Migrator) initiateStreaming() error {
 	go func() {
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
-		for {
-			<-ticker.C
+		for range ticker.C {
 			if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 				return
 			}

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -134,7 +134,7 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 		}
 	}
 	argIsQuestion := (arg == "?")
-	throttleHint := "# Note: you may only throttle for as long as your binary logs are not purged\n"
+	throttleHint := "# Note: you may only throttle for as long as your binary logs are not purged"
 
 	if err := this.hooksExecutor.onInteractiveCommand(command); err != nil {
 		return NoPrintStatusRule, err
@@ -282,7 +282,7 @@ help                                 # This message
 				return NoPrintStatusRule, nil
 			}
 			this.migrationContext.SetThrottleQuery(arg)
-			fmt.Fprintf(writer, throttleHint)
+			fmt.Fprintln(writer, throttleHint)
 			return ForcePrintStatusAndHintRule, nil
 		}
 	case "throttle-http":
@@ -292,7 +292,7 @@ help                                 # This message
 				return NoPrintStatusRule, nil
 			}
 			this.migrationContext.SetThrottleHTTP(arg)
-			fmt.Fprintf(writer, throttleHint)
+			fmt.Fprintln(writer, throttleHint)
 			return ForcePrintStatusAndHintRule, nil
 		}
 	case "throttle-control-replicas":
@@ -315,7 +315,7 @@ help                                 # This message
 				return NoPrintStatusRule, err
 			}
 			atomic.StoreInt64(&this.migrationContext.ThrottleCommandedByUser, 1)
-			fmt.Fprintf(writer, throttleHint)
+			fmt.Fprintln(writer, throttleHint)
 			return ForcePrintStatusAndHintRule, nil
 		}
 	case "no-throttle", "unthrottle", "resume", "continue":

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -87,10 +87,10 @@ func (this *EventsStreamer) notifyListeners(binlogEvent *binlog.BinlogDMLEvent) 
 
 	for _, listener := range this.listeners {
 		listener := listener
-		if strings.ToLower(listener.databaseName) != strings.ToLower(binlogEvent.DatabaseName) {
+		if !strings.EqualFold(listener.databaseName, binlogEvent.DatabaseName) {
 			continue
 		}
-		if strings.ToLower(listener.tableName) != strings.ToLower(binlogEvent.TableName) {
+		if !strings.EqualFold(listener.tableName, binlogEvent.TableName) {
 			continue
 		}
 		if listener.async {

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -252,8 +252,7 @@ func (this *Throttler) collectControlReplicasLag() {
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
-	for {
-		<-ticker.C
+	for range ticker.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -448,10 +448,10 @@ func (this *Throttler) initiateThrottlerCollection(firstThrottlingCollected chan
 		this.collectGeneralThrottleMetrics()
 		firstThrottlingCollected <- true
 
-		throttlerMetricsTick := time.NewTicker(time.Second)
-		defer throttlerMetricsTick.Stop()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
-			<-throttlerMetricsTick.C
+			<-ticker.C
 			if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 				return
 			}

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -448,7 +448,7 @@ func (this *Throttler) initiateThrottlerCollection(firstThrottlingCollected chan
 		this.collectGeneralThrottleMetrics()
 		firstThrottlingCollected <- true
 
-		throttlerMetricsTick := time.NewTicker(1 * time.Second)
+		throttlerMetricsTick := time.NewTicker(time.Second)
 		defer throttlerMetricsTick.Stop()
 		for {
 			<-throttlerMetricsTick.C

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -170,8 +170,7 @@ func (this *Throttler) collectReplicationLag(firstThrottlingCollected chan<- boo
 
 	ticker := time.NewTicker(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
 	defer ticker.Stop()
-	for {
-		<-ticker.C
+	for range ticker.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}
@@ -328,8 +327,7 @@ func (this *Throttler) collectThrottleHTTPStatus(firstThrottlingCollected chan<-
 	collectInterval := time.Duration(this.migrationContext.ThrottleHTTPIntervalMillis) * time.Millisecond
 	ticker := time.NewTicker(collectInterval)
 	defer ticker.Stop()
-	for {
-		<-ticker.C
+	for range ticker.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}
@@ -450,8 +448,7 @@ func (this *Throttler) initiateThrottlerCollection(firstThrottlingCollected chan
 
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
-		for {
-			<-ticker.C
+		for range ticker.C {
 			if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 				return
 			}
@@ -482,8 +479,7 @@ func (this *Throttler) initiateThrottlerChecks() {
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
-	for {
-		<-ticker.C
+	for range ticker.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -501,6 +501,9 @@ func BuildDMLUpdateQuery(databaseName, tableName string, tableColumns, sharedCol
 	}
 
 	equalsComparison, err := BuildEqualsPreparedComparison(uniqueKeyColumns.Names())
+	if err != nil {
+		return "", sharedArgs, uniqueKeyArgs, err
+	}
 	result = fmt.Sprintf(`
  			update /* gh-ost %s.%s */
  					%s.%s


### PR DESCRIPTION
### Description

This PR resolves a list of warnings from [the `staticcheck` linter](https://staticcheck.io/) and enables it in CI

In 2 x cases the linter was ignored with `// nolint` tags:
1. `golang.org/x/crypto/ssh/terminal` deprecation
    - To be fixed once releases are on `go mod`
3. `empty branch (staticcheck)` warning at `go/base/utils.go:72`
    - We don't care about the `error` in this case 🤫 

`strings.EqualFold(...)` is [about 2.6x faster than `==` + w/2 x `strings.ToLower(...)`'d strings](https://github.com/havoron/equalfold-bench#intel-core-i7-3770k-cpu--350ghz-ram-1800-mhz) _(what `master` does now)_, also it's `0` allocation vs `2` 🚀. So there may be efficiency gains to the binlog streamer

Also, while I fixed some code I removed `error`-returns from funcs that are goroutines, ie: nothing reads the `error` return

Original suggestions:
```bash
tim@Tims-MacBook-Pro gh-ost % golangci-lint run
go/cmd/gh-ost/main.go:22:2: SA1019: package golang.org/x/crypto/ssh/terminal is deprecated: this package moved to golang.org/x/term. (staticcheck)
	"golang.org/x/crypto/ssh/terminal"
	^
go/base/context.go:849:5: SA1019: cfg.Section("client").Haskey is deprecated: Use "HasKey" instead. (staticcheck)
	if cfg.Section("client").Haskey("user") {
	   ^
go/base/context.go:853:5: SA1019: cfg.Section("client").Haskey is deprecated: Use "HasKey" instead. (staticcheck)
	if cfg.Section("client").Haskey("password") {
	   ^
go/base/context.go:857:5: SA1019: cfg.Section("osc").Haskey is deprecated: Use "HasKey" instead. (staticcheck)
	if cfg.Section("osc").Haskey("chunk_size") {
	   ^
go/base/context.go:864:5: SA1019: cfg.Section("osc").Haskey is deprecated: Use "HasKey" instead. (staticcheck)
	if cfg.Section("osc").Haskey("max_load") {
	   ^
go/base/context.go:868:5: SA1019: cfg.Section("osc").Haskey is deprecated: Use "HasKey" instead. (staticcheck)
	if cfg.Section("osc").Haskey("replication_lag_query") {
	   ^
go/logic/applier.go:347:19: SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (staticcheck)
	heartbeatTick := time.Tick(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
	                 ^
go/logic/migrator.go:814:16: SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (staticcheck)
	statusTick := time.Tick(1 * time.Second)
	              ^
go/logic/throttler.go:171:12: SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (staticcheck)
	ticker := time.Tick(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
	          ^
go/sql/builder.go:503:2: SA4006: this value of `err` is never used (staticcheck)
	equalsComparison, err := BuildEqualsPreparedComparison(uniqueKeyColumns.Names())
	^
go/logic/streamer.go:90:6: SA6005: should use strings.EqualFold instead (staticcheck)
		if strings.ToLower(listener.databaseName) != strings.ToLower(binlogEvent.DatabaseName) {
		   ^
go/logic/streamer.go:93:6: SA6005: should use strings.EqualFold instead (staticcheck)
		if strings.ToLower(listener.tableName) != strings.ToLower(binlogEvent.TableName) {
		   ^
go/logic/server.go:285:4: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			fmt.Fprintf(writer, throttleHint)
			^
go/logic/server.go:295:4: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			fmt.Fprintf(writer, throttleHint)
			^
go/logic/server.go:318:4: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			fmt.Fprintf(writer, throttleHint)
			^
go/base/utils.go:72:2: SA9003: empty branch (staticcheck)
	if err := db.QueryRow(extraPortQuery).Scan(&extraPort); err != nil {
	^
go/logic/migrator.go:28:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
	GhostTableMigrated         ChangelogState = "GhostTableMigrated"
	^
```

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
