### PR TITLE
Fix successive failures error in streamer

### DIFF
--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -193,7 +193,7 @@ func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 			} else {
 				successiveFailures = 0
 			}
-			if successiveFailures > this.migrationContext.MaxRetries() {
+			if successiveFailures >= this.migrationContext.MaxRetries() {
 				return fmt.Errorf("%d successive failures in streamer reconnect at coordinates %+v", successiveFailures, this.GetReconnectBinlogCoordinates())
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1370

### Description

This PR fixes a conditional in `go/logic/streamer.go` so the specified max retries is respected

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
