### PR TITLE
Enable the errcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
-  timeout: 5m
+  timeout: 3m
 linters:
-  disable:
-    - errcheck
   enable:
     - contextcheck
     - durationcheck
@@ -18,7 +16,22 @@ linters:
     - prealloc
     - rowserrcheck
     - sqlclosecheck
+    - structcheck
     - unconvert
     - unused
     - wastedassign
     - whitespace
+issues:
+  exclude-rules:
+    - linters:
+        - errcheck
+      path: '(.+)_test\.go'
+    - linters:
+        - errcheck
+      text: 'Error return value of `(this\.)?migrationContext\.Log\.(Errore|Errorf|Fatal|Fatale|Fatalf|Warning|Warningf)`'
+    - linters:
+        - errcheck
+      text: 'Error return value of `tx.Rollback`'
+    - linters:
+        - errcheck
+      text: 'Error return value of `log\.(Errore|Errorf|Fatal|Fatale|Fatalf|Warning|Warningf)`'

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -183,7 +183,10 @@ func main() {
 	if migrationContext.AlterStatement == "" {
 		log.Fatal("--alter must be provided and statement must not be empty")
 	}
-	parser := sql.NewParserFromAlterStatement(migrationContext.AlterStatement)
+	parser, err := sql.NewParserFromAlterStatement(migrationContext.AlterStatement)
+	if err != nil {
+		log.Fatale(err)
+	}
 	migrationContext.AlterStatementOptions = parser.GetAlterStatementOptions()
 
 	if migrationContext.DatabaseName == "" {
@@ -302,7 +305,9 @@ func main() {
 
 	migrator := logic.NewMigrator(migrationContext, AppVersion)
 	if err := migrator.Migrate(); err != nil {
-		migrator.ExecOnFailureHook()
+		if err = migrator.ExecOnFailureHook(); err != nil {
+			migrationContext.Log.Errore(err)
+		}
 		migrationContext.Log.Fatale(err)
 	}
 	fmt.Fprintln(os.Stdout, "# Done")

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -137,7 +137,9 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 		return err
 	}
 	for i, sharedUniqueKey := range sharedUniqueKeys {
-		this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, &sharedUniqueKey.Columns)
+		if err = this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, &sharedUniqueKey.Columns); err != nil {
+			return err
+		}
 		uniqueKeyIsValid := true
 		for _, column := range sharedUniqueKey.Columns.Columns() {
 			switch column.Type {
@@ -179,8 +181,14 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 	// This additional step looks at which columns are unsigned. We could have merged this within
 	// the `getTableColumns()` function, but it's a later patch and introduces some complexity; I feel
 	// comfortable in doing this as a separate step.
-	this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, this.migrationContext.OriginalTableColumns, this.migrationContext.SharedColumns, &this.migrationContext.UniqueKey.Columns)
-	this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.GetGhostTableName(), this.migrationContext.GhostTableColumns, this.migrationContext.MappedSharedColumns)
+	if err = this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, this.migrationContext.OriginalTableColumns,
+		this.migrationContext.SharedColumns, &this.migrationContext.UniqueKey.Columns); err != nil {
+		return err
+	}
+	if err = this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.GetGhostTableName(), this.migrationContext.GhostTableColumns,
+		this.migrationContext.MappedSharedColumns); err != nil {
+		return err
+	}
 
 	for i := range this.migrationContext.SharedColumns.Columns() {
 		column := this.migrationContext.SharedColumns.Columns()[i]

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -94,10 +94,14 @@ func (this *EventsStreamer) notifyListeners(binlogEvent *binlog.BinlogDMLEvent) 
 		}
 		if listener.async {
 			go func() {
-				listener.onDmlEvent(binlogEvent)
+				if err := listener.onDmlEvent(binlogEvent); err != nil {
+					this.migrationContext.Log.Errorf("Failed to notify listeners of DML event: %+v", err)
+				}
 			}()
 		} else {
-			listener.onDmlEvent(binlogEvent)
+			if err := listener.onDmlEvent(binlogEvent); err != nil {
+				this.migrationContext.Log.Errorf("Failed to notify listeners of DML event: %+v", err)
+			}
 		}
 	}
 }

--- a/go/sql/parser.go
+++ b/go/sql/parser.go
@@ -56,10 +56,10 @@ func NewAlterTableParser() *AlterTableParser {
 	}
 }
 
-func NewParserFromAlterStatement(alterStatement string) *AlterTableParser {
+func NewParserFromAlterStatement(alterStatement string) (*AlterTableParser, error) {
 	parser := NewAlterTableParser()
-	parser.ParseAlterStatement(alterStatement)
-	return parser
+	err := parser.ParseAlterStatement(alterStatement)
+	return parser, err
 }
 
 func (this *AlterTableParser) tokenizeAlterStatement(alterStatement string) (tokens []string, err error) {
@@ -154,7 +154,9 @@ func (this *AlterTableParser) ParseAlterStatement(alterStatement string) (err er
 	alterTokens, _ := this.tokenizeAlterStatement(this.alterStatementOptions)
 	for _, alterToken := range alterTokens {
 		alterToken = this.sanitizeQuotesFromAlterStatement(alterToken)
-		this.parseAlterToken(alterToken)
+		if err = this.parseAlterToken(alterToken); err != nil {
+			return err
+		}
 		this.alterTokens = append(this.alterTokens, alterToken)
 	}
 	return nil


### PR DESCRIPTION
### Description

This PR enables the [`errcheck` ](https://github.com/kisielk/errcheck) linter in the project `golangci-lint` config:

> errcheck is a program for checking for unchecked errors in go programs.

Also a lot of missing error handling was added for problems (or `// nolint:errcheck` flags for some false-positives)

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
