### PR TITLE
Prevent throttle() from blocking forever when context is cancelled

### DIFF
--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -504,6 +504,8 @@ func (thlr *Throttler) initiateThrottlerChecks() {
 // throttle sees if throttling needs take place, and if so, continuously sleeps (blocks)
 // until throttling reasons are gone
 func (thlr *Throttler) throttle(onThrottled func()) {
+	timer := time.NewTimer(250 * time.Millisecond)
+	defer timer.Stop()
 	for {
 		// IsThrottled() is non-blocking; the throttling decision making takes place asynchronously.
 		// Therefore calling IsThrottled() is cheap
@@ -513,10 +515,11 @@ func (thlr *Throttler) throttle(onThrottled func()) {
 		if onThrottled != nil {
 			onThrottled()
 		}
+		timer.Reset(250 * time.Millisecond)
 		select {
 		case <-thlr.migrationContext.GetContext().Done():
 			return
-		case <-time.After(250 * time.Millisecond):
+		case <-timer.C:
 		}
 	}
 }

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -513,7 +513,11 @@ func (thlr *Throttler) throttle(onThrottled func()) {
 		if onThrottled != nil {
 			onThrottled()
 		}
-		time.Sleep(250 * time.Millisecond)
+		select {
+		case <-thlr.migrationContext.GetContext().Done():
+			return
+		case <-time.After(250 * time.Millisecond):
+		}
 	}
 }
 

--- a/go/logic/throttler_test.go
+++ b/go/logic/throttler_test.go
@@ -1,0 +1,103 @@
+/*
+   Copyright 2022 GitHub Inc.
+         See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package logic
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/github/gh-ost/go/base"
+)
+
+func newTestThrottler() *Throttler {
+	migrationContext := base.NewMigrationContext()
+	return NewThrottler(migrationContext, NewApplier(migrationContext), NewInspector(migrationContext), "test")
+}
+
+func TestThrottleReturnsWhenNotThrottled(t *testing.T) {
+	thlr := newTestThrottler()
+	// not throttled by default — should return immediately
+	done := make(chan struct{})
+	go func() {
+		thlr.throttle(nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("throttle() did not return when not throttled")
+	}
+}
+
+func TestThrottleBlocksWhileThrottled(t *testing.T) {
+	thlr := newTestThrottler()
+	thlr.migrationContext.SetThrottled(true, "test", base.NoThrottleReasonHint)
+
+	done := make(chan struct{})
+	go func() {
+		thlr.throttle(nil)
+		close(done)
+	}()
+
+	// should still be blocking after 300ms
+	select {
+	case <-done:
+		t.Fatal("throttle() returned while still throttled")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// unthrottle — should unblock within the next 250ms sleep cycle
+	thlr.migrationContext.SetThrottled(false, "", base.NoThrottleReasonHint)
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("throttle() did not return after unthrottling")
+	}
+}
+
+func TestThrottleReturnsOnContextCancellation(t *testing.T) {
+	thlr := newTestThrottler()
+	thlr.migrationContext.SetThrottled(true, "test", base.NoThrottleReasonHint)
+
+	done := make(chan struct{})
+	go func() {
+		thlr.throttle(nil)
+		close(done)
+	}()
+
+	// should be blocked
+	select {
+	case <-done:
+		t.Fatal("throttle() returned before context was cancelled")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	thlr.migrationContext.CancelContext()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("throttle() did not return after context cancellation")
+	}
+}
+
+func TestThrottleCallsOnThrottledCallback(t *testing.T) {
+	thlr := newTestThrottler()
+	thlr.migrationContext.SetThrottled(true, "test", base.NoThrottleReasonHint)
+
+	var callCount atomic.Int32
+	go func() {
+		thlr.throttle(func() { callCount.Add(1) })
+	}()
+
+	// wait long enough for at least two callback invocations
+	time.Sleep(700 * time.Millisecond)
+	assert.GreaterOrEqual(t, callCount.Load(), int32(2))
+
+	thlr.migrationContext.CancelContext()
+}

--- a/go/logic/throttler_test.go
+++ b/go/logic/throttler_test.go
@@ -91,8 +91,10 @@ func TestThrottleCallsOnThrottledCallback(t *testing.T) {
 	thlr.migrationContext.SetThrottled(true, "test", base.NoThrottleReasonHint)
 
 	var callCount atomic.Int32
+	done := make(chan struct{})
 	go func() {
 		thlr.throttle(func() { callCount.Add(1) })
+		close(done)
 	}()
 
 	// wait long enough for at least two callback invocations
@@ -100,4 +102,9 @@ func TestThrottleCallsOnThrottledCallback(t *testing.T) {
 	assert.GreaterOrEqual(t, callCount.Load(), int32(2))
 
 	thlr.migrationContext.CancelContext()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("throttle() did not return after context cancellation")
+	}
 }


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1670

### Description

This PR fixes a deadlock where a migration process becomes permanently stuck after `abort()` is called (e.g. following heartbeat failures due to a MySQL failover).

When the context is cancelled, `initiateThrottlerChecks` exits via `ctx.Done()` without calling `SetThrottled(false)`, leaving `isThrottled` permanently `true`. The `throttle()` loop had no awareness of context cancellation — it only checked `IsThrottled()` — so it would spin indefinitely, preventing the migration goroutine from ever returning.

The fix replaces `time.Sleep(250ms)` with a `select` that also listens on `ctx.Done()`, so `throttle()` unblocks immediately when the migration is aborted.

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.