### PR TITLE
Panic if InitiateHeartbeat exhausts retries to avoid looping infinitely

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -574,6 +574,7 @@ func (this *Applier) InitiateHeartbeat() {
 			continue
 		}
 		if err := injectHeartbeat(); err != nil {
+			this.migrationContext.PanicAbort <- fmt.Errorf("injectHeartbeat writing failed %d times, last error: %w", numSuccessiveFailures, err)
 			return
 		}
 	}


### PR DESCRIPTION
Based on experience, if the writer database fails inbeetween the copy & cutover stages (e.g. during cutover pause), the heartbeat writes will fail and stop, then leading to throttled state and an infinite loop of `throttler.shouldThrottle()`.

Since this state is irrecoverable, make the heartbeat writer panic if retries are exhausted, so that the migration can fail and be restarted later.

We've tested this in production now without issues, but if there's some desired behaviour that this PR changes, we might consider adding a new CLI option to control it - feedback welcome.

Closes https://github.com/github/gh-ost/issues/1569 (issue has some more context too)

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
