### PR TITLE
Upgrade builder images to go 1.23

### DIFF
--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -1,4 +1,4 @@
-FROM golang:1.22-bullseye
+FROM golang:1.23-bullseye
 
 RUN apt-get update
 RUN apt-get install -y ruby ruby-dev rubygems build-essential

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.22-bullseye
+FROM golang:1.23-bullseye
 LABEL maintainer="github@github.com"
 
 RUN apt-get update


### PR DESCRIPTION
Upgrade builder docker images to go 1.23

Following up to https://github.com/github/gh-ost/pull/1511 so the cibuild works.