### PR TITLE
fix: add missing error check for WriteChangelogState in initiateApplier

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1362,7 +1362,9 @@ func (this *Migrator) initiateApplier() error {
 				return err
 			}
 		}
-		this.applier.WriteChangelogState(string(GhostTableMigrated))
+		if _, err := this.applier.WriteChangelogState(string(GhostTableMigrated)); err != nil {
+			return err
+		}
 	}
 
 	// ensure performance_schema.metadata_locks is available.


### PR DESCRIPTION
The WriteChangelogState call at line 1365 was missing error handling, which could cause the migration to fail silently if the changelog table was not properly created. This manifested as a "Table doesn't exist" error later in the migration process.

All other calls to WriteChangelogState in the codebase properly check for errors, so I'm guessing this was just overlooked

## A Pull Request should be associated with an Issue.

Relates to https://github.com/github/gh-ost/issues/1622. This doesn't actually solve "why didn't the changelog table get created in my migration" but it does handle the error when trying to write to that table.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/gh-ost/issues/0123456789

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR [briefly explain what it does]

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
