### PR TITLE
analyze table before cutover

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1196,6 +1196,23 @@ func (this *Applier) ApplyDMLEventQueries(dmlEvents [](*binlog.BinlogDMLEvent)) 
 	return nil
 }
 
+// AnalyzeTable actively analyze table to ensure that the ghost table's statistics are timely updated
+func (this *Applier) AnalyzeTable() {
+	query := fmt.Sprintf(`analyze table /* gh-ost */ %s.%s`,
+		sql.EscapeName(this.migrationContext.DatabaseName),
+		sql.EscapeName(this.migrationContext.GetGhostTableName()),
+	)
+
+	this.migrationContext.Log.Infof("Analyzing ghost table %s.%s",
+		sql.EscapeName(this.migrationContext.DatabaseName),
+		sql.EscapeName(this.migrationContext.GetGhostTableName()),
+	)
+	if _, err := sqlutils.ExecNoPrepare(this.db, query); err != nil {
+		this.migrationContext.Log.Warningf("Ghost table analyzes failed")
+	}
+	this.migrationContext.Log.Infof("Ghost table analyzed")
+}
+
 func (this *Applier) Teardown() {
 	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -420,6 +420,9 @@ func (this *Migrator) Migrate() (err error) {
 	}
 	this.printStatus(ForcePrintStatusRule)
 
+	// analyze table before cutover
+	this.applier.AnalyzeTable()
+
 	if this.migrationContext.IsCountingTableRows() {
 		this.migrationContext.Log.Info("stopping query for exact row count, because that can accidentally lock out the cut over")
 		this.migrationContext.CancelTableRowsCount()


### PR DESCRIPTION
Related issue: #1418 

Description:
analyze ghost table before cutover to avoid table statistics not timely updated.