### PR TITLE
Add `cpu-profile` interactive command

### DIFF
--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -17,7 +17,7 @@ Both interfaces may serve at the same time. Both respond to simple text command,
 - `help`: shows a brief list of available commands
 - `status`: returns a detailed status summary of migration progress and configuration
 - `sup`: returns a brief status summary of migration progress
-- `cpu-profile`: returns a base64-encoded runtime/pprof CPU profile using a duration, default: `30s`. Comma-separated options `gzip` and/or `block` (blocked profile) may follow the profile duration
+- `cpu-profile`: returns a base64-encoded [`runtime/pprof`](https://pkg.go.dev/runtime/pprof) CPU profile using a duration, default: `30s`. Comma-separated options `gzip` and/or `block` (blocked profile) may follow the profile duration
 - `coordinates`: returns recent (though not exactly up to date) binary log coordinates of the inspected server
 - `applier`: returns the hostname of the applier
 - `inspector`: returns the hostname of the inspector

--- a/doc/interactive-commands.md
+++ b/doc/interactive-commands.md
@@ -17,6 +17,7 @@ Both interfaces may serve at the same time. Both respond to simple text command,
 - `help`: shows a brief list of available commands
 - `status`: returns a detailed status summary of migration progress and configuration
 - `sup`: returns a brief status summary of migration progress
+- `cpu-profile`: returns a base64-encoded runtime/pprof CPU profile using a duration, default: `30s`. Comma-separated options `gzip` and/or `block` (blocked profile) may follow the profile duration
 - `coordinates`: returns recent (though not exactly up to date) binary log coordinates of the inspected server
 - `applier`: returns the hostname of the applier
 - `inspector`: returns the hostname of the inspector

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -87,7 +87,7 @@ func (this *Server) runCPUProfile(args string) (string, error) {
 		defer runtime.SetBlockProfileRate(0)
 	}
 	if useGzip {
-		writer = gzip.NewWriter(&buf)
+		writer = gzip.NewWriter(writer)
 	}
 	if err = pprof.StartCPUProfile(writer); err != nil {
 		return "", err

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -7,15 +7,28 @@ package logic
 
 import (
 	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/github/gh-ost/go/base"
+)
+
+var (
+	ErrCPUProfilingBadOption  = errors.New("unrecognized cpu profiling option")
+	ErrCPUProfilingInProgress = errors.New("cpu profiling already in progress")
+	defaultCPUProfileDuration = time.Second * 30
 )
 
 type printStatusFunc func(PrintStatusRule, io.Writer)
@@ -27,6 +40,7 @@ type Server struct {
 	tcpListener      net.Listener
 	hooksExecutor    *HooksExecutor
 	printStatus      printStatusFunc
+	isCPUProfiling   int64
 }
 
 func NewServer(migrationContext *base.MigrationContext, hooksExecutor *HooksExecutor, printStatus printStatusFunc) *Server {
@@ -35,6 +49,53 @@ func NewServer(migrationContext *base.MigrationContext, hooksExecutor *HooksExec
 		hooksExecutor:    hooksExecutor,
 		printStatus:      printStatus,
 	}
+}
+
+func (this *Server) runCPUProfile(args string) (string, error) {
+	if atomic.LoadInt64(&this.isCPUProfiling) > 0 {
+		return "", ErrCPUProfilingInProgress
+	}
+
+	duration := defaultCPUProfileDuration
+
+	var err error
+	var useGzip bool
+	if args != "" {
+		s := strings.Split(args, ",")
+		// a duration string must be the 1st field, if any
+		if duration, err = time.ParseDuration(s[0]); err != nil {
+			return "", err
+		}
+		for _, arg := range s[1:] {
+			switch arg {
+			case "block", "blocked", "blocking":
+				runtime.SetBlockProfileRate(1)
+				defer runtime.SetBlockProfileRate(0)
+			case "gzip":
+				useGzip = true
+			default:
+				return "", ErrCPUProfilingBadOption
+			}
+		}
+	}
+
+	atomic.StoreInt64(&this.isCPUProfiling, 1)
+	defer atomic.StoreInt64(&this.isCPUProfiling, 0)
+
+	var buf bytes.Buffer
+	var writer io.Writer = &buf
+	if useGzip {
+		writer = gzip.NewWriter(&buf)
+	}
+	if err = pprof.StartCPUProfile(writer); err != nil {
+		return "", err
+	}
+
+	time.Sleep(duration)
+	pprof.StopCPUProfile()
+	this.migrationContext.Log.Infof("Captured %d byte runtime/pprof CPU profile (gzip=%v)", buf.Len(), useGzip)
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }
 
 func (this *Server) BindSocketFile() (err error) {
@@ -144,6 +205,7 @@ func (this *Server) applyServerCommand(command string, writer *bufio.Writer) (pr
 			fmt.Fprint(writer, `available commands:
 status                               # Print a detailed status message
 sup                                  # Print a short status message
+cpu-profile=<options>                # Print a base64-encoded runtime/pprof CPU profile using a duration, default: 30s. Comma-separated options 'gzip' and/or 'block' (blocked profile) may follow the profile duration
 coordinates                          # Print the currently inspected coordinates
 applier                              # Print the hostname of the applier
 inspector                            # Print the hostname of the inspector
@@ -169,6 +231,12 @@ help                                 # This message
 		return ForcePrintStatusOnlyRule, nil
 	case "info", "status":
 		return ForcePrintStatusAndHintRule, nil
+	case "cpu-profile":
+		profile, err := this.runCPUProfile(arg)
+		if err == nil {
+			fmt.Fprintln(writer, profile)
+		}
+		return NoPrintStatusRule, err
 	case "coordinates":
 		{
 			if argIsQuestion || arg == "" {

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -59,7 +59,7 @@ func (this *Server) runCPUProfile(args string) (string, error) {
 	duration := defaultCPUProfileDuration
 
 	var err error
-	var useGzip bool
+	var blockProfile, useGzip bool
 	if args != "" {
 		s := strings.Split(args, ",")
 		// a duration string must be the 1st field, if any
@@ -69,8 +69,7 @@ func (this *Server) runCPUProfile(args string) (string, error) {
 		for _, arg := range s[1:] {
 			switch arg {
 			case "block", "blocked", "blocking":
-				runtime.SetBlockProfileRate(1)
-				defer runtime.SetBlockProfileRate(0)
+				blockProfile = true
 			case "gzip":
 				useGzip = true
 			default:
@@ -84,6 +83,10 @@ func (this *Server) runCPUProfile(args string) (string, error) {
 
 	var buf bytes.Buffer
 	var writer io.Writer = &buf
+	if blockProfile {
+		runtime.SetBlockProfileRate(1)
+		defer runtime.SetBlockProfileRate(0)
+	}
 	if useGzip {
 		writer = gzip.NewWriter(&buf)
 	}

--- a/go/logic/server.go
+++ b/go/logic/server.go
@@ -52,10 +52,6 @@ func NewServer(migrationContext *base.MigrationContext, hooksExecutor *HooksExec
 }
 
 func (this *Server) runCPUProfile(args string) (string, error) {
-	if atomic.LoadInt64(&this.isCPUProfiling) > 0 {
-		return "", ErrCPUProfilingInProgress
-	}
-
 	duration := defaultCPUProfileDuration
 
 	var err error
@@ -78,6 +74,9 @@ func (this *Server) runCPUProfile(args string) (string, error) {
 		}
 	}
 
+	if atomic.LoadInt64(&this.isCPUProfiling) > 0 {
+		return "", ErrCPUProfilingInProgress
+	}
 	atomic.StoreInt64(&this.isCPUProfiling, 1)
 	defer atomic.StoreInt64(&this.isCPUProfiling, 0)
 

--- a/go/logic/server_test.go
+++ b/go/logic/server_test.go
@@ -2,7 +2,6 @@ package logic
 
 import (
 	"encoding/base64"
-	"fmt"
 	"testing"
 	"time"
 
@@ -43,8 +42,6 @@ func TestServerRunCPUProfile(t *testing.T) {
 		profile, err := s.runCPUProfile("")
 		tests.S(t).ExpectNil(err)
 		tests.S(t).ExpectNotEquals(profile, "")
-
-		fmt.Println(profile)
 
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)

--- a/go/logic/server_test.go
+++ b/go/logic/server_test.go
@@ -45,7 +45,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectEquals(len(data), 106)
+		tests.S(t).ExpectNotEquals(len(data), 0)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 
@@ -60,7 +60,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectEquals(len(data), 106)
+		tests.S(t).ExpectNotEquals(len(data), 0)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 
@@ -75,7 +75,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectEquals(len(data), 10)
+		tests.S(t).ExpectNotEquals(len(data), 0)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 }

--- a/go/logic/server_test.go
+++ b/go/logic/server_test.go
@@ -1,0 +1,81 @@
+package logic
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/github/gh-ost/go/base"
+	"github.com/openark/golib/tests"
+)
+
+func TestServerRunCPUProfile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("failed already running", func(t *testing.T) {
+		s := &Server{isCPUProfiling: 1}
+		profile, err := s.runCPUProfile("15ms")
+		tests.S(t).ExpectEquals(err, ErrCPUProfilingInProgress)
+		tests.S(t).ExpectEquals(profile, "")
+	})
+
+	t.Run("failed bad duration", func(t *testing.T) {
+		s := &Server{isCPUProfiling: 0}
+		profile, err := s.runCPUProfile("should-fail")
+		tests.S(t).ExpectNotNil(err)
+		tests.S(t).ExpectEquals(profile, "")
+	})
+
+	t.Run("failed bad option", func(t *testing.T) {
+		s := &Server{isCPUProfiling: 0}
+		profile, err := s.runCPUProfile("10ms,badoption")
+		tests.S(t).ExpectEquals(err, ErrCPUProfilingBadOption)
+		tests.S(t).ExpectEquals(profile, "")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		s := &Server{
+			isCPUProfiling:   0,
+			migrationContext: base.NewMigrationContext(),
+		}
+		defaultCPUProfileDuration = time.Millisecond * 10
+		profile, err := s.runCPUProfile("")
+		tests.S(t).ExpectNil(err)
+		tests.S(t).ExpectNotEquals(profile, "")
+
+		data, err := base64.StdEncoding.DecodeString(profile)
+		tests.S(t).ExpectNil(err)
+		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
+	})
+
+	t.Run("success with block", func(t *testing.T) {
+		s := &Server{
+			isCPUProfiling:   0,
+			migrationContext: base.NewMigrationContext(),
+		}
+		profile, err := s.runCPUProfile("10ms,block")
+		tests.S(t).ExpectNil(err)
+		tests.S(t).ExpectNotEquals(profile, "")
+
+		data, err := base64.StdEncoding.DecodeString(profile)
+		tests.S(t).ExpectNil(err)
+		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
+	})
+
+	t.Run("success with block and gzip", func(t *testing.T) {
+		s := &Server{
+			isCPUProfiling:   0,
+			migrationContext: base.NewMigrationContext(),
+		}
+		profile, err := s.runCPUProfile("10ms,block,gzip")
+		tests.S(t).ExpectNil(err)
+		tests.S(t).ExpectNotEquals(profile, "")
+
+		data, err := base64.StdEncoding.DecodeString(profile)
+		tests.S(t).ExpectNil(err)
+		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
+	})
+}

--- a/go/logic/server_test.go
+++ b/go/logic/server_test.go
@@ -2,6 +2,7 @@ package logic
 
 import (
 	"encoding/base64"
+	"fmt"
 	"testing"
 	"time"
 
@@ -43,9 +44,11 @@ func TestServerRunCPUProfile(t *testing.T) {
 		tests.S(t).ExpectNil(err)
 		tests.S(t).ExpectNotEquals(profile, "")
 
+		fmt.Println(profile)
+
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectEquals(len(data), 106)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 
@@ -60,7 +63,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectEquals(len(data), 106)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 
@@ -75,7 +78,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 
 		data, err := base64.StdEncoding.DecodeString(profile)
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectEquals(len(data), 10)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 }

--- a/go/logic/server_test.go
+++ b/go/logic/server_test.go
@@ -1,7 +1,6 @@
 package logic
 
 import (
-	"encoding/base64"
 	"testing"
 	"time"
 
@@ -16,21 +15,21 @@ func TestServerRunCPUProfile(t *testing.T) {
 		s := &Server{isCPUProfiling: 1}
 		profile, err := s.runCPUProfile("15ms")
 		tests.S(t).ExpectEquals(err, ErrCPUProfilingInProgress)
-		tests.S(t).ExpectEquals(profile, "")
+		tests.S(t).ExpectEquals(profile, nil)
 	})
 
 	t.Run("failed bad duration", func(t *testing.T) {
 		s := &Server{isCPUProfiling: 0}
 		profile, err := s.runCPUProfile("should-fail")
 		tests.S(t).ExpectNotNil(err)
-		tests.S(t).ExpectEquals(profile, "")
+		tests.S(t).ExpectEquals(profile, nil)
 	})
 
 	t.Run("failed bad option", func(t *testing.T) {
 		s := &Server{isCPUProfiling: 0}
 		profile, err := s.runCPUProfile("10ms,badoption")
 		tests.S(t).ExpectEquals(err, ErrCPUProfilingBadOption)
-		tests.S(t).ExpectEquals(profile, "")
+		tests.S(t).ExpectEquals(profile, nil)
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -41,11 +40,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 		defaultCPUProfileDuration = time.Millisecond * 10
 		profile, err := s.runCPUProfile("")
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(profile, "")
-
-		data, err := base64.StdEncoding.DecodeString(profile)
-		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectNotEquals(profile, nil)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 
@@ -56,11 +51,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 		}
 		profile, err := s.runCPUProfile("10ms,block")
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(profile, "")
-
-		data, err := base64.StdEncoding.DecodeString(profile)
-		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectNotEquals(profile, nil)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 
@@ -71,11 +62,7 @@ func TestServerRunCPUProfile(t *testing.T) {
 		}
 		profile, err := s.runCPUProfile("10ms,block,gzip")
 		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(profile, "")
-
-		data, err := base64.StdEncoding.DecodeString(profile)
-		tests.S(t).ExpectNil(err)
-		tests.S(t).ExpectNotEquals(len(data), 0)
+		tests.S(t).ExpectNotEquals(profile, nil)
 		tests.S(t).ExpectEquals(s.isCPUProfiling, int64(0))
 	})
 }


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related issue: https://github.com/github/gh-ost/issues/1359

### Description

This PR adds the `cpu-profile` interactive command which:
1. Returns a `runtime/pprof` CPU profile as a base64-encoded string
    - Default `30s` duration if no duration provided. Override-able eg: `cpu-profile=10s`
2. Optional gzip compression eg: `cpu-profile=15s,gzip`
3. Optional block profile, eg: `cpu-profile=30s,block`
> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.