### PR TITLE
Only build RPM and deb packages for amd64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,8 @@ function build {
 
   (cd $buildpath && tar cfz ./gh-ost-binary-${osshort}-${GOARCH}-${timestamp}.tar.gz $target)
 
-  if [ "$GOOS" == "linux" ] ; then
+  # build RPM and deb for Linux, x86-64 only
+  if [ "$GOOS" == "linux" ] && [ "$GOARCH" == "amd64" ] ; then
     echo "Creating Distro full packages"
     builddir=$(setuptree)
     cp $buildpath/$target $builddir/gh-ost/usr/bin


### PR DESCRIPTION
### Description

This PR updates `build.sh` to only generate RPM and deb packages for Linux x86-64, as these were being overwritten by packages generated containing arm64 binaries.

Related issue:
- #1152