### PR TITLE
Use `os.TempDir()` for test socket path

### DIFF
--- a/go/logic/test_utils.go
+++ b/go/logic/test_utils.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"fmt"
+	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/mysql"
@@ -68,9 +68,7 @@ func newTestMigrationContext() *base.MigrationContext {
 	migrationContext.PanicOnWarnings = true
 	migrationContext.AllowedRunningOnMaster = true
 
-	//nolint:dogsled
-	_, filename, _, _ := runtime.Caller(0)
-	migrationContext.ServeSocketFile = filepath.Join(filepath.Dir(filename), "../../tmp/gh-ost.sock")
+	migrationContext.ServeSocketFile = filepath.Join(os.TempDir(), "gh-ost.sock")
 
 	return migrationContext
 }


### PR DESCRIPTION
### Description

This PR replaces `runtime.Caller(0)`-based socket path construction with `os.TempDir()` in `newTestMigrationContext`.

As the path is constructed relative to the source tree, in some CI environments the path might be too long, causing tests to fail due to the fact that Linux enforces a hard limit of 108 characters for Unix socket paths.

This also ensures that each test run no longer shares a hardcoded socket path, reducing the risk of failures if a previous test leaked the socket.

As an additional benefit, it drops the `runtime` import and the `//nolint:dogsled` suppression.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
