### PR TITLE
force index in iteration range end value queries

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -574,7 +574,7 @@ func (this *Applier) CalculateNextIterationRangeEndValues() (hasFurtherRange boo
 		query, explodedArgs, err := buildFunc(
 			this.migrationContext.DatabaseName,
 			this.migrationContext.OriginalTableName,
-			&this.migrationContext.UniqueKey.Columns,
+			this.migrationContext.UniqueKey,
 			this.migrationContext.MigrationIterationRangeMinValues.AbstractValues(),
 			this.migrationContext.MigrationRangeMaxValues.AbstractValues(),
 			atomic.LoadInt64(&this.migrationContext.ChunkSize),

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -279,7 +279,7 @@ func BuildUniqueKeyRangeEndPreparedQueryViaOffset(databaseName, tableName string
 						%s
 					from
 						%s.%s
-                    force index (%s)
+					force index (%s)
 					where %s and %s
 					order by
 						%s
@@ -338,7 +338,7 @@ func BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, tableName str
 							%s
 						from
 							%s.%s
-                        force index (%s)
+						force index (%s)
 						where %s and %s
 						order by
 							%s

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -280,10 +280,11 @@ func TestBuildUniqueKeyRangeEndPreparedQuery(t *testing.T) {
 	var chunkSize int64 = 500
 	{
 		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKey := UniqueKey{"PRIMARY", *uniqueKeyColumns, false, false}
 		rangeStartArgs := []interface{}{3, 17}
 		rangeEndArgs := []interface{}{103, 117}
 
-		query, explodedArgs, err := BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, originalTableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
+		query, explodedArgs, err := BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, originalTableName, &uniqueKey, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
 		test.S(t).ExpectNil(err)
 		expected := `
 				select /* gh-ost mydb.tbl test */ name, position
@@ -292,6 +293,7 @@ func TestBuildUniqueKeyRangeEndPreparedQuery(t *testing.T) {
 				        name, position
 				      from
 				        mydb.tbl
+                      force index (PRIMARY)
 				      where ((name > ?) or (((name = ?)) AND (position > ?))) and ((name < ?) or (((name = ?)) AND (position < ?)) or ((name = ?) and (position = ?)))
 				      order by
 				        name asc, position asc


### PR DESCRIPTION
Description

This PR forces the unique-key index to be used in iteration range end value queries when copying data to the _gho table.
Force the unique-key index to avoid inappropriate optimizer selection, as discussed in #1242 .