### PR TITLE
Fix migration test passing when `convert-utf8mb4` test setup was partially failing

### DIFF
--- a/localtests/convert-utf8mb4/create.sql
+++ b/localtests/convert-utf8mb4/create.sql
@@ -7,9 +7,6 @@ create table gh_ost_test (
   primary key(id)
 ) auto_increment=1;
 
-insert into gh_ost_test values (null, 'átesting');
-
-
 insert into gh_ost_test values (null, 'Hello world, Καλημέρα κόσμε, コンニチハ', 'átesting0', 'initial');
 
 drop event if exists gh_ost_test;

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -116,7 +116,8 @@ test_single() {
     gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "set @@global.sql_mode='$(cat $tests_path/$test_name/sql_mode)'"
   fi
 
-  gh-ost-test-mysql-master --default-character-set=utf8mb4 test < $tests_path/$test_name/create.sql
+  cat $tests_path/$test_name/create.sql
+  bash -x gh-ost-test-mysql-master --default-character-set=utf8mb4 test < $tests_path/$test_name/create.sql
 
   extra_args=""
   if [ -f $tests_path/$test_name/extra_args ] ; then

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -118,6 +118,7 @@ test_single() {
 
   cat $tests_path/$test_name/create.sql
   bash -x gh-ost-test-mysql-master --default-character-set=utf8mb4 test < $tests_path/$test_name/create.sql
+  echo $?
 
   extra_args=""
   if [ -f $tests_path/$test_name/extra_args ] ; then

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -116,9 +116,15 @@ test_single() {
     gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "set @@global.sql_mode='$(cat $tests_path/$test_name/sql_mode)'"
   fi
 
-  cat $tests_path/$test_name/create.sql
-  bash -x gh-ost-test-mysql-master --default-character-set=utf8mb4 test < $tests_path/$test_name/create.sql
-  echo $?
+  gh-ost-test-mysql-master --default-character-set=utf8mb4 test < $tests_path/$test_name/create.sql
+  test_create_result=$?
+
+  if [ $test_create_result -ne 0 ] ; then
+    echo
+    echo "ERROR $test_name create failure. cat $tests_path/$test_name/create.sql:"
+    cat $tests_path/$test_name/create.sql
+    return 1
+  fi
 
   extra_args=""
   if [ -f $tests_path/$test_name/extra_args ] ; then
@@ -257,7 +263,7 @@ build_binary() {
 
 test_all() {
   build_binary
-  find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | while read test_name ; do
+  find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | sort | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
       create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table _gh_ost_test_gho \G")

--- a/script/cibuild-gh-ost-replica-tests
+++ b/script/cibuild-gh-ost-replica-tests
@@ -61,7 +61,7 @@ test_mysql_version() {
   gh-ost-test-mysql-master -uroot -e "grant all on *.* to 'gh-ost'@'%'"
 
   echo "### Running gh-ost tests for $mysql_version"
-  bash ./localtests/test.sh -b bin/gh-ost datetime-with-zero
+  bash -x ./localtests/test.sh -b bin/gh-ost
 
   find sandboxes -name "stop_all" | bash
 }

--- a/script/cibuild-gh-ost-replica-tests
+++ b/script/cibuild-gh-ost-replica-tests
@@ -61,7 +61,7 @@ test_mysql_version() {
   gh-ost-test-mysql-master -uroot -e "grant all on *.* to 'gh-ost'@'%'"
 
   echo "### Running gh-ost tests for $mysql_version"
-  bash -x ./localtests/test.sh -b bin/gh-ost
+  ./localtests/test.sh -b bin/gh-ost
 
   find sandboxes -name "stop_all" | bash
 }

--- a/script/cibuild-gh-ost-replica-tests
+++ b/script/cibuild-gh-ost-replica-tests
@@ -61,7 +61,7 @@ test_mysql_version() {
   gh-ost-test-mysql-master -uroot -e "grant all on *.* to 'gh-ost'@'%'"
 
   echo "### Running gh-ost tests for $mysql_version"
-  ./localtests/test.sh -b bin/gh-ost
+  bash ./localtests/test.sh -b bin/gh-ost datetime-with-zero
 
   find sandboxes -name "stop_all" | bash
 }


### PR DESCRIPTION
I noticed in the CI for another PR that we had an error message that was being ignored:
```
ERROR 1136 (21S01) at line 10: Column count doesn't match value count at row 1
```

This was in the test setup for `convert-utf8mb4`, and was caused by an `insert` statement not having enough fields (it should have had four fields because the last two columns in the test table are `not null`):
```
insert into gh_ost_test values (null, 'átesting');
```

This PR addresses this by:
- adding error checking to migration test setup so that we can detect when tests are not setup correctly (as the actual test succeeded when run in this case)
- fixing the error in the test setup for `convert-utf8mb4` by removing the unnecessary invalid `insert` statement

I have also added a `sort` for the list of tests so that it's easier to track progress through the list of tests.