### PR TITLE
Change coordinates column in checkpoint table to `TEXT`

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -433,7 +433,7 @@ func (this *Applier) CreateCheckpointTable() error {
 	colDefs := []string{
 		"`gh_ost_chk_id` bigint auto_increment primary key",
 		"`gh_ost_chk_timestamp` bigint",
-		"`gh_ost_chk_coords` varchar(4096)",
+		"`gh_ost_chk_coords` text charset ascii",
 		"`gh_ost_chk_iteration` bigint",
 		"`gh_ost_rows_copied` bigint",
 		"`gh_ost_dml_applied` bigint",


### PR DESCRIPTION
### Description

This PR changes the `gh_ost_chk_coords` column in the checkpoint table from `VARCHAR(4096)` to ascii `TEXT` column, so it can store GTID sets up to 65,535 characters long.

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
