### PR TITLE
feat binlog apply optimization

### DIFF
--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -129,6 +129,10 @@ Noteworthy is that setting `--dml-batch-size` to higher value _does not_ mean `g
 When binlog unique key value is over `MigrationIterationRangeMaxValues`, and less than `MigrationRangeMaxValues`, the binlog will be ignored. Because the data will be synced by copy chunk.
 When binlog unique key value is over `MigrationRangeMaxValues` or less than `MigrationIterationRangeMaxValues`, the binlog will be applied.
 
+### is-merge-dml-event
+When is-merge-dml-event is `true`, and the chunk unique key is int or float type. the sync binlog event while be merged into map, and the key is unique key value.
+Then traverse the map, merge all delete operations into one `delete sql`, merge all insert and update operations into `replace sql`, and then execute.
+
 ### exact-rowcount
 
 A `gh-ost` execution need to copy whatever rows you have in your existing table onto the ghost table. This can and often will be, a large number. Exactly what that number is?

--- a/doc/command-line-flags.md
+++ b/doc/command-line-flags.md
@@ -125,6 +125,10 @@ Why is this behavior configurable? Different workloads have different characteri
 
 Noteworthy is that setting `--dml-batch-size` to higher value _does not_ mean `gh-ost` blocks or waits on writes. The batch size is an upper limit on transaction size, not a minimal one. If `gh-ost` doesn't have "enough" events in the pipe, it does not wait on the binary log, it just writes what it already has. This conveniently suggests that if write load is light enough for `gh-ost` to only see a few events in the binary log at a given time, then it is also light enough for `gh-ost` to apply a fraction of the batch size.
 
+### ignore-over-iteration-range-max-binlog
+When binlog unique key value is over `MigrationIterationRangeMaxValues`, and less than `MigrationRangeMaxValues`, the binlog will be ignored. Because the data will be synced by copy chunk.
+When binlog unique key value is over `MigrationRangeMaxValues` or less than `MigrationIterationRangeMaxValues`, the binlog will be applied.
+
 ### exact-rowcount
 
 A `gh-ost` execution need to copy whatever rows you have in your existing table onto the ghost table. This can and often will be, a large number. Exactly what that number is?

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -194,7 +194,10 @@ type MigrationContext struct {
 	controlReplicasLagResult               mysql.ReplicationLagResult
 	TotalRowsCopied                        int64
 	TotalDMLEventsApplied                  int64
+	TotalDMLEventsIgnored                  int64
 	DMLBatchSize                           int64
+	IgnoreOverIterationRangeMaxBinlog      bool
+	IsMergeDMLEvents                       bool
 	isThrottled                            bool
 	throttleReason                         string
 	throttleReasonHint                     ThrottleReasonHint

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -108,6 +108,8 @@ func main() {
 	defaultRetries := flag.Int64("default-retries", 60, "Default number of retries for various operations before panicking")
 	cutOverLockTimeoutSeconds := flag.Int64("cut-over-lock-timeout-seconds", 3, "Max number of seconds to hold locks on tables while attempting to cut-over (retry attempted when lock exceeds timeout)")
 	niceRatio := flag.Float64("nice-ratio", 0, "force being 'nice', imply sleep time per chunk time; range: [0.0..100.0]. Example values: 0 is aggressive. 1: for every 1ms spent copying rows, sleep additional 1ms (effectively doubling runtime); 0.7: for every 10ms spend in a rowcopy chunk, spend 7ms sleeping immediately after")
+	flag.BoolVar(&migrationContext.IgnoreOverIterationRangeMaxBinlog, "ignore-over-iteration-range-max-binlog", false, "When binlog unique key value is over MigrationIterationRangeMaxValues, and less than MigrationRangeMaxValues, the binlog will be ignored. Because the data will be synced by copy chunk")
+	flag.BoolVar(&migrationContext.IsMergeDMLEvents, "is-merge-dml-event", false, "Merge DML Binlog Event")
 
 	maxLagMillis := flag.Int64("max-lag-millis", 1500, "replication lag at which to throttle operation")
 	replicationLagQuery := flag.String("replication-lag-query", "", "Deprecated. gh-ost uses an internal, subsecond resolution query")

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1421,7 +1421,7 @@ func (this *Applier) isIgnoreOverMaxChunkRangeEvent(uniqueKeyArgs []interface{})
 		return false, nil
 	}
 
-	// 比较是否大于等于最大边界值，如果是就不能忽略，需要应用对应的binlog
+	// Compare whether it is greater than or equal to the maximum boundary value. If it is, it cannot be ignored and the corresponding binlog needs to be applied.
 	ignore, err := func() (bool, error) {
 		for order, uniqueKeyCol := range this.migrationContext.UniqueKey.Columns.Columns() {
 			if uniqueKeyCol.CompareValueFunc == nil {
@@ -1439,7 +1439,7 @@ func (this *Applier) isIgnoreOverMaxChunkRangeEvent(uniqueKeyArgs []interface{})
 			}
 		}
 
-		// 等于边界值的时候，不能忽略
+		// When it is equal to the boundary value, it cannot be ignored.
 		return false, nil
 	}()
 	if err != nil {
@@ -1450,7 +1450,7 @@ func (this *Applier) isIgnoreOverMaxChunkRangeEvent(uniqueKeyArgs []interface{})
 		return false, nil
 	}
 
-	// 比较是否超过IterationRangeMax的边界值，如果大于可以忽略，小于就不能忽略
+	// Compare whether it exceeds the boundary value of IterationRangeMax. If it is greater, it can be ignored, if it is less, it cannot be ignored.
 	ignore, err = func() (bool, error) {
 		for order, uniqueKeyCol := range this.migrationContext.UniqueKey.Columns.Columns() {
 			than, err := uniqueKeyCol.CompareValueFunc(uniqueKeyArgs[order], this.migrationContext.MigrationIterationRangeMaxValues.StringColumn(order))
@@ -1464,7 +1464,7 @@ func (this *Applier) isIgnoreOverMaxChunkRangeEvent(uniqueKeyArgs []interface{})
 			}
 		}
 
-		// 等于边界值的时候，不能忽略
+		//When it is equal to the boundary value, it cannot be ignored.
 		return false, nil
 	}()
 	if err != nil {

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1453,6 +1453,10 @@ func (this *Applier) isIgnoreOverMaxChunkRangeEvent(uniqueKeyArgs []interface{})
 
 	// Compare whether it exceeds the boundary value of IterationRangeMax. If it is greater, it can be ignored, if it is less, it cannot be ignored.
 	ignore, err = func() (bool, error) {
+		if this.migrationContext.MigrationIterationRangeMaxValues == nil {
+			return true, nil
+		}
+
 		for order, uniqueKeyCol := range this.migrationContext.UniqueKey.Columns.Columns() {
 			than, err := uniqueKeyCol.CompareValueFunc(uniqueKeyArgs[order], this.migrationContext.MigrationIterationRangeMaxValues.StringColumn(order))
 			if err != nil {

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1386,7 +1386,8 @@ func (this *Applier) ApplyDMLEventQueries(dmlEvents [](*binlog.BinlogDMLEvent)) 
 		return nil
 	}
 
-	if this.migrationContext.IsMergeDMLEvents && this.migrationContext.UniqueKey.IsMemoryComparable {
+	// IsMergeDMLEvents is enabled and unique key is memory comparable and unique key has only one column
+	if this.migrationContext.IsMergeDMLEvents && this.migrationContext.UniqueKey.IsMemoryComparable && this.migrationContext.UniqueKey.Len() == 1 {
 		err = dbTxFunc(applyMapFunc)
 	} else {
 		err = dbTxFunc(applyAllFunc)

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -137,6 +138,7 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 	for i, sharedUniqueKey := range sharedUniqueKeys {
 		this.applyColumnTypes(this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName, &sharedUniqueKey.Columns)
 		uniqueKeyIsValid := true
+		isMemoryComparable := true
 		for _, column := range sharedUniqueKey.Columns.Columns() {
 			switch column.Type {
 			case sql.FloatColumnType:
@@ -152,9 +154,15 @@ func (this *Inspector) inspectOriginalAndGhostTables() (err error) {
 					uniqueKeyIsValid = false
 				}
 			}
+			if isMemoryComparable && column.FormatValueFunc != nil {
+				isMemoryComparable = true
+			} else {
+				isMemoryComparable = false
+			}
 		}
 		if uniqueKeyIsValid {
 			this.migrationContext.UniqueKey = sharedUniqueKeys[i]
+			this.migrationContext.UniqueKey.IsMemoryComparable = isMemoryComparable
 			break
 		}
 	}
@@ -598,6 +606,23 @@ func (this *Inspector) applyColumnTypes(databaseName, tableName string, columnsL
 			if strings.Contains(columnType, "unsigned") {
 				column.IsUnsigned = true
 			}
+			if strings.Contains(columnType, "int") {
+				column.CompareValueFunc = func(a interface{}, b interface{}) (int, error) {
+					_a := new(big.Int)
+					if _a, _ = _a.SetString(fmt.Sprintf("%+v", a), 10); a == nil {
+						return 0, fmt.Errorf("CompareValueFunc err, %+v convert int is nil", a)
+					}
+					_b := new(big.Int)
+					if _b, _ = _b.SetString(fmt.Sprintf("%+v", b), 10); b == nil {
+						return 0, fmt.Errorf("CompareValueFunc err, %+v convert int is nil", b)
+					}
+					return _a.Cmp(_b), nil
+				}
+
+				column.FormatValueFunc = func(a interface{}) (string, error) {
+					return fmt.Sprintf("%+v", a), nil
+				}
+			}
 			if strings.Contains(columnType, "mediumint") {
 				column.Type = sql.MediumIntColumnType
 			}
@@ -612,6 +637,9 @@ func (this *Inspector) applyColumnTypes(databaseName, tableName string, columnsL
 			}
 			if strings.Contains(columnType, "float") {
 				column.Type = sql.FloatColumnType
+				column.FormatValueFunc = func(a interface{}) (string, error) {
+					return fmt.Sprintf("%+v", a), nil
+				}
 			}
 			if strings.HasPrefix(columnType, "enum") {
 				column.Type = sql.EnumColumnType

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1261,9 +1261,6 @@ func (this *Migrator) onApplyEventStruct(eventStruct *applyEventStruct) error {
 		}
 		// Create a task to apply the DML event; this will be execute by executeWriteFuncs()
 		var applyEventFunc tableWriteFunc = func() error {
-			if this.migrationContext.UniqueKey.IsMemoryComparable {
-				return this.applier.ApplyDMLEventQueries(dmlEvents)
-			}
 			return this.applier.ApplyDMLEventQueries(dmlEvents)
 		}
 		if err := this.retryOperation(applyEventFunc); err != nil {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1025,9 +1025,10 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 
 	currentBinlogCoordinates := *this.eventsStreamer.GetCurrentBinlogCoordinates()
 
-	status := fmt.Sprintf("Copy: %d/%d %.1f%%; Applied: %d; Backlog: %d/%d; Time: %+v(total), %+v(copy); streamer: %+v; Lag: %.2fs, HeartbeatLag: %.2fs, State: %s; ETA: %s",
+	status := fmt.Sprintf("Copy: %d/%d %.1f%%; Applied: %d; Ignored: %d; Backlog: %d/%d; Time: %+v(total), %+v(copy); streamer: %+v; Lag: %.2fs, HeartbeatLag: %.2fs, State: %s; ETA: %s",
 		totalRowsCopied, rowsEstimate, progressPct,
 		atomic.LoadInt64(&this.migrationContext.TotalDMLEventsApplied),
+		atomic.LoadInt64(&this.migrationContext.TotalDMLEventsIgnored),
 		len(this.applyEventsQueue), cap(this.applyEventsQueue),
 		base.PrettifyDurationOutput(elapsedTime), base.PrettifyDurationOutput(this.migrationContext.ElapsedRowCopyTime()),
 		currentBinlogCoordinates,
@@ -1260,6 +1261,9 @@ func (this *Migrator) onApplyEventStruct(eventStruct *applyEventStruct) error {
 		}
 		// Create a task to apply the DML event; this will be execute by executeWriteFuncs()
 		var applyEventFunc tableWriteFunc = func() error {
+			if this.migrationContext.UniqueKey.IsMemoryComparable {
+				return this.applier.ApplyDMLEventQueries(dmlEvents)
+			}
 			return this.applier.ApplyDMLEventQueries(dmlEvents)
 		}
 		if err := this.retryOperation(applyEventFunc); err != nil {

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -433,15 +433,15 @@ func BuildDMLDeleteQuery(databaseName, tableName string, tableColumns, uniqueKey
 	return result, uniqueKeyArgs, nil
 }
 
-func BuildDMLInsertQuery(databaseName, tableName string, tableColumns, sharedColumns, mappedSharedColumns *ColumnList, args []interface{}) (result string, sharedArgs []interface{}, err error) {
+func BuildDMLInsertQuery(databaseName, tableName string, tableColumns, sharedColumns, mappedSharedColumns, uniqueKeyColumns *ColumnList, args []interface{}) (result string, sharedArgs, uniqueKeyArgs []interface{}, err error) {
 	if len(args) != tableColumns.Len() {
-		return result, args, fmt.Errorf("args count differs from table column count in BuildDMLInsertQuery")
+		return result, args, nil, fmt.Errorf("args count differs from table column count in BuildDMLInsertQuery")
 	}
 	if !sharedColumns.IsSubsetOf(tableColumns) {
-		return result, args, fmt.Errorf("shared columns is not a subset of table columns in BuildDMLInsertQuery")
+		return result, args, nil, fmt.Errorf("shared columns is not a subset of table columns in BuildDMLInsertQuery")
 	}
 	if sharedColumns.Len() == 0 {
-		return result, args, fmt.Errorf("No shared columns found in BuildDMLInsertQuery")
+		return result, args, nil, fmt.Errorf("No shared columns found in BuildDMLInsertQuery")
 	}
 	databaseName = EscapeName(databaseName)
 	tableName = EscapeName(tableName)
@@ -450,6 +450,12 @@ func BuildDMLInsertQuery(databaseName, tableName string, tableColumns, sharedCol
 		tableOrdinal := tableColumns.Ordinals[column.Name]
 		arg := column.convertArg(args[tableOrdinal], false)
 		sharedArgs = append(sharedArgs, arg)
+	}
+
+	for _, column := range uniqueKeyColumns.Columns() {
+		tableOrdinal := tableColumns.Ordinals[column.Name]
+		arg := column.convertArg(args[tableOrdinal], true)
+		uniqueKeyArgs = append(uniqueKeyArgs, arg)
 	}
 
 	mappedSharedColumnNames := duplicateNames(mappedSharedColumns.Names())
@@ -470,7 +476,7 @@ func BuildDMLInsertQuery(databaseName, tableName string, tableColumns, sharedCol
 		strings.Join(mappedSharedColumnNames, ", "),
 		strings.Join(preparedValues, ", "),
 	)
-	return result, sharedArgs, nil
+	return result, sharedArgs, uniqueKeyArgs, nil
 }
 
 func BuildDMLUpdateQuery(databaseName, tableName string, tableColumns, sharedColumns, mappedSharedColumns, uniqueKeyColumns *ColumnList, valueArgs, whereArgs []interface{}) (result string, sharedArgs, uniqueKeyArgs []interface{}, err error) {

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -491,7 +491,8 @@ func TestBuildDMLInsertQuery(t *testing.T) {
 	args := []interface{}{3, "testname", "first", 17, 23}
 	{
 		sharedColumns := NewColumnList([]string{"id", "name", "position", "age"})
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{"position"})
+		query, sharedArgs, uniqueKeyArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -502,10 +503,12 @@ func TestBuildDMLInsertQuery(t *testing.T) {
 		`
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", 17, 23}))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{17}))
 	}
 	{
 		sharedColumns := NewColumnList([]string{"position", "name", "age", "id"})
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{"position", "name"})
+		query, sharedArgs, uniqueKeyArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -516,15 +519,18 @@ func TestBuildDMLInsertQuery(t *testing.T) {
 		`
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{17, "testname", 23, 3}))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{17, "testname"}))
 	}
 	{
 		sharedColumns := NewColumnList([]string{"position", "name", "surprise", "id"})
-		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{"id"})
+		_, _, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNotNil(err)
 	}
 	{
 		sharedColumns := NewColumnList([]string{})
-		_, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{})
+		_, _, _, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNotNil(err)
 	}
 }
@@ -538,7 +544,8 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		// testing signed
 		args := []interface{}{3, "testname", "first", int8(-1), 23}
 		sharedColumns := NewColumnList([]string{"id", "name", "position", "age"})
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{"position"})
+		query, sharedArgs, uniqueKeyArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -549,12 +556,14 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		`
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", int8(-1), 23}))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{int8(-1)}))
 	}
 	{
 		// testing unsigned
 		args := []interface{}{3, "testname", "first", int8(-1), 23}
 		sharedColumns.SetUnsigned("position")
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{"position"})
+		query, sharedArgs, uniqueKeyArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -565,12 +574,14 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		`
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", uint8(255), 23}))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{uint8(255)}))
 	}
 	{
 		// testing unsigned
 		args := []interface{}{3, "testname", "first", int32(-1), 23}
 		sharedColumns.SetUnsigned("position")
-		query, sharedArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, args)
+		uniqueKeyColumns := NewColumnList([]string{"position"})
+		query, sharedArgs, uniqueKeyArgs, err := BuildDMLInsertQuery(databaseName, tableName, tableColumns, sharedColumns, sharedColumns, uniqueKeyColumns, args)
 		test.S(t).ExpectNil(err)
 		expected := `
 			replace /* gh-ost mydb.tbl */
@@ -581,6 +592,7 @@ func TestBuildDMLInsertQuerySignedUnsigned(t *testing.T) {
 		`
 		test.S(t).ExpectEquals(normalizeQuery(query), normalizeQuery(expected))
 		test.S(t).ExpectTrue(reflect.DeepEqual(sharedArgs, []interface{}{3, "testname", uint32(4294967295), 23}))
+		test.S(t).ExpectTrue(reflect.DeepEqual(uniqueKeyArgs, []interface{}{uint32(4294967295)}))
 	}
 }
 


### PR DESCRIPTION
### Description

1. Support for ignoring binlog events that exceed chunk boundary values.
If the value corresponding to the unique key of the binlog exceeds the maximum value of chunk iteration and is less than the maximum boundary value of the copy, it is ignored.

2. Support for binlog merge processing.
When the columns of the unique key selected by chunk are int or float, the binlog is processed by map merging, and all delete operations are merged into one `delete sql`.All insert and update operations are merged into one `replace sql`. Then execute these sql in db transaction.


> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
