### PR TITLE
skip delete events of changelog table in onChangelogEvent function

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -200,6 +200,11 @@ func (this *Migrator) canStopStreaming() bool {
 
 // onChangelogEvent is called when a binlog event operation on the changelog table is intercepted.
 func (this *Migrator) onChangelogEvent(dmlEvent *binlog.BinlogDMLEvent) (err error) {
+	if dmlEvent.NewColumnValues == nil {
+		// for some compatible systems, such as OceanBase Binlog Service, UPSERT is transferred to
+		// DELETE + INSERT, we need to skip DELETE events here.
+		return nil
+	}
 	// Hey, I created the changelog table, I know the type of columns it has!
 	switch hint := dmlEvent.NewColumnValues.StringColumn(2); hint {
 	case "state":


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related issue: https://github.com/github/gh-ost/issues/1427

### Description

This PR skip the DELETE events of changelog table in onChangelogEvent function.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
