### PR TITLE
feat(#1235): add an optimizer switch flag to migration context

### DIFF
--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -288,9 +288,9 @@ Makes the _old_ table include a timestamp value. The _old_ table is what the ori
 
 ### optimizer-switch
 
-Default is "", this allow to override a `SET GLOBAL optimizer_switch=key=value` by one set on the session with `SET SESSION optimizer_switch=key=value`.
+Default is "prefer_ordering_index=on", this allow to override a `SET GLOBAL optimizer_switch=key=value` by one set on the session with `SET SESSION optimizer_switch=key=value`.
 You can find values on https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html.
-Example: `--optimizer-switch="prefer_ordering_index=on"`.
+Example: `--optimizer-switch="prefer_ordering_index=off"`.
 
 ### tungsten
 

--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -286,6 +286,12 @@ Defaults to 1000 (1 second). Configures the HTTP throttler check timeout in mill
 
 Makes the _old_ table include a timestamp value. The _old_ table is what the original table is renamed to at the end of a successful migration. For example, if the table is `gh_ost_test`, then the _old_ table would normally be `_gh_ost_test_del`. With `--timestamp-old-table` it would be, for example, `_gh_ost_test_20170221103147_del`.
 
+### optimizer-switch
+
+Default is "", this allow to override a `SET GLOBAL optimizer_switch=key=value` by one set on the session with `SET SESSION optimizer_switch=key=value`.
+You can find values on https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html.
+Example: `--optimizer-switch="prefer_ordering_index=on"`.
+
 ### tungsten
 
 See [`tungsten`](cheatsheet.md#tungsten) on the cheatsheet.

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -209,6 +209,7 @@ type MigrationContext struct {
 	CutOverCompleteFlag                    int64
 	InCutOverCriticalSectionFlag           int64
 	PanicAbort                             chan error
+	OptimizerSwitch                        string
 
 	OriginalTableColumnsOnApplier    *sql.ColumnList
 	OriginalTableColumns             *sql.ColumnList

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -139,6 +139,7 @@ func main() {
 	criticalLoad := flag.String("critical-load", "", "Comma delimited status-name=threshold, same format as --max-load. When status exceeds threshold, app panics and quits")
 	flag.Int64Var(&migrationContext.CriticalLoadIntervalMilliseconds, "critical-load-interval-millis", 0, "When 0, migration immediately bails out upon meeting critical-load. When non-zero, a second check is done after given interval, and migration only bails out if 2nd check still meets critical load")
 	flag.Int64Var(&migrationContext.CriticalLoadHibernateSeconds, "critical-load-hibernate-seconds", 0, "When non-zero, critical-load does not panic and bail out; instead, gh-ost goes into hibernation for the specified duration. It will not read/write anything from/to any server")
+	flag.StringVar(&migrationContext.OptimizerSwitch, "optimizer-switch", "", "Optimizer switch params, eg: prefer_ordering_index=on")
 	quiet := flag.Bool("quiet", false, "quiet")
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -139,7 +139,7 @@ func main() {
 	criticalLoad := flag.String("critical-load", "", "Comma delimited status-name=threshold, same format as --max-load. When status exceeds threshold, app panics and quits")
 	flag.Int64Var(&migrationContext.CriticalLoadIntervalMilliseconds, "critical-load-interval-millis", 0, "When 0, migration immediately bails out upon meeting critical-load. When non-zero, a second check is done after given interval, and migration only bails out if 2nd check still meets critical load")
 	flag.Int64Var(&migrationContext.CriticalLoadHibernateSeconds, "critical-load-hibernate-seconds", 0, "When non-zero, critical-load does not panic and bail out; instead, gh-ost goes into hibernation for the specified duration. It will not read/write anything from/to any server")
-	flag.StringVar(&migrationContext.OptimizerSwitch, "optimizer-switch", "", "Optimizer switch params, eg: prefer_ordering_index=on")
+	flag.StringVar(&migrationContext.OptimizerSwitch, "optimizer-switch", "prefer_ordering_index=on", "optimizer_switch param")
 	quiet := flag.Bool("quiet", false, "quiet")
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")


### PR DESCRIPTION
### Description

This add a `optimizer_switch` string flag.

`--optimizer-switch="prefer_ordering_index=on"`

I don't check the value, easier to maintains, this will just fail if its a unknown value, depending the mysql/maria/percona version.

Related issue: https://github.com/github/gh-ost/issues/1235

