### PR TITLE
Pin docker image to stretch

### DIFF
--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -1,5 +1,10 @@
 FROM golang:1.17-stretch
 
+# Update stretch repositories
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update
 RUN apt-get install -y ruby ruby-dev rubygems build-essential
 RUN gem install --no-ri --no-rdoc fpm

--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.17-stretch
 
 RUN apt-get update
 RUN apt-get install -y ruby ruby-dev rubygems build-essential

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.17-stretch
 LABEL maintainer="github@github.com"
 
 RUN apt-get update

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,11 @@
 FROM golang:1.17-stretch
 LABEL maintainer="github@github.com"
 
+#Update stretch repositories
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update
 RUN apt-get install -y lsb-release
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Description

This is necessary for https://github.com/github/gh-ost/pull/1309 to upload the tarballs correctly 

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
