### PR TITLE
Fix output for `binary` keys in `-verbose` mode.

### DIFF
--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -325,7 +325,7 @@ func (this *ColumnValues) AbstractValues() []interface{} {
 func (this *ColumnValues) StringColumn(index int) string {
 	val := this.AbstractValues()[index]
 	if ints, ok := val.([]uint8); ok {
-		return string(ints)
+		return fmt.Sprintf("%x", ints)
 	}
 	return fmt.Sprintf("%+v", val)
 }

--- a/go/sql/types_test.go
+++ b/go/sql/types_test.go
@@ -40,3 +40,12 @@ func TestGetColumn(t *testing.T) {
 		require.Nil(t, column)
 	}
 }
+
+func TestBinaryToString(t *testing.T) {
+	id := []uint8{0x1b, 0x99}
+	col := make([]interface{}, 1)
+	col[0] = id
+	cv := ToColumnValues(col)
+
+	require.Equal(t, "1b99", cv.StringColumn(0))
+}


### PR DESCRIPTION
### Description

When migrating a table with a `binary` key in `-verbose` mode, different sequences of bytes may prevent execution output from being logged, or correctly logged, to the console.

This happens because the `MigrationRange*Values` are printed to the screen without any type of encoding. One particularly problematic sequence is `27`/`0x1b`, `Escape`, which causes the terminal to stop logging for the duration of the migration:

```
2025-05-23 11:53:27 INFO Listening on unix socket file: /tmp/gh-ost.test.binfoo.sock
2025-05-23 11:53:27 INFO Intercepted changelog state ReadMigrationRangeValues
2025-05-23 11:53:27 INFO Handled changelog state ReadMigrationRangeValues
2025-05-23 11:53:27 INFO Migration min values: [
```

This commit changes the to-string rendering for `binary` keys, rendering the values as a hex string rather than an unescaped series of bytes:

```
2025-05-23 11:53:58 INFO Listening on unix socket file: /tmp/gh-ost.test.binfoo.sock
2025-05-23 11:53:58 INFO Intercepted changelog state ReadMigrationRangeValues
2025-05-23 11:53:58 INFO Handled changelog state ReadMigrationRangeValues
2025-05-23 11:53:58 INFO Migration min values: [b51b0000000000000000000000000000]
2025-05-23 11:53:58 INFO Migration max values: [b51b0000000000000000000000000000]
2025-05-23 11:53:58 INFO Waiting for first throttle metrics to be collected
...
```

While this build passes and has the expected outcome locally, I'm not positive that this change to `StringColumn`  is used only for logging/debugging purposes. This is something I hope you can verify.


> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
