### PR TITLE
gh-ost: fix bug preventing cutover retries from succeeding

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -105,7 +105,7 @@ func NewMigrator(context *base.MigrationContext, appVersion string) *Migrator {
 		ghostTableMigrated:         make(chan bool),
 		firstThrottlingCollected:   make(chan bool, 3),
 		rowCopyComplete:            make(chan error),
-		allEventsUpToLockProcessed: make(chan string),
+		allEventsUpToLockProcessed: make(chan string, 1),
 
 		copyRowsQueue:          make(chan tableWriteFunc),
 		applyEventsQueue:       make(chan *applyEventStruct, base.MaxEventsBatchSize),
@@ -582,6 +582,13 @@ func (this *Migrator) cutOver() (err error) {
 // Inject the "AllEventsUpToLockProcessed" state hint, wait for it to appear in the binary logs,
 // make sure the queue is drained.
 func (this *Migrator) waitForEventsUpToLock() (err error) {
+	// Drain any stale signal from a previous timed-out attempt, so it doesn't
+	// block executeWriteFuncs or get misinterpreted on this attempt.
+	select {
+	case <-this.allEventsUpToLockProcessed:
+	default:
+	}
+
 	timeout := time.NewTimer(time.Second * time.Duration(this.migrationContext.CutOverLockTimeoutSeconds))
 
 	this.migrationContext.MarkPointOfInterest()


### PR DESCRIPTION
```
  The bug is a deadlock caused by an orphaned unbuffered channel send in 
  executeWriteFuncs after waitForEventsUpToLock times out.
  Sequence of events:
  1. Row copy completes. The main goroutine enters the cut-over retry loop.
  2. atomicCutOver() takes locks and calls waitForEventsUpToLock(), which writes
   AllEventsUpToLockProcessed:<timestamp> to the _ghc table and starts a timer
  of CutOverLockTimeoutSeconds (default 3s).
  3. The streamer picks up the changelog event from the binlog and
  onChangelogStateEvent fires. It asynchronously enqueues a func into
  applyEventsQueue that will send the challenge string to the
  allEventsUpToLockProcessed channel.
  4. But there are pending DML events ahead in applyEventsQueue (the Backlog
  shown in logs). executeWriteFuncs must process each one (which involves SQL
  writes via ApplyDMLEventQueries). Processing 692+ DML events takes longer than
   the 3-second timeout.
  5. The timeout fires in waitForEventsUpToLock → returns error → atomicCutOver
  cleans up, releases locks, returns error to the retrier.
  6. Later, executeWriteFuncs reaches the enqueued func and executes:
  this.allEventsUpToLockProcessed <- changelogStateString
  6. This is a send on an unbuffered channel with no receiver (because
  waitForEventsUpToLock already returned). This goroutine blocks forever.
  7. executeWriteFuncs is now permanently stuck. The applyEventsQueue is never
  drained again.
  8. The queue fills to 1000/1000. The DML listener in notifyListeners blocks
  trying to enqueue events. This blocks the binlog streamer consumer, which
  blocks the binlog reader.
  9. No more binlog events are processed — including heartbeat events.
  TimeSinceLastHeartbeatOnChangelog() grows monotonically.
  10. The retrier calls cutOver() again, but sleepWhileTrue at line 517 sees
  heartbeatLag > maxLagMillisecondsThrottle and loops forever, waiting for the
  binlog-derived HeartbeatLag to drop below the threshold. It never will,
  because the binlog streamer is dead.
  Why throttle-based Lag stays low
  The Lag metric (reported as Lag: 0.04s) is derived from a direct SQL query to
  the _ghc table by the throttler (collectReplicationLag). The heartbeat writer
  goroutine is still running fine — it keeps writing fresh timestamps into the
  table. But the HeartbeatLag metric is derived from the binlog stream, which is
   blocked. These two metrics diverge, and it's the binlog-derived one that
  gates the cut-over.
  Conditions that trigger this
  The bug requires the applyEventsQueue to have enough pending DML events at
  cut-over time that processing them takes longer than
  CutOverLockTimeoutSeconds. This is more likely on:
  - Large, write-heavy tables (lots of DML events in the backlog)
  - Migrations that were recently throttled (backlog builds up during
  throttling)
  
  Our logs confirm at 17:08:10 the state was throttled, lag=22.838986s
  with Backlog: 692/1000, and one second later at 17:08:11 it transitioned to
  migrating with Backlog: 1000/1000 — the throttling ended (perhaps because the
  copy just finished), many new DML events from the binlog flooded in, and the
  cut-over attempt timed out.
  
  The fix should make the allEventsUpToLockProcessed channel buffered (capacity
  1 or more), or add a timeout/select to the send at line 227, or drain any
  stale value from the channel at the start of waitForEventsUpToLock. The
  simplest correct fix:
  // Line 108: make the channel buffered
  allEventsUpToLockProcessed: make(chan string, 1),
  And add a drain at the top of waitForEventsUpToLock:
  // Drain any stale signal from a previous timed-out attempt
  select {
  case <-this.allEventsUpToLockProcessed:
  default:
  }
  This ensures that: (a) the func won't block executeWriteFuncs forever even if
  no one is receiving, and (b) stale signals from previous attempts are
  discarded before waiting for the new one.
```