### PR TITLE
Fix conversion bug when string data comes from binlog

### DIFF
--- a/go/sql/types.go
+++ b/go/sql/types.go
@@ -53,14 +53,22 @@ type Column struct {
 }
 
 func (this *Column) convertArg(arg interface{}, isUniqueKeyColumn bool) interface{} {
+	var arg2Bytes []byte
 	if s, ok := arg.(string); ok {
-		arg2Bytes := []byte(s)
-		// convert to bytes if character string without charsetConversion.
+		arg2Bytes = []byte(s)
+	} else if b, ok := arg.([]uint8); ok {
+		arg2Bytes = b
+	} else {
+		arg2Bytes = nil
+	}
+
+	if arg2Bytes != nil {
 		if this.Charset != "" && this.charsetConversion == nil {
 			arg = arg2Bytes
 		} else {
 			if encoding, ok := charsetEncodingMap[this.Charset]; ok {
-				arg, _ = encoding.NewDecoder().String(s)
+				decodedBytes, _ := encoding.NewDecoder().Bytes(arg2Bytes)
+				arg = string(decodedBytes)
 			}
 		}
 

--- a/go/sql/types_test.go
+++ b/go/sql/types_test.go
@@ -49,3 +49,19 @@ func TestBinaryToString(t *testing.T) {
 
 	require.Equal(t, "1b99", cv.StringColumn(0))
 }
+
+func TestConvertArgCharsetDecoding(t *testing.T) {
+	latin1Bytes := []uint8{0x47, 0x61, 0x72, 0xe7, 0x6f, 0x6e, 0x20, 0x21}
+
+	col := Column{
+		Charset: "latin1",
+		charsetConversion: &CharacterSetConversion{
+			FromCharset: "latin1",
+			ToCharset:   "utf8mb4",
+		},
+	}
+
+	// Should decode []uint8
+	str := col.convertArg(latin1Bytes, false)
+	require.Equal(t, "Garçon !", str)
+}


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1568

### Description

This PR fixes a string conversion bug by applying character set conversions when the input is `[]uint8`, in addition to the existing case of when the input is `string`.

When using gh-ost to migrate a table from latin1 to utf8mb3 character encoding, the initial data copy works correctly, but new data with special characters inserted during the migration via binlog replication fails with "Incorrect string value" errors.

The reason for this is that the data is a binary byte array when converted from the binlog, so the character set conversion is not applied.

I added a new test for latin1-encoded byte array input to this method and confirmed that the reproduction from the linked issue is fixed with this change.

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
