### PR TITLE
fix issue 887

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -232,6 +232,8 @@ type MigrationContext struct {
 
 	recentBinlogCoordinates mysql.BinlogCoordinates
 
+	AllowSetupMetadataLockInstruments bool
+
 	Log Logger
 }
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -134,7 +134,7 @@ func main() {
 	flag.Int64Var(&migrationContext.HooksStatusIntervalSec, "hooks-status-interval", 60, "how many seconds to wait between calling onStatus hook")
 
 	flag.UintVar(&migrationContext.ReplicaServerId, "replica-server-id", 99999, "server id used by gh-ost process. Default: 99999")
-
+	flag.BoolVar(&migrationContext.AllowSetupMetadataLockInstruments, "allow-setup-metadata-lock-instruments", false, "validate rename session acquiring lock whether is original table before unlock tables in cut-over phase")
 	maxLoad := flag.String("max-load", "", "Comma delimited status-name=threshold. e.g: 'Threads_running=100,Threads_connected=500'. When status exceeds threshold, app throttles writes")
 	criticalLoad := flag.String("critical-load", "", "Comma delimited status-name=threshold, same format as --max-load. When status exceeds threshold, app panics and quits")
 	flag.Int64Var(&migrationContext.CriticalLoadIntervalMilliseconds, "critical-load-interval-millis", 0, "When 0, migration immediately bails out upon meeting critical-load. When non-zero, a second check is done after given interval, and migration only bails out if 2nd check still meets critical load")

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -638,7 +638,10 @@ func (this *Migrator) atomicCutOver() (err error) {
 	defer atomic.StoreInt64(&this.migrationContext.InCutOverCriticalSectionFlag, 0)
 
 	okToUnlockTable := make(chan bool, 4)
+	okToDropSentryTable := make(chan bool, 4)
+	dropSentryTableDone := make(chan bool, 2)
 	defer func() {
+		okToDropSentryTable <- true
 		okToUnlockTable <- true
 	}()
 
@@ -648,7 +651,7 @@ func (this *Migrator) atomicCutOver() (err error) {
 	tableLocked := make(chan error, 2)
 	tableUnlocked := make(chan error, 2)
 	go func() {
-		if err := this.applier.AtomicCutOverMagicLock(lockOriginalSessionIdChan, tableLocked, okToUnlockTable, tableUnlocked); err != nil {
+		if err := this.applier.AtomicCutOverMagicLock(lockOriginalSessionIdChan, tableLocked, okToUnlockTable, tableUnlocked, okToDropSentryTable, dropSentryTableDone); err != nil {
 			this.migrationContext.Log.Errore(err)
 		}
 	}()
@@ -674,6 +677,7 @@ func (this *Migrator) atomicCutOver() (err error) {
 		if err := this.applier.AtomicCutoverRename(renameSessionIdChan, tablesRenamed); err != nil {
 			// Abort! Release the lock
 			atomic.StoreInt64(&tableRenameKnownToHaveFailed, 1)
+			okToDropSentryTable <- true
 			okToUnlockTable <- true
 		}
 	}()
@@ -691,6 +695,7 @@ func (this *Migrator) atomicCutOver() (err error) {
 	// Wait for the RENAME to appear in PROCESSLIST
 	if err := this.retryOperation(waitForRename, true); err != nil {
 		// Abort! Release the lock
+		okToDropSentryTable <- true
 		okToUnlockTable <- true
 		return err
 	}
@@ -703,9 +708,20 @@ func (this *Migrator) atomicCutOver() (err error) {
 	}
 	this.migrationContext.Log.Infof("Connection holding lock on original table still exists")
 
+	okToDropSentryTable <- true
+	<-dropSentryTableDone
+
+	if err := this.applier.ValidateGhostTableLocked(renameSessionId); err != nil {
+		// Abort! Kill Rename session and release the lock
+		if err := this.applier.KillRenameSession(renameSessionId); err != nil {
+			this.migrationContext.Log.Errore(err)
+		}
+		okToUnlockTable <- true
+		return err
+	}
+
 	// Now that we've found the RENAME blocking, AND the locking connection still alive,
 	// we know it is safe to proceed to release the lock
-
 	okToUnlockTable <- true
 	// BAM! magic table dropped, original table lock is released
 	// -> RENAME released -> queries on original are unblocked.
@@ -1146,6 +1162,13 @@ func (this *Migrator) initiateApplier() error {
 		}
 	}
 	this.applier.WriteChangelogState(string(GhostTableMigrated))
+
+	if this.migrationContext.AllowSetupMetadataLockInstruments {
+		if err := this.applier.EnableMetadataLockInstrument(); err != nil {
+			this.migrationContext.Log.Errorf("Unable to enable metadata lock instrument, see further error details. Bailing out")
+			return err
+		}
+	}
 	go this.applier.InitiateHeartbeat()
 	return nil
 }


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/887

### Description

This PR adds a detection of whether rename session is acquiring the lock of the original table, to avoid data loss caused by directly unlock tables after drop magic table while rename session is still acquiring the lock of the ghost table in the atomic cut-over phase. The detection method via enable the instrument [wait/lock/metadata/sql/mdl](https://dev.mysql.com/doc/refman/5.7/en/performance-schema-metadata-locks-table.html).

Here add a parameter `allow-setup-metadata-lock-instruments` to enable wait/lock/metadata/sql/mdl instrument. In atomic cut-over phase, add two channels `okToDropSentryTable`, `dropSentryTableDone`,   the channel `okToUnlockTable` only do one thing that releasing the locks,  after `migrator` receiving `dropSentryTableDone` channel, then detect whether rename session is ready (acquire original table lock) or not.  If not, you will get a message like the follows, __Expect rename session xxxxx acquiring table metadata lock is `schema`.`table`, but got `schema`.`_table_gho`__,  then cancel the current cut-over, and try again. 

Thank you!