### PR TITLE
Tear down streamer

### DIFF
--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -219,5 +219,7 @@ func (this *EventsStreamer) Close() (err error) {
 }
 
 func (this *EventsStreamer) Teardown() {
+	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()
+	this.Close()
 }

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -180,6 +180,7 @@ func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	var successiveFailures int64
 	var lastAppliedRowsEventHint mysql.BinlogCoordinates
 	for {
+		this.migrationContext.Log.Debugf("Am I gonna stop??, %v", canStopStreaming())
 		if canStopStreaming() {
 			return nil
 		}

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -180,7 +180,6 @@ func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	var successiveFailures int64
 	var lastAppliedRowsEventHint mysql.BinlogCoordinates
 	for {
-		this.migrationContext.Log.Debugf("Am I gonna stop??, %v", canStopStreaming())
 		if canStopStreaming() {
 			return nil
 		}

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/github/gh-ost/go/base"
@@ -222,4 +223,5 @@ func (this *EventsStreamer) Teardown() {
 	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()
 	this.Close()
+	atomic.StoreInt64(&this.migrationContext.CutOverCompleteFlag, 1)
 }


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/465

### Description

The PR https://github.com/github/gh-ost/pull/479 introduces "teardown" and make it possible to use gh-ost as a library. However some cleanups are missing.

This PR closes streamer properly when tearing down.

Downstream PR is https://github.com/bytebase/gh-ost/pull/3
