### PR TITLE
Do not report extremely high HeartbeatLag values until the first heartbeat is read

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -450,6 +450,7 @@ func (mgtr *Migrator) checkAbort() error {
 func (mgtr *Migrator) Migrate() (err error) {
 	mgtr.migrationContext.Log.Infof("Migrating %s.%s", sql.EscapeName(mgtr.migrationContext.DatabaseName), sql.EscapeName(mgtr.migrationContext.OriginalTableName))
 	mgtr.migrationContext.StartTime = time.Now()
+	mgtr.migrationContext.SetLastHeartbeatOnChangelogTime(mgtr.migrationContext.StartTime)
 
 	// Ensure context is cancelled on exit (cleanup)
 	defer mgtr.migrationContext.CancelContext()
@@ -667,6 +668,7 @@ func (mgtr *Migrator) Revert() error {
 		sql.EscapeName(mgtr.migrationContext.DatabaseName), sql.EscapeName(mgtr.migrationContext.OriginalTableName),
 		sql.EscapeName(mgtr.migrationContext.DatabaseName), sql.EscapeName(mgtr.migrationContext.OldTableName))
 	mgtr.migrationContext.StartTime = time.Now()
+	mgtr.migrationContext.SetLastHeartbeatOnChangelogTime(mgtr.migrationContext.StartTime)
 
 	// Ensure context is cancelled on exit (cleanup)
 	defer mgtr.migrationContext.CancelContext()

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -990,6 +990,7 @@ func (suite *MigratorTestSuite) TestRevertEmpty() {
 		err = migrator.Migrate()
 		oldTableName = migrationContext.GetOldTableName()
 		suite.Require().NoError(err)
+		suite.Require().Less(migrationContext.TimeSinceLastHeartbeatOnChangelog(), 24*time.Hour)
 	}
 
 	// revert the original migration
@@ -1008,6 +1009,7 @@ func (suite *MigratorTestSuite) TestRevertEmpty() {
 
 		err = migrator.Revert()
 		suite.Require().NoError(err)
+		suite.Require().Less(migrationContext.TimeSinceLastHeartbeatOnChangelog(), 24*time.Hour)
 	}
 }
 


### PR DESCRIPTION
### Description

Discovered it's possible to log uninitialized time values of `lastHeartbeatOnChangelogTime` before the first heartbeat arrives.

```
[gh-ost] : Copy: 0/0 100.0%; Applied: 0; Backlog: 0/1000; Time: 0s(total), 0s(copy); streamer: binlog.1350661:30466581; Lag: 0.00s, HeartbeatLag: 9223372036.85s, State: migrating; ETA: due
```

In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.