### PR TITLE
fix(applier): added support for unique text column, they are mapped to uint8[]

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -8,6 +8,7 @@ package logic
 import (
 	gosql "database/sql"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync/atomic"
@@ -1298,7 +1299,8 @@ func (this *Applier) updateModifiesUniqueKeyColumns(dmlEvent *binlog.BinlogDMLEv
 		tableOrdinal := this.migrationContext.OriginalTableColumns.Ordinals[column.Name]
 		whereColumnValue := dmlEvent.WhereColumnValues.AbstractValues()[tableOrdinal]
 		newColumnValue := dmlEvent.NewColumnValues.AbstractValues()[tableOrdinal]
-		if newColumnValue != whereColumnValue {
+
+		if !reflect.DeepEqual(whereColumnValue, newColumnValue) {
 			return column.Name, true
 		}
 	}

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -62,8 +62,8 @@ func TestApplierGenerateSqlModeQuery(t *testing.T) {
 }
 
 func TestApplierUpdateModifiesUniqueKeyColumns(t *testing.T) {
-	columns := sql.NewColumnList([]string{"id", "item_id"})
-	columnValues := sql.ToColumnValues([]interface{}{123456, 42})
+	columns := sql.NewColumnList([]string{"id", "item_id", "item_text"})
+	columnValues := sql.ToColumnValues([]interface{}{123456, 42, []uint8{116, 101, 115, 116}})
 
 	migrationContext := base.NewMigrationContext()
 	migrationContext.OriginalTableColumns = columns


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1582


### Description

This PR changes the `updateModifiesUniqueKeyColumns` function in `applier.go` to use `reflect.DeepEqual` for value comparison to handle unique keys that are text fields because they are mapped to unit8[] slices.
