### PR TITLE
[parser] support create-table flag

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -77,10 +77,12 @@ func NewThrottleCheckResult(throttle bool, reason string, reasonHint ThrottleRea
 type MigrationContext struct {
 	Uuid string
 
-	DatabaseName          string
-	OriginalTableName     string
-	AlterStatement        string
-	AlterStatementOptions string // anything following the 'ALTER TABLE [schema.]table' from AlterStatement
+	DatabaseName             string
+	OriginalTableName        string
+	AlterStatement           string
+	AlterStatementOptions    string // anything following the 'ALTER TABLE [schema.]table' from AlterStatement
+	CreateTableStatement     string
+	CreateTableStatementBody string // anything following the 'CREATE TABLE [schema.]table' from CreateTableStatement
 
 	countMutex               sync.Mutex
 	countTableRowsCancelFunc func()

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -183,3 +183,26 @@ func TestApplierInstantDDL(t *testing.T) {
 		test.S(t).ExpectEquals(stmt, "ALTER /* gh-ost */ TABLE `test`.`mytable` ADD INDEX (foo), ALGORITHM=INSTANT")
 	})
 }
+
+func TestApplierCreateGhostTable(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		migrationContext := base.NewMigrationContext()
+		migrationContext.DatabaseName = "test"
+		migrationContext.OriginalTableName = "mytable"
+		applier := NewApplier(migrationContext)
+
+		stmt := applier.generateCreateGhostTableQuery()
+		test.S(t).ExpectEquals(stmt, "create /* gh-ost */ table `test`.`_mytable_gho` like `test`.`mytable`")
+	})
+
+	t.Run("withCustomCreateTable", func(t *testing.T) {
+		migrationContext := base.NewMigrationContext()
+		migrationContext.DatabaseName = "test"
+		migrationContext.OriginalTableName = "mytable"
+		migrationContext.CreateTableStatementBody = "(id VARCHAR(24), PRIMARY KEY(id))"
+		applier := NewApplier(migrationContext)
+
+		stmt := applier.generateCreateGhostTableQuery()
+		test.S(t).ExpectEquals(stmt, "create /* gh-ost */ table `test`.`_mytable_gho` (id VARCHAR(24), PRIMARY KEY(id))")
+	})
+}

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -52,6 +52,7 @@ func (this *HooksExecutor) applyEnvironmentVariables(extraVariables ...string) [
 	env = append(env, fmt.Sprintf("GH_OST_GHOST_TABLE_NAME=%s", this.migrationContext.GetGhostTableName()))
 	env = append(env, fmt.Sprintf("GH_OST_OLD_TABLE_NAME=%s", this.migrationContext.GetOldTableName()))
 	env = append(env, fmt.Sprintf("GH_OST_DDL=%s", this.migrationContext.AlterStatement))
+	env = append(env, fmt.Sprintf("GH_OST_CREATE_TABLE=%s", this.migrationContext.CreateTableStatement))
 	env = append(env, fmt.Sprintf("GH_OST_ELAPSED_SECONDS=%f", this.migrationContext.ElapsedTime().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_ELAPSED_COPY_SECONDS=%f", this.migrationContext.ElapsedRowCopyTime().Seconds()))
 	estimatedRows := atomic.LoadInt64(&this.migrationContext.RowsEstimate) + atomic.LoadInt64(&this.migrationContext.RowsDeltaEstimate)

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -114,8 +114,9 @@ func TestMigratorOnChangelogEvent(t *testing.T) {
 func TestMigratorValidateStatement(t *testing.T) {
 	t.Run("add-column", func(t *testing.T) {
 		migrationContext := base.NewMigrationContext()
+		migrationContext.AlterStatement = `ALTER TABLE test ADD test_new VARCHAR(64) NOT NULL`
 		migrator := NewMigrator(migrationContext, "1.2.3")
-		tests.S(t).ExpectNil(migrator.parser.ParseAlterStatement(`ALTER TABLE test ADD test_new VARCHAR(64) NOT NULL`))
+		tests.S(t).ExpectNil(migrator.parser.ParseStatement())
 
 		tests.S(t).ExpectNil(migrator.validateAlterStatement())
 		tests.S(t).ExpectEquals(len(migrator.migrationContext.DroppedColumnsMap), 0)
@@ -123,8 +124,9 @@ func TestMigratorValidateStatement(t *testing.T) {
 
 	t.Run("drop-column", func(t *testing.T) {
 		migrationContext := base.NewMigrationContext()
+		migrationContext.AlterStatement = `ALTER TABLE test DROP abc`
 		migrator := NewMigrator(migrationContext, "1.2.3")
-		tests.S(t).ExpectNil(migrator.parser.ParseAlterStatement(`ALTER TABLE test DROP abc`))
+		tests.S(t).ExpectNil(migrator.parser.ParseStatement())
 
 		tests.S(t).ExpectNil(migrator.validateAlterStatement())
 		tests.S(t).ExpectEquals(len(migrator.migrationContext.DroppedColumnsMap), 1)
@@ -134,8 +136,9 @@ func TestMigratorValidateStatement(t *testing.T) {
 
 	t.Run("rename-column", func(t *testing.T) {
 		migrationContext := base.NewMigrationContext()
+		migrationContext.AlterStatement = `ALTER TABLE test CHANGE test123 test1234 bigint unsigned`
 		migrator := NewMigrator(migrationContext, "1.2.3")
-		tests.S(t).ExpectNil(migrator.parser.ParseAlterStatement(`ALTER TABLE test CHANGE test123 test1234 bigint unsigned`))
+		tests.S(t).ExpectNil(migrator.parser.ParseStatement())
 
 		err := migrator.validateAlterStatement()
 		tests.S(t).ExpectNotNil(err)
@@ -145,9 +148,10 @@ func TestMigratorValidateStatement(t *testing.T) {
 
 	t.Run("rename-column-approved", func(t *testing.T) {
 		migrationContext := base.NewMigrationContext()
+		migrationContext.AlterStatement = `ALTER TABLE test CHANGE test123 test1234 bigint unsigned`
 		migrator := NewMigrator(migrationContext, "1.2.3")
 		migrator.migrationContext.ApproveRenamedColumns = true
-		tests.S(t).ExpectNil(migrator.parser.ParseAlterStatement(`ALTER TABLE test CHANGE test123 test1234 bigint unsigned`))
+		tests.S(t).ExpectNil(migrator.parser.ParseStatement())
 
 		tests.S(t).ExpectNil(migrator.validateAlterStatement())
 		tests.S(t).ExpectEquals(len(migrator.migrationContext.DroppedColumnsMap), 0)
@@ -155,8 +159,9 @@ func TestMigratorValidateStatement(t *testing.T) {
 
 	t.Run("rename-table", func(t *testing.T) {
 		migrationContext := base.NewMigrationContext()
+		migrationContext.AlterStatement = `ALTER TABLE test RENAME TO test_new`
 		migrator := NewMigrator(migrationContext, "1.2.3")
-		tests.S(t).ExpectNil(migrator.parser.ParseAlterStatement(`ALTER TABLE test RENAME TO test_new`))
+		tests.S(t).ExpectNil(migrator.parser.ParseStatement())
 
 		err := migrator.validateAlterStatement()
 		tests.S(t).ExpectNotNil(err)

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -23,7 +23,7 @@ const (
 )
 
 // EscapeName will escape a db/table/column/... name by wrapping with backticks.
-// It is not fool proof. I'm just trying to do the right thing here, not solving
+// It is not full proof. I'm just trying to do the right thing here, not solving
 // SQL injection issues, which should be irrelevant for this tool.
 func EscapeName(name string) string {
 	if unquoted, err := strconv.Unquote(name); err == nil {

--- a/go/sql/create_table_parser.go
+++ b/go/sql/create_table_parser.go
@@ -1,0 +1,115 @@
+/*
+   Copyright 2022 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package sql
+
+type CreateTableParser struct {
+	createTableStatementBody string
+
+	explicitSchema         string
+	explicitTable          string
+	hasForeignKeys         bool
+	isAutoIncrementDefined bool
+}
+
+func NewCreateTableParser(statement string) *CreateTableParser {
+	return &CreateTableParser{
+		createTableStatementBody: statement,
+	}
+}
+
+func NewParserFromCreateTableStatement(alterStatement string) *CreateTableParser {
+	parser := NewCreateTableParser(alterStatement)
+	parser.ParseStatement()
+	return parser
+}
+
+func (this *CreateTableParser) ParseStatement() (err error) {
+	for _, createTableRegexp := range createTableExplicitSchemaTableRegexps {
+		if submatch := createTableRegexp.FindStringSubmatch(this.createTableStatementBody); len(submatch) > 0 {
+			this.explicitSchema = submatch[1]
+			this.explicitTable = submatch[2]
+			this.createTableStatementBody = submatch[3]
+			break
+		}
+	}
+	for _, createTableRegexp := range createTableExplicitTableRegexps {
+		if submatch := createTableRegexp.FindStringSubmatch(this.createTableStatementBody); len(submatch) > 0 {
+			this.explicitTable = submatch[1]
+			this.createTableStatementBody = submatch[2]
+			break
+		}
+	}
+	for _, token := range tokenizeStatement(this.createTableStatementBody) {
+		token = sanitizeQuotesFromToken(token)
+		this.parseCreateTableToken(token)
+	}
+	return nil
+}
+
+func (this *CreateTableParser) parseCreateTableToken(token string) {
+	{
+		// foreign key.
+		if foreignKeyTableRegexp.MatchString(token) {
+			this.hasForeignKeys = true
+		}
+	}
+	{
+		// auto_increment
+		if autoIncrementRegexp.MatchString(token) {
+			this.isAutoIncrementDefined = true
+		}
+	}
+}
+
+func (this *CreateTableParser) Type() ParserType {
+	return ParserTypeCreateTable
+}
+
+func (this *CreateTableParser) GetNonTrivialRenames() map[string]string {
+	return make(map[string]string)
+}
+
+func (this *CreateTableParser) HasNonTrivialRenames() bool {
+	return len(this.GetNonTrivialRenames()) > 0
+}
+
+func (this *CreateTableParser) DroppedColumnsMap() map[string]bool {
+	return nil
+}
+
+func (this *CreateTableParser) IsRenameTable() bool {
+	// We always return false because we need to check for table renames manually
+	// outside the parser.
+	return false
+}
+
+func (this *CreateTableParser) IsAutoIncrementDefined() bool {
+	return this.isAutoIncrementDefined
+}
+
+func (this *CreateTableParser) GetExplicitSchema() string {
+	return this.explicitSchema
+}
+
+func (this *CreateTableParser) HasExplicitSchema() bool {
+	return this.GetExplicitSchema() != ""
+}
+
+func (this *CreateTableParser) GetExplicitTable() string {
+	return this.explicitTable
+}
+
+func (this *CreateTableParser) HasExplicitTable() bool {
+	return this.GetExplicitTable() != ""
+}
+
+func (this *CreateTableParser) GetOptions() string {
+	return this.createTableStatementBody
+}
+
+func (this *CreateTableParser) HasForeignKeys() bool {
+	return this.hasForeignKeys
+}

--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -13,6 +13,41 @@ import (
 	"strings"
 )
 
+type ParserType int
+
+const (
+	ParserTypeUnknown ParserType = iota
+	ParserTypeAlterTable
+	ParserTypeCreateTable
+)
+
+func (t ParserType) String() string {
+	switch t {
+	case ParserTypeAlterTable:
+		return "alter"
+	case ParserTypeCreateTable:
+		return "create-table"
+	default:
+		return ""
+	}
+}
+
+type Parser interface {
+	Type() ParserType
+	ParseStatement() error
+	GetNonTrivialRenames() map[string]string
+	HasNonTrivialRenames() bool
+	DroppedColumnsMap() map[string]bool
+	IsRenameTable() bool
+	IsAutoIncrementDefined() bool
+	GetExplicitSchema() string
+	HasExplicitSchema() bool
+	GetExplicitTable() string
+	HasExplicitTable() bool
+	HasForeignKeys() bool
+	GetOptions() string
+}
+
 type ColumnType int
 
 const (

--- a/localtests/create-table/create.sql
+++ b/localtests/create-table/create.sql
@@ -1,0 +1,29 @@
+drop table if exists gh_ost_test;
+create table gh_ost_test (
+	id int auto_increment,
+	a int not null,
+	b int not null,
+	primary key(id)
+) auto_increment=1;
+
+drop event if exists gh_ost_test;
+delimiter ;;
+create event gh_ost_test
+  on schedule every 1 second
+  starts current_timestamp
+  ends current_timestamp + interval 60 second
+  on completion not preserve
+  enable
+  do
+begin
+insert into gh_ost_test (id, a, b) values (null, 2,3);
+insert into gh_ost_test (id, a, b) values (null, 2,4);
+insert into gh_ost_test (id, a, b) values (null, 2,5);
+insert into gh_ost_test (id, a, b) values (null, 2,6);
+insert into gh_ost_test (id, a, b) values (null, 2,7);
+insert into gh_ost_test (id, a, b) values (null, 2,8);
+insert into gh_ost_test (id, a, b) values (null, 2,9);
+insert into gh_ost_test (id, a, b) values (null, 2,0);
+insert into gh_ost_test (id, a, b) values (null, 2,1);
+insert into gh_ost_test (id, a, b) values (null, 2,2);
+end ;;

--- a/localtests/create-table/extra_args
+++ b/localtests/create-table/extra_args
@@ -1,0 +1,2 @@
+--alter=""
+--create-table="(id int auto_increment, a int not null, b int not null, primary key(id), KEY new_index (a))"


### PR DESCRIPTION
### Description

This PR adds a new flag called "--create-table", an alternative to the "--alter" flag. With "--create-table" you can redefine the table that you want gh-ost to migrate to, effectively supporting what would have required multiple ALTERs.

For example, If you need to restructure the secondary indexes on a MySQL table, you would need to do the following:

_Assuming a and b are already columns in the table_...

- ADD COLUMN `x`INT, ADD COLUMN `y` VARCHAR(24),
   ADD INDEX `a_x_idx` (`a`, `x`),
   ADD INDEX `y_idx` (y),
   DROP INDEX `a_b_idx`

Now you can simply provide a "--create-table" flag like so
```
--create-table="( ..., x INT, y VARCHAR(24), ... KEY a_x_idx (a,x), KEY y_idx (y) ...)"
```

The PR is a bit large as it includes some refactors to maintain code cleanliness. I can separate out some of the refactors into separate PRs for ease of review
