### PR TITLE
Fix `--version` output

### DIFF
--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -160,13 +160,14 @@ func main() {
 		flag.PrintDefaults()
 		return
 	}
+
+	if AppVersion == "" {
+		AppVersion = "unversioned"
+	}
+	if GitCommit == "" {
+		GitCommit = "unknown"
+	}
 	if *version {
-		if AppVersion == "" {
-			AppVersion = "unversioned"
-		}
-		if GitCommit == "" {
-			GitCommit = "unknown"
-		}
 		fmt.Printf("%s (git commit: %s)\n", AppVersion, GitCommit)
 		return
 	}

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -161,11 +161,13 @@ func main() {
 		return
 	}
 	if *version {
-		appVersion := AppVersion
-		if appVersion == "" {
-			appVersion = "unversioned"
+		if AppVersion == "" {
+			AppVersion = "unversioned"
 		}
-		fmt.Printf("%s (git commit: %s)", appVersion, GitCommit)
+		if GitCommit == "" {
+			GitCommit = "unknown"
+		}
+		fmt.Printf("%s (git commit: %s)\n", AppVersion, GitCommit)
 		return
 	}
 


### PR DESCRIPTION
### Description

This PR fixes a problem introduced in https://github.com/github/gh-ost/pull/1347 due to my forgetting to add newline character to `fmt.Printf(...)` 🤦 

Secondly, I've made an empty `GitCommit` display a bit more clearer


#### Before _(notice no `\n` char)_
```bash
tvaillancourt@tvailla-ltmxctu gh-ost % ./gh-ost --version
unversioned (git commit: )%  
```

#### After: undefined `AppVersion`+`GitCommit`
```bash
tvaillancourt@tvailla-ltmxctu gh-ost % ./gh-ost --version                        
unversioned (git commit: unknown)
tvaillancourt@tvailla-ltmxctu gh-ost %
```

#### After
```bash
tvaillancourt@tvailla-ltmxctu gh-ost % go build -o gh-ost -ldflags "-X main.AppVersion=1.1.6 -X main.GitCommit=$(git rev-parse HEAD)" ./go/cmd/gh-ost/main.go
tvaillancourt@tvailla-ltmxctu gh-ost % ./gh-ost --version                                                                                                    
1.1.6 (git commit: 5ebb95347e2002a5a959483f3e801cd3267e7e88)
tvaillancourt@tvailla-ltmxctu gh-ost %
```

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.