### PR TITLE
Move successful cleanup into func

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -361,15 +361,6 @@ func (this *Migrator) Migrate() (err error) {
 	if err := this.createFlagFiles(); err != nil {
 		return err
 	}
-	onSuccessFunc := func() error {
-		if err := this.finalCleanup(); err != nil {
-			return nil //nolint:nilerr
-		}
-		if err := this.hooksExecutor.onSuccess(); err != nil {
-			return err
-		}
-		return nil
-	}
 	// In MySQL 8.0 (and possibly earlier) some DDL statements can be applied instantly.
 	// Attempt to do this if AttemptInstantDDL is set.
 	if this.migrationContext.AttemptInstantDDL {
@@ -378,7 +369,10 @@ func (this *Migrator) Migrate() (err error) {
 		} else {
 			this.migrationContext.Log.Infof("Attempting to execute alter with ALGORITHM=INSTANT")
 			if err := this.applier.AttemptInstantDDL(); err == nil {
-				if err := onSuccessFunc(); err != nil {
+				if err := this.finalCleanup(); err != nil {
+					return nil
+				}
+				if err := this.hooksExecutor.onSuccess(); err != nil {
 					return err
 				}
 				this.migrationContext.Log.Infof("Success! table %s.%s migrated instantly", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
@@ -460,7 +454,10 @@ func (this *Migrator) Migrate() (err error) {
 	}
 	atomic.StoreInt64(&this.migrationContext.CutOverCompleteFlag, 1)
 
-	if err := onSuccessFunc(); err != nil {
+	if err := this.finalCleanup(); err != nil {
+		return nil
+	}
+	if err := this.hooksExecutor.onSuccess(); err != nil {
 		return err
 	}
 	this.migrationContext.Log.Infof("Done migrating %s.%s", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -363,7 +363,7 @@ func (this *Migrator) Migrate() (err error) {
 	}
 	onSuccessFunc := func() error {
 		if err := this.finalCleanup(); err != nil {
-			return nil
+			return nil //nolint:nilerr
 		}
 		if err := this.hooksExecutor.onSuccess(); err != nil {
 			return err


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1510

### Description

Trying to fix inconsistent behavior between instant and usual ways of migrating. 

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
