### PR TITLE
Parse binlog timestamp in UTC

### DIFF
--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -13,6 +13,8 @@ import (
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 
+	"time"
+
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 	"golang.org/x/net/context"
@@ -36,15 +38,16 @@ func NewGoMySQLReader(migrationContext *base.MigrationContext) *GoMySQLReader {
 		currentCoordinates:      mysql.BinlogCoordinates{},
 		currentCoordinatesMutex: &sync.Mutex{},
 		binlogSyncer: replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
-			ServerID:             uint32(migrationContext.ReplicaServerId),
-			Flavor:               gomysql.MySQLFlavor,
-			Host:                 connectionConfig.Key.Hostname,
-			Port:                 uint16(connectionConfig.Key.Port),
-			User:                 connectionConfig.User,
-			Password:             connectionConfig.Password,
-			TLSConfig:            connectionConfig.TLSConfig(),
-			UseDecimal:           true,
-			MaxReconnectAttempts: migrationContext.BinlogSyncerMaxReconnectAttempts,
+			ServerID:                uint32(migrationContext.ReplicaServerId),
+			Flavor:                  gomysql.MySQLFlavor,
+			Host:                    connectionConfig.Key.Hostname,
+			Port:                    uint16(connectionConfig.Key.Port),
+			User:                    connectionConfig.User,
+			Password:                connectionConfig.Password,
+			TLSConfig:               connectionConfig.TLSConfig(),
+			UseDecimal:              true,
+			MaxReconnectAttempts:    migrationContext.BinlogSyncerMaxReconnectAttempts,
+			TimestampStringLocation: time.UTC,
 		}),
 	}
 }


### PR DESCRIPTION
### Description

This PR addresses a situation where `TIMESTAMP` fields can be corrupted. Quoting @dm-2:

> gh-ost is incorrectly modifying the timezone of timestamp fields of rows when the following criteria are met:
> - database is running in non-UTC timezone, and
> - row is changed whilst a migration is running, and
> - field is timestamp, and
> - field contains a non-UTC timestamp

This is caused by how `go-mysql/replication` package parses binlog timestamps based on timezone. In the latest release this behaviour was disabled by editing the vendored package https://github.com/github/gh-ost/commit/7e0bdbe72a7f81d7a5546bc74279ade9f79baec5 , but in the master branch it is enabled.

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
