### PR TITLE
Add `GH_OST_INSTANT_DDL` for gh-ost-on-success hook

### DIFF
--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -81,7 +81,7 @@ The following variables are available on all hooks:
 
 The following variable are available on particular hooks:
 
-- `GH_OST_INSTANT_DDL` is only available in `gh-ost-on-success`. The value is true if instant DDL was successful.
+- `GH_OST_INSTANT_DDL` is only available in `gh-ost-on-success`. The value is `true` if instant DDL was successful, and `false` if it was not.
 - `GH_OST_COMMAND` is only available in `gh-ost-on-interactive-command`
 - `GH_OST_STATUS` is only available in `gh-ost-on-status`
 - `GH_OST_LAST_BATCH_COPY_ERROR` is only available in `gh-ost-on-batch-copy-retry`

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -81,6 +81,7 @@ The following variables are available on all hooks:
 
 The following variable are available on particular hooks:
 
+- `GH_OST_INSTANT_DDL` is only available in `gh-ost-on-success`. The value is true if instant DDL was successful.
 - `GH_OST_COMMAND` is only available in `gh-ost-on-interactive-command`
 - `GH_OST_STATUS` is only available in `gh-ost-on-status`
 - `GH_OST_LAST_BATCH_COPY_ERROR` is only available in `gh-ost-on-batch-copy-retry`

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -148,8 +148,9 @@ func (this *HooksExecutor) onInteractiveCommand(command string) error {
 	return this.executeHooks(onInteractiveCommand, v)
 }
 
-func (this *HooksExecutor) onSuccess() error {
-	return this.executeHooks(onSuccess)
+func (this *HooksExecutor) onSuccess(instantDDL bool) error {
+	v := fmt.Sprintf("GH_OST_INSTANT_DDL=%t", instantDDL)
+	return this.executeHooks(onSuccess, v)
 }
 
 func (this *HooksExecutor) onFailure() error {

--- a/go/logic/hooks_test.go
+++ b/go/logic/hooks_test.go
@@ -105,6 +105,8 @@ func TestHooksExecutorExecuteHooks(t *testing.T) {
 				require.Equal(t, 50.0, progress)
 			case "GH_OST_TABLE_NAME":
 				require.Equal(t, migrationContext.OriginalTableName, split[1])
+			case "GH_OST_INSTANT_DDL":
+				require.Equal(t, "false", split[1])
 			case "TEST":
 				require.Equal(t, t.Name(), split[1])
 			}

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -478,13 +478,14 @@ func (this *Migrator) Migrate() (err error) {
 	if this.migrationContext.AttemptInstantDDL {
 		if this.migrationContext.Noop {
 			this.migrationContext.Log.Debugf("Noop operation; not really attempting instant DDL")
+			return this.hooksExecutor.onSuccess(true)
 		} else {
 			this.migrationContext.Log.Infof("Attempting to execute alter with ALGORITHM=INSTANT")
 			if err := this.applier.AttemptInstantDDL(); err == nil {
 				if err := this.finalCleanup(); err != nil {
 					return nil
 				}
-				if err := this.hooksExecutor.onSuccess(); err != nil {
+				if err := this.hooksExecutor.onSuccess(true); err != nil {
 					return err
 				}
 				this.migrationContext.Log.Infof("Success! table %s.%s migrated instantly", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
@@ -620,7 +621,7 @@ func (this *Migrator) Migrate() (err error) {
 	if err := this.finalCleanup(); err != nil {
 		return nil
 	}
-	if err := this.hooksExecutor.onSuccess(); err != nil {
+	if err := this.hooksExecutor.onSuccess(false); err != nil {
 		return err
 	}
 	this.migrationContext.Log.Infof("Done migrating %s.%s", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
@@ -734,7 +735,7 @@ func (this *Migrator) Revert() error {
 	if err := this.finalCleanup(); err != nil {
 		return nil
 	}
-	if err := this.hooksExecutor.onSuccess(); err != nil {
+	if err := this.hooksExecutor.onSuccess(false); err != nil {
 		return err
 	}
 	this.migrationContext.Log.Infof("Done reverting %s.%s", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -478,7 +478,6 @@ func (this *Migrator) Migrate() (err error) {
 	if this.migrationContext.AttemptInstantDDL {
 		if this.migrationContext.Noop {
 			this.migrationContext.Log.Debugf("Noop operation; not really attempting instant DDL")
-			return this.hooksExecutor.onSuccess(true)
 		} else {
 			this.migrationContext.Log.Infof("Attempting to execute alter with ALGORITHM=INSTANT")
 			if err := this.applier.AttemptInstantDDL(); err == nil {


### PR DESCRIPTION
### Description

This PR adds boolean environment variable `GH_OST_INSTANT_DDL` for `gh-ost-on-success` hook, so one can tell whether gh-ost used instant DDL successfully  


> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
