### PR TITLE
chore(script): use GOPATH variable instead of hardcoded path

### DIFF
--- a/script/build
+++ b/script/build
@@ -14,7 +14,7 @@ version=$(git rev-parse HEAD)
 describe=$(git describe --tags --always --dirty)
 
 export GOPATH="$PWD/.gopath"
-cd .gopath/src/github.com/github/gh-ost
+cd "$GOPATH/src/github.com/github/gh-ost"
 
 # We put the binaries directly into the bindir, because we have no need for shim wrappers
 go build -o "$bindir/gh-ost" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/gh-ost/main.go


### PR DESCRIPTION
Replace hardcoded GOPATH path with $GOPATH variable to improve portability of the build script.