### PR TITLE
Retry attempt InstantDDL up to `--default-retries`

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -308,16 +308,15 @@ func (this *Applier) AttemptInstantDDL() error {
 	return retryOnLockWaitTimeout(func() error {
 		_, err := this.db.Exec(query)
 		return err
-	}, this.migrationContext.Log)
+	}, this.migrationContext.MaxRetries(), this.migrationContext.Log)
 }
 
 // retryOnLockWaitTimeout retries the given operation on MySQL lock wait timeout
 // (errno 1205). Non-timeout errors return immediately. This is used for instant
 // DDL attempts where the operation may be blocked by a long-running transaction.
-func retryOnLockWaitTimeout(operation func() error, logger base.Logger) error {
-	const maxRetries = 5
+func retryOnLockWaitTimeout(operation func() error, maxRetries int64, logger base.Logger) error {
 	var err error
-	for i := 0; i < maxRetries; i++ {
+	for i := int64(0); i < maxRetries; i++ {
 		if i != 0 {
 			logger.Infof("Retrying after lock wait timeout (attempt %d/%d)", i+1, maxRetries)
 			RetrySleepFn(time.Duration(i) * 5 * time.Second)

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -216,7 +216,7 @@ func TestRetryOnLockWaitTimeout(t *testing.T) {
 		err := retryOnLockWaitTimeout(func() error {
 			calls++
 			return nil
-		}, logger)
+		}, int64(5), logger)
 		require.NoError(t, err)
 		require.Equal(t, 1, calls)
 	})
@@ -229,7 +229,7 @@ func TestRetryOnLockWaitTimeout(t *testing.T) {
 				return lockWaitTimeoutErr
 			}
 			return nil
-		}, logger)
+		}, int64(5), logger)
 		require.NoError(t, err)
 		require.Equal(t, 3, calls)
 	})
@@ -239,7 +239,7 @@ func TestRetryOnLockWaitTimeout(t *testing.T) {
 		err := retryOnLockWaitTimeout(func() error {
 			calls++
 			return nonRetryableErr
-		}, logger)
+		}, int64(5), logger)
 		require.ErrorIs(t, err, nonRetryableErr)
 		require.Equal(t, 1, calls)
 	})
@@ -250,7 +250,7 @@ func TestRetryOnLockWaitTimeout(t *testing.T) {
 		err := retryOnLockWaitTimeout(func() error {
 			calls++
 			return genericErr
-		}, logger)
+		}, int64(5), logger)
 		require.ErrorIs(t, err, genericErr)
 		require.Equal(t, 1, calls)
 	})
@@ -260,7 +260,7 @@ func TestRetryOnLockWaitTimeout(t *testing.T) {
 		err := retryOnLockWaitTimeout(func() error {
 			calls++
 			return lockWaitTimeoutErr
-		}, logger)
+		}, int64(5), logger)
 		require.ErrorIs(t, err, lockWaitTimeoutErr)
 		require.Equal(t, 5, calls)
 	})


### PR DESCRIPTION
Following on https://github.com/github/gh-ost/pull/1651, increase the max instant DDL attempts from 5 to `MaxRetries`, which is configurable with `--default-retries`. In high-concurrency environments, we may need more retries due to metadata lock wait timeout.  

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
