### PR TITLE
Add script and docs for linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 run:
   timeout: 5m
-  modules-download-mode: readonly
-
 linters:
   disable:
     - errcheck

--- a/doc/coding-ghost.md
+++ b/doc/coding-ghost.md
@@ -5,7 +5,7 @@
 Getting started with gh-ost development is simple!
 
 - First obtain the repository with `git clone` or `go get`.
-- From inside of the repository run `script/cibuild`
+- From inside of the repository run `script/cibuild`.
 - This will bootstrap the environment if needed, format the code, build the code, and then run the unit test.
 
 ## CI build workflow
@@ -13,6 +13,12 @@ Getting started with gh-ost development is simple!
 `script/cibuild` performs the following actions will bootstrap the environment to build `gh-ost` correctly, build, perform syntax checks and run unit tests.
 
 If additional steps are needed, please add them into this workflow so that the workflow remains simple.
+
+## `golang-ci` linter
+
+Pull Requests to gh-ost are automatically linted by [`golang-ci`](https://golangci-lint.run/) to enfore best-practices. The linter config is located at [`.golangci.yml`](https://github.com/github/gh-ost/blob/master/.golangci.yml) and the `golangci-lint` GitHub Action is located at [`.github/workflows/golangci-lint.yml`](https://github.com/github/gh-ost/blob/master/.github/workflows/golangci-lint.yml).
+
+To run the `golang-ci` linters locally, use `script/lint`. This step is recommended before pushing code.
 
 ## Notes:
 

--- a/doc/coding-ghost.md
+++ b/doc/coding-ghost.md
@@ -16,9 +16,9 @@ If additional steps are needed, please add them into this workflow so that the w
 
 ## `golang-ci` linter
 
-Pull Requests to gh-ost are automatically linted by [`golang-ci`](https://golangci-lint.run/) to enfore best-practices. The linter config is located at [`.golangci.yml`](https://github.com/github/gh-ost/blob/master/.golangci.yml) and the `golangci-lint` GitHub Action is located at [`.github/workflows/golangci-lint.yml`](https://github.com/github/gh-ost/blob/master/.github/workflows/golangci-lint.yml).
+To enfore best-practices, Pull Requests are automatically linted by [`golang-ci`](https://golangci-lint.run/). The linter config is located at [`.golangci.yml`](https://github.com/github/gh-ost/blob/master/.golangci.yml) and the `golangci-lint` GitHub Action is located at [`.github/workflows/golangci-lint.yml`](https://github.com/github/gh-ost/blob/master/.github/workflows/golangci-lint.yml).
 
-To run the `golang-ci` linters locally, use `script/lint`. This step is recommended before pushing code.
+To run the `golang-ci` linters locally _(recommended before push)_, use `script/lint`.
 
 ## Notes:
 

--- a/script/ensure-golangci-lint-installed
+++ b/script/ensure-golangci-lint-installed
@@ -10,7 +10,7 @@ if [ -z "$GOPATH" ]; then
 fi
 
 if [ ! -x "$GOPATH/bin/golangci-lint" ]; then
-  echo "Installing golangci-lint with install script: $GOLANGCI_INSTALL_SCRIPT"
+  echo "Installing golangci-lint $GOLANGCI_RELEASE using script: $GOLANGCI_INSTALL_SCRIPT"
   curl -sSfL $GOLANGCI_INSTALL_SCRIPT | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_RELEASE
 fi
 

--- a/script/ensure-golangci-lint-installed
+++ b/script/ensure-golangci-lint-installed
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# See https://github.com/golangci/golangci-lint/releases
+GOLANGCI_RELEASE=v1.46.2
+GOLANGCI_INSTALL_SCRIPT=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+
+if [ -z "$GOPATH" ]; then
+  echo "GOPATH must be set"
+  exit 1
+fi
+
+if [ ! -x "$GOPATH/bin/golangci-lint" ]; then
+  echo "Installing golangci-lint with install script: $GOLANGCI_INSTALL_SCRIPT"
+  curl -sSfL $GOLANGCI_INSTALL_SCRIPT | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_RELEASE
+fi
+
+$GOPATH/bin/golangci-lint --version

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+. script/ensure-go-installed
+. script/ensure-golangci-lint-installed
+
+if [ -x "$GOPATH/bin/golangci-lint" ]; then
+  echo "Running golangci-lint run"
+  $GOPATH/bin/golangci-lint run --config=.golangci.yml
+  echo "Done, exit code: $?"
+else
+  echo "ERROR: cannot find golangci-lint at $GOPATH/bin"
+  exit 1
+fi


### PR DESCRIPTION
Resolves #741

### Description

This PR adds some docs on the `golangci-lint` linter and adds the scripts `script/ensure-golangci-lint-installed` and `script/lint` to simplify running the linter locally during development

Lastly, the `golangci-lint` setting `modules-download-mode: readonly` was removed because it created problems deleting the `.gopath`

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
