### PR TITLE
chore: increase the cutover lock timeout

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -403,8 +403,8 @@ func (this *MigrationContext) SetCutOverLockTimeoutSeconds(timeoutSeconds int64)
 	if timeoutSeconds < 1 {
 		return fmt.Errorf("Minimal timeout is 1sec. Timeout remains at %d", this.CutOverLockTimeoutSeconds)
 	}
-	if timeoutSeconds > 10 {
-		return fmt.Errorf("Maximal timeout is 10sec. Timeout remains at %d", this.CutOverLockTimeoutSeconds)
+	if timeoutSeconds > 60 {
+		return fmt.Errorf("Maximal timeout is 60sec. Timeout remains at %d", this.CutOverLockTimeoutSeconds)
 	}
 	this.CutOverLockTimeoutSeconds = timeoutSeconds
 	return nil


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/gh-ost/issues/0123456789

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

The maximum 10-second timeout is almost never gonna make gh-ost to work for large tables. We should give control to users for this flag.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [X] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
