### PR TITLE
Avoid logging MySQL connection configs 

### DIFF
--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -320,7 +320,7 @@ func main() {
 	migrator := logic.NewMigrator(migrationContext, AppVersion)
 	if err := migrator.Migrate(); err != nil {
 		migrator.ExecOnFailureHook()
-		migrationContext.Log.Fatale(err)
+		migrationContext.Log.Fatale("Migration failed. Please check the logs for more details.")
 	}
 	fmt.Fprintln(os.Stdout, "# Done")
 }

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -320,7 +320,7 @@ func main() {
 	migrator := logic.NewMigrator(migrationContext, AppVersion)
 	if err := migrator.Migrate(); err != nil {
 		migrator.ExecOnFailureHook()
-		migrationContext.Log.Fatale("Migration failed. Please check the logs for more details.")
+		migrationContext.Log.Fatale(err)
 	}
 	fmt.Fprintln(os.Stdout, "# Done")
 }

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	ErrMigratorUnsupportedRenameAlter = errors.New("ALTER statement seems to RENAME the table. This is not supported, and you should run your RENAME outside gh-ost.")
+	ErrMigrationNotAllowedOnMaster    = errors.New("It seems like this migration attempt to run directly on master. Preferably it would be executed on a replica (this reduces load from the master). To proceed please provide --allow-on-master.")
 	RetrySleepFn                      = time.Sleep
 )
 
@@ -809,7 +810,7 @@ func (this *Migrator) initiateInspector() (err error) {
 			this.migrationContext.AddThrottleControlReplicaKey(this.migrationContext.InspectorConnectionConfig.Key)
 		}
 	} else if this.migrationContext.InspectorIsAlsoApplier() && !this.migrationContext.AllowedRunningOnMaster {
-		return fmt.Errorf("It seems like this migration attempt to run directly on master. Preferably it would be executed on a replica (and this reduces load from the master). To proceed please provide --allow-on-master. Inspector config=%+v, applier config=%+v", this.migrationContext.InspectorConnectionConfig, this.migrationContext.ApplierConnectionConfig)
+		return ErrMigrationNotAllowedOnMaster
 	}
 	if err := this.inspector.validateLogSlaveUpdates(); err != nil {
 		return err


### PR DESCRIPTION
Avoid logging MySQL connection configs.
Fix for [https://github.com/github/gh-ost/security/code-scanning/2](https://github.com/github/gh-ost/security/code-scanning/2)
