### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dm-2 @rashiq @meiji163 @timvaillancourt
+* @rashiq @meiji163 @timvaillancourt


### PR DESCRIPTION
Remove `@dm-2` from CODEOWNERS as I am no longer a maintainer for gh-ost.