### PR TITLE
Change CI tests to use `ubuntu-20.04` because `ubuntu-latest` doesn't support MySQL 5.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/replica-tests.yml
+++ b/.github/workflows/replica-tests.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         version: [mysql-5.7.25,mysql-8.0.16]


### PR DESCRIPTION
### Description

This PR pins the CI base image as `ubuntu-20.04` because the `ubuntu-latest` tag is now an alias for `ubuntu-22.04`, which doesn't support MySQL 5.7. This is causing our CI migration tests to fail because `ubuntu-22.04` doesn't contain the libraries needed to run MySQL 5.7.
