### PR TITLE
Prevent race condition on cutover completion

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -749,6 +749,11 @@ func (this *Applier) InitiateHeartbeat() {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}
+
+		if atomic.LoadInt64(&this.migrationContext.CutOverCompleteFlag) > 0 {
+			return
+		}
+
 		// Generally speaking, we would issue a goroutine, but I'd actually rather
 		// have this block the loop rather than spam the master in the event something
 		// goes wrong

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -750,7 +750,7 @@ func (this *Applier) InitiateHeartbeat() {
 			return
 		}
 
-		if atomic.LoadInt64(&this.migrationContext.CutOverCompleteFlag) > 0 {
+		if atomic.LoadInt64(&this.migrationContext.CleanupImminentFlag) > 0 {
 			return
 		}
 


### PR DESCRIPTION
### Description

This PR fixes a race between the heartbeat goroutine and `finalCleanup()` that can cause gh-ost to panic with a misleading FATAL after a successful migration:

```
FATAL injectHeartbeat writing failed 121 times, last error: Error 1146 (42S02): Table '<schema>._<table>_ghc' doesn't exist
```

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
