### PR TITLE
Fix corrupt modified enum values

### DIFF
--- a/localtests/enum-modified/create.sql
+++ b/localtests/enum-modified/create.sql
@@ -1,0 +1,26 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+  id int auto_increment,
+  i int not null,
+  e enum('red', 'green', 'blue', 'orange') null default null collate 'utf8_bin',
+  primary key(id)
+) auto_increment=1;
+
+insert into gh_ost_test values (null, 7, 'red');
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+  insert into gh_ost_test values (null, 11, 'red');
+  insert into gh_ost_test values (null, 13, 'green');
+  insert into gh_ost_test values (null, 17, 'blue');
+  set @last_insert_id := last_insert_id();
+  update gh_ost_test set e='orange' where id = @last_insert_id;
+end ;;

--- a/localtests/enum-modified/extra_args
+++ b/localtests/enum-modified/extra_args
@@ -1,0 +1,1 @@
+--alter="modify column e enum('brown', 'green', 'blue', 'orange') default null" 


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/920

### Description

This PR aims to resolve the scenario described in #920 where an existing `enum` column-value is modified

More info TBD

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
