### PR TITLE
Tweak the testcontainers setup

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -103,6 +103,11 @@ type MigrationContext struct {
 	AzureMySQL               bool
 	AttemptInstantDDL        bool
 
+	// SkipPortValidation allows skipping the port validation in `ValidateConnection`
+	// This is useful when connecting to a MySQL instance where the external port
+	// may not match the internal port.
+	SkipPortValidation bool
+
 	config            ContextConfig
 	configMutex       *sync.Mutex
 	ConfigFile        string

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -63,18 +63,27 @@ func StringContainsAll(s string, substrings ...string) bool {
 
 func ValidateConnection(db *gosql.DB, connectionConfig *mysql.ConnectionConfig, migrationContext *MigrationContext, name string) (string, error) {
 	versionQuery := `select @@global.version`
-	var port, extraPort int
+
 	var version string
 	if err := db.QueryRow(versionQuery).Scan(&version); err != nil {
 		return "", err
 	}
+
+	if migrationContext.SkipPortValidation {
+		return version, nil
+	}
+
+	var extraPort int
+
 	extraPortQuery := `select @@global.extra_port`
 	if err := db.QueryRow(extraPortQuery).Scan(&extraPort); err != nil { //nolint:staticcheck
 		// swallow this error. not all servers support extra_port
 	}
+
 	// AliyunRDS set users port to "NULL", replace it by gh-ost param
 	// GCP set users port to "NULL", replace it by gh-ost param
 	// Azure MySQL set users port to a different value by design, replace it by gh-ost para
+	var port int
 	if migrationContext.AliyunRDS || migrationContext.GoogleCloudPlatform || migrationContext.AzureMySQL {
 		port = connectionConfig.Key.Port
 	} else {


### PR DESCRIPTION
### Description

This PR attempts to improve the testcontainers ergonomics.

* Added a new `SkipPortValidation` on the migration context. This is only used internally and allows skipping the port validation, which is useful with MySQL containers running in docker with a randomly assigned "external" port.

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
