### PR TITLE
Add `--transaction-isolation` flag

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -6,6 +6,7 @@
 package base
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -292,13 +293,16 @@ func NewMigrationContext() *MigrationContext {
 	}
 }
 
-func (this *MigrationContext) SetConnectionConfig(storageEngine string) error {
-	var transactionIsolation string
+func (this *MigrationContext) SetConnectionConfig(storageEngine, transactionIsolation string) error {
 	switch storageEngine {
 	case "rocksdb":
 		transactionIsolation = "READ-COMMITTED"
 	default:
-		transactionIsolation = "REPEATABLE-READ"
+		switch transactionIsolation {
+		case "READ-COMMITTED", "REPEATABLE-READ":
+		default:
+			return errors.New("unsupported transaction isolation level")
+		}
 	}
 	this.InspectorConnectionConfig.TransactionIsolation = transactionIsolation
 	this.ApplierConnectionConfig.TransactionIsolation = transactionIsolation

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -109,6 +109,7 @@ func main() {
 	dmlBatchSize := flag.Int64("dml-batch-size", 10, "batch size for DML events to apply in a single transaction (range 1-100)")
 	defaultRetries := flag.Int64("default-retries", 60, "Default number of retries for various operations before panicking")
 	cutOverLockTimeoutSeconds := flag.Int64("cut-over-lock-timeout-seconds", 3, "Max number of seconds to hold locks on tables while attempting to cut-over (retry attempted when lock exceeds timeout)")
+	transactionIsolation := flag.String("transaction-isolation", "REPEATABLE-READ", "transaction isolation level to be used by the applier and inspector. Possible options: REPEATABLE-READ or READ-COMMITTED")
 	niceRatio := flag.Float64("nice-ratio", 0, "force being 'nice', imply sleep time per chunk time; range: [0.0..100.0]. Example values: 0 is aggressive. 1: for every 1ms spent copying rows, sleep additional 1ms (effectively doubling runtime); 0.7: for every 10ms spend in a rowcopy chunk, spend 7ms sleeping immediately after")
 
 	maxLagMillis := flag.Int64("max-lag-millis", 1500, "replication lag at which to throttle operation")
@@ -189,7 +190,7 @@ func main() {
 		migrationContext.Log.SetLevel(log.ERROR)
 	}
 
-	if err := migrationContext.SetConnectionConfig(*storageEngine); err != nil {
+	if err := migrationContext.SetConnectionConfig(*storageEngine, *transactionIsolation); err != nil {
 		migrationContext.Log.Fatale(err)
 	}
 


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related issue: https://github.com/github/gh-ost/issues/1262

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR resolves https://github.com/github/gh-ost/issues/1262 by adding a `--transaction-isolation` flag that supports both `REPEATABLE-READ` _(default - what GitHub tests)_ and `READ-COMMITTED`

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
