### PR TITLE
Base validate connection cleanup

### DIFF
--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -83,7 +83,7 @@ func ValidateConnection(db *gosql.DB, connectionConfig *mysql.ConnectionConfig, 
 
 	if !port.Valid || extraPort == 0 {
 		return "", fmt.Errorf("Unexpected database port reported: %+v", port.Int64)
-	} else if connectionConfig.Key.Port != port.Int64 || extraPort == 0 || connectionConfig.Key.Port != extraPort {
+	} else if connectionConfig.Key.Port != port.Int64 && (extraPort == 0 || connectionConfig.Key.Port != extraPort) {
 		return "", fmt.Errorf("Unexpected database port reported: %+v / extra_port: %+v", port.Int64, extraPort)
 	}
 

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -62,34 +62,32 @@ func StringContainsAll(s string, substrings ...string) bool {
 }
 
 func ValidateConnection(db *gosql.DB, connectionConfig *mysql.ConnectionConfig, migrationContext *MigrationContext, name string) (string, error) {
-	versionQuery := `select @@global.version`
-	var port, extraPort int
+	query := `select @@global.version, @@global.port`
 	var version string
-	if err := db.QueryRow(versionQuery).Scan(&version); err != nil {
+	var port gosql.NullInt64
+	if err := db.QueryRow(query).Scan(&version, &port); err != nil {
 		return "", err
 	}
+
 	extraPortQuery := `select @@global.extra_port`
-	if err := db.QueryRow(extraPortQuery).Scan(&extraPort); err != nil { // nolint:staticcheck
-		// swallow this error. not all servers support extra_port
-	}
+	var extraPort int64
+	// swallow possible error. not all servers support extra_port
+	_ = db.QueryRow(extraPortQuery).Scan(&extraPort)
+
 	// AliyunRDS set users port to "NULL", replace it by gh-ost param
 	// GCP set users port to "NULL", replace it by gh-ost param
-	// Azure MySQL set users port to a different value by design, replace it by gh-ost para
+	// Azure MySQL set users port to a different value by design, replace it by gh-ost param
 	if migrationContext.AliyunRDS || migrationContext.GoogleCloudPlatform || migrationContext.AzureMySQL {
-		port = connectionConfig.Key.Port
-	} else {
-		portQuery := `select @@global.port`
-		if err := db.QueryRow(portQuery).Scan(&port); err != nil {
-			return "", err
-		}
+		port.Int64 = connectionConfig.Key.Port
+		port.Valid = true
 	}
 
-	if connectionConfig.Key.Port == port || (extraPort > 0 && connectionConfig.Key.Port == extraPort) {
-		migrationContext.Log.Infof("%s connection validated on %+v", name, connectionConfig.Key)
-		return version, nil
-	} else if extraPort == 0 {
-		return "", fmt.Errorf("Unexpected database port reported: %+v", port)
-	} else {
-		return "", fmt.Errorf("Unexpected database port reported: %+v / extra_port: %+v", port, extraPort)
+	if !port.Valid || extraPort == 0 {
+		return "", fmt.Errorf("Unexpected database port reported: %+v", port.Int64)
+	} else if connectionConfig.Key.Port != port.Int64 || extraPort == 0 || connectionConfig.Key.Port != extraPort {
+		return "", fmt.Errorf("Unexpected database port reported: %+v / extra_port: %+v", port.Int64, extraPort)
 	}
+
+	migrationContext.Log.Infof("%s connection validated on %+v", name, connectionConfig.Key)
+	return version, nil
 }

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -49,7 +49,7 @@ func main() {
 	migrationContext := base.NewMigrationContext()
 	flag.StringVar(&migrationContext.InspectorConnectionConfig.Key.Hostname, "host", "127.0.0.1", "MySQL hostname (preferably a replica, not the master)")
 	flag.StringVar(&migrationContext.AssumeMasterHostname, "assume-master-host", "", "(optional) explicitly tell gh-ost the identity of the master. Format: some.host.com[:port] This is useful in master-master setups where you wish to pick an explicit master, or in a tungsten-replicator where gh-ost is unable to determine the master")
-	flag.IntVar(&migrationContext.InspectorConnectionConfig.Key.Port, "port", 3306, "MySQL port (preferably a replica, not the master)")
+	flag.Int64Var(&migrationContext.InspectorConnectionConfig.Key.Port, "port", 3306, "MySQL port (preferably a replica, not the master)")
 	flag.Float64Var(&migrationContext.InspectorConnectionConfig.Timeout, "mysql-timeout", 0.0, "Connect, read and write timeout for MySQL")
 	flag.StringVar(&migrationContext.CliUser, "user", "", "MySQL user")
 	flag.StringVar(&migrationContext.CliPassword, "password", "", "MySQL password")

--- a/go/mysql/instance_key.go
+++ b/go/mysql/instance_key.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-const DefaultInstancePort = 3306
+const DefaultInstancePort int64 = 3306
 
 var (
 	ipv4HostPortRegexp = regexp.MustCompile("^([^:]+):([0-9]+)$")

--- a/go/mysql/instance_key.go
+++ b/go/mysql/instance_key.go
@@ -28,7 +28,7 @@ var (
 // InstanceKey is an instance indicator, identified by hostname and port
 type InstanceKey struct {
 	Hostname string
-	Port     int
+	Port     int64
 }
 
 const detachHint = "//"
@@ -52,7 +52,7 @@ func NewRawInstanceKey(hostPort string) (*InstanceKey, error) {
 	instanceKey := &InstanceKey{Hostname: hostname, Port: DefaultInstancePort}
 	if port != "" {
 		var err error
-		if instanceKey.Port, err = strconv.Atoi(port); err != nil {
+		if instanceKey.Port, err = strconv.ParseInt(port, 10, 64); err != nil {
 			return instanceKey, fmt.Errorf("Invalid port: %s", port)
 		}
 	}

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -107,7 +107,7 @@ func GetMasterKeyFromSlaveStatus(connectionConfig *ConnectionConfig) (masterKey 
 
 		masterKey = &InstanceKey{
 			Hostname: rowMap.GetString("Master_Host"),
-			Port:     rowMap.GetInt("Master_Port"),
+			Port:     rowMap.GetInt64("Master_Port"),
 		}
 		return nil
 	})


### PR DESCRIPTION
### Description

This PR simplifies the code in `base.ValidateConnection` and reduces the number of queries from 3 -> 2 in most cases by gathering the `@@global.version` and @@global.port` in the same query

Later, the `@@global.port` variable is checked for `NULL` as this can happen on some cloud MySQL flavours

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
