### PR TITLE
refactor cutover for MySQL 8.x rename feature && support OceanBase

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -103,6 +103,7 @@ type MigrationContext struct {
 	GoogleCloudPlatform      bool
 	AzureMySQL               bool
 	AttemptInstantDDL        bool
+	OceanBase                bool
 
 	// SkipPortValidation allows skipping the port validation in `ValidateConnection`
 	// This is useful when connecting to a MySQL instance where the external port

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -60,7 +60,7 @@ func (this *Inspector) InitDBConnections() (err error) {
 	}
 	this.dbVersion = this.migrationContext.InspectorMySQLVersion
 
-	if !this.migrationContext.AliyunRDS && !this.migrationContext.GoogleCloudPlatform && !this.migrationContext.AzureMySQL {
+	if !this.migrationContext.AliyunRDS && !this.migrationContext.GoogleCloudPlatform && !this.migrationContext.AzureMySQL && !this.migrationContext.OceanBase {
 		if impliedKey, err := mysql.GetInstanceKey(this.db); err != nil {
 			return err
 		} else {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Close #1433  Close #1427

### Description

This PR is based on #715 by @shlomi-noach. There is a new option `--oceanbase` which is introduced for OceanBase Binlog Service, just like the `azure` and `gcp` options. This PR would also change the behavior of the atomic cut over on MySQL 8.0.13 and later versions, please let me know if anyone have concerns about it.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
