### PR TITLE
Disable CGO for release builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ function build {
   echo "Building ${osname}-${GOARCH} binary"
   export GOOS
   export GOARCH
-  CGO_ENABLED=0 go build -ldflags "$ldflags" -o $buildpath/$target go/cmd/gh-ost/main.go
+  CGO_ENABLED="${CGO_ENABLED:-0}" go build -ldflags "$ldflags" -o "$buildpath/$target" go/cmd/gh-ost/main.go
 
   if [ $? -ne 0 ]; then
       echo "Build failed for ${osname} ${GOARCH}."

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ function build {
   echo "Building ${osname}-${GOARCH} binary"
   export GOOS
   export GOARCH
-  go build -ldflags "$ldflags" -o $buildpath/$target go/cmd/gh-ost/main.go
+  CGO_ENABLED=0 go build -ldflags "$ldflags" -o $buildpath/$target go/cmd/gh-ost/main.go
 
   if [ $? -ne 0 ]; then
       echo "Build failed for ${osname} ${GOARCH}."


### PR DESCRIPTION
### Description
Disable CGO by default for release build so it produces statically linked binaries

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
