### PR TITLE
Add basic test for inspector

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -132,10 +132,7 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 	if err != nil {
 		return err
 	}
-	sharedUniqueKeys, err := this.getSharedUniqueKeys(this.migrationContext.OriginalTableUniqueKeys, this.migrationContext.GhostTableUniqueKeys)
-	if err != nil {
-		return err
-	}
+	sharedUniqueKeys := this.getSharedUniqueKeys(this.migrationContext.OriginalTableUniqueKeys, this.migrationContext.GhostTableUniqueKeys)
 	for i, sharedUniqueKey := range sharedUniqueKeys {
 		this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, &sharedUniqueKey.Columns)
 		uniqueKeyIsValid := true
@@ -728,7 +725,7 @@ func (this *Inspector) getCandidateUniqueKeys(tableName string) (uniqueKeys [](*
 
 // getSharedUniqueKeys returns the intersection of two given unique keys,
 // testing by list of columns
-func (this *Inspector) getSharedUniqueKeys(originalUniqueKeys, ghostUniqueKeys [](*sql.UniqueKey)) (uniqueKeys [](*sql.UniqueKey), err error) {
+func (this *Inspector) getSharedUniqueKeys(originalUniqueKeys, ghostUniqueKeys []*sql.UniqueKey) (uniqueKeys []*sql.UniqueKey) {
 	// We actually do NOT rely on key name, just on the set of columns. This is because maybe
 	// the ALTER is on the name itself...
 	for _, originalUniqueKey := range originalUniqueKeys {
@@ -738,7 +735,7 @@ func (this *Inspector) getSharedUniqueKeys(originalUniqueKeys, ghostUniqueKeys [
 			}
 		}
 	}
-	return uniqueKeys, nil
+	return uniqueKeys
 }
 
 // getSharedColumns returns the intersection of two lists of columns in same order as the first list

--- a/go/logic/inspect_test.go
+++ b/go/logic/inspect_test.go
@@ -1,10 +1,16 @@
+/*
+   Copyright 2022 GitHub Inc.
+         See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
 package logic
 
 import (
 	"testing"
 
-	"github.com/github/gh-ost/go/sql"
 	test "github.com/openark/golib/tests"
+
+	"github.com/github/gh-ost/go/sql"
 )
 
 func TestInspectGetSharedUniqueKeys(t *testing.T) {

--- a/go/logic/inspect_test.go
+++ b/go/logic/inspect_test.go
@@ -1,0 +1,25 @@
+package logic
+
+import (
+	"testing"
+
+	"github.com/github/gh-ost/go/sql"
+	test "github.com/openark/golib/tests"
+)
+
+func TestInspectGetSharedUniqueKeys(t *testing.T) {
+	origUniqKeys := []*sql.UniqueKey{
+		{Columns: *sql.NewColumnList([]string{"id", "item_id"})},
+		{Columns: *sql.NewColumnList([]string{"id", "org_id"})},
+	}
+	ghostUniqKeys := []*sql.UniqueKey{
+		{Columns: *sql.NewColumnList([]string{"id", "item_id"})},
+		{Columns: *sql.NewColumnList([]string{"id", "org_id"})},
+		{Columns: *sql.NewColumnList([]string{"item_id", "user_id"})},
+	}
+	inspector := &Inspector{}
+	sharedUniqKeys := inspector.getSharedUniqueKeys(origUniqKeys, ghostUniqKeys)
+	test.S(t).ExpectEquals(len(sharedUniqKeys), 2)
+	test.S(t).ExpectEquals(sharedUniqKeys[0].Columns.String(), "id,item_id")
+	test.S(t).ExpectEquals(sharedUniqKeys[1].Columns.String(), "id,org_id")
+}


### PR DESCRIPTION
### Description

This PR adds a simple test for the `.getSharedUniqueKeys()` func of `go/logic/inspector.go`

Also, the `err error` return was removed from `.getSharedUniqueKeys()` because it is never set

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
