### PR TITLE
Move tables 1.6 crash safe resume

### DIFF
--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -374,7 +374,12 @@ func main() {
 			log.Fatal("--postpone-cut-over-flag-file must be specified when using --move-tables")
 		}
 		if !migrationContext.Checkpoint {
-			log.Fatal("--checkpoint must be specified when using --move-tables")
+			log.Infof("--move-tables requires checkpointing; enabling --checkpoint")
+			migrationContext.Checkpoint = true
+		}
+		if !migrationContext.UseGTIDs {
+			log.Infof("--move-tables requires GTID coordinates for cutover drain checks; enabling --gtid")
+			migrationContext.UseGTIDs = true
 		}
 		migrationContext.MoveTables.TableNames = strings.Split(*moveTables, ",")
 		for i := range migrationContext.MoveTables.TableNames {

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -373,6 +373,9 @@ func main() {
 		if migrationContext.PostponeCutOverFlagFile == "" {
 			log.Fatal("--postpone-cut-over-flag-file must be specified when using --move-tables")
 		}
+		if !migrationContext.Checkpoint {
+			log.Fatal("--checkpoint must be specified when using --move-tables")
+		}
 		migrationContext.MoveTables.TableNames = strings.Split(*moveTables, ",")
 		for i := range migrationContext.MoveTables.TableNames {
 			migrationContext.MoveTables.TableNames[i] = strings.TrimSpace(migrationContext.MoveTables.TableNames[i])

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -131,6 +131,14 @@ func (apl *Applier) checkpointDrainGTIDString(chk *Checkpoint) string {
 	return chk.MoveTablesCutOverDrainGTID.String()
 }
 
+func (apl *Applier) checkpointRangeColumnNames() (minColumnNames []string, maxColumnNames []string) {
+	for _, col := range apl.migrationContext.UniqueKey.Columns.Columns() {
+		minColumnNames = append(minColumnNames, sql.TruncateColumnName(col.Name, sql.MaxColumnNameLength-4)+"_min")
+		maxColumnNames = append(maxColumnNames, sql.TruncateColumnName(col.Name, sql.MaxColumnNameLength-4)+"_max")
+	}
+	return minColumnNames, maxColumnNames
+}
+
 // compileMigrationKeyWarningRegex compiles a regex pattern that matches duplicate key warnings
 // for the migration's unique key. Duplicate warnings are formatted differently across MySQL versions,
 // hence the optional table name prefix. Metacharacters in table/index names are escaped to avoid
@@ -994,15 +1002,39 @@ func (apl *Applier) WriteCheckpoint(chk *Checkpoint) (int64, error) {
 }
 
 func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
-	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ * from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
+	minColumnNames, maxColumnNames := apl.checkpointRangeColumnNames()
+	selectColumns := []string{
+		"gh_ost_chk_id",
+		"gh_ost_chk_timestamp",
+		"gh_ost_chk_coords",
+		"gh_ost_chk_iteration",
+		"gh_ost_rows_copied",
+		"gh_ost_dml_applied",
+		"gh_ost_is_cutover",
+	}
+	if apl.migrationContext.IsMoveTablesMode() {
+		selectColumns = append(selectColumns, "gh_ost_move_tables_cutover_started", "gh_ost_move_tables_drain_gtid")
+	}
+	selectColumns = append(selectColumns, minColumnNames...)
+	selectColumns = append(selectColumns, maxColumnNames...)
+
+	row := apl.checkpointDB().QueryRow(fmt.Sprintf(
+		`select /* gh-ost */ %s from %s.%s order by gh_ost_chk_id desc limit 1`,
+		strings.Join(selectColumns, ", "),
+		sql.EscapeName(apl.checkpointDatabaseName()),
+		sql.EscapeName(apl.migrationContext.GetCheckpointTableName()),
+	))
 	chk := &Checkpoint{
 		IterationRangeMin: sql.NewColumnValues(apl.migrationContext.UniqueKey.Columns.Len()),
 		IterationRangeMax: sql.NewColumnValues(apl.migrationContext.UniqueKey.Columns.Len()),
 	}
 
-	var coordStr string
+	var coordStr, drainGTIDStr string
 	var timestamp int64
 	ptrs := []interface{}{&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover}
+	if apl.migrationContext.IsMoveTablesMode() {
+		ptrs = append(ptrs, &chk.MoveTablesCutOverStarted, &drainGTIDStr)
+	}
 	ptrs = append(ptrs, chk.IterationRangeMin.ValuesPointers...)
 	ptrs = append(ptrs, chk.IterationRangeMax.ValuesPointers...)
 	err := row.Scan(ptrs...)
@@ -1025,6 +1057,13 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 			return nil, err
 		}
 		chk.LastTrxCoords = fileCoords
+	}
+	if apl.migrationContext.IsMoveTablesMode() && drainGTIDStr != "" {
+		drainGTID, err := mysql.NewGTIDBinlogCoordinates(drainGTIDStr)
+		if err != nil {
+			return nil, err
+		}
+		chk.MoveTablesCutOverDrainGTID = drainGTID
 	}
 	return chk, nil
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -776,8 +776,8 @@ func (apl *Applier) CreateCheckpointTable() error {
 	}
 	if apl.migrationContext.IsMoveTablesMode() {
 		colDefs = append(colDefs,
-			"`gh_ost_cutover_started` tinyint(1) DEFAULT '0'",
-			"`gh_ost_drain_gtid` text charset ascii",
+			"`gh_ost_move_tables_cutover_started` tinyint(1) DEFAULT '0'",
+			"`gh_ost_move_tables_drain_gtid` text charset ascii",
 		)
 	}
 	for _, col := range apl.migrationContext.UniqueKey.Columns.Columns() {
@@ -1041,7 +1041,7 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 }
 
 func (apl *Applier) ReadMoveTablesCutOverCheckpoint() (*Checkpoint, error) {
-	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ gh_ost_chk_id, gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration, gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover, gh_ost_cutover_started, gh_ost_drain_gtid from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
+	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ gh_ost_chk_id, gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration, gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover, gh_ost_move_tables_cutover_started, gh_ost_move_tables_drain_gtid from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
 	chk := &Checkpoint{}
 	var coordStr, drainGTIDStr string
 	var timestamp int64

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -382,6 +382,7 @@ func (apl *Applier) prepareQueries() (err error) {
 			apl.checkpointDatabaseName(),
 			apl.migrationContext.GetCheckpointTableName(),
 			&apl.migrationContext.UniqueKey.Columns,
+			apl.migrationContext.IsMoveTablesMode(),
 		); err != nil {
 			return err
 		}
@@ -772,8 +773,12 @@ func (apl *Applier) CreateCheckpointTable() error {
 		"`gh_ost_rows_copied` bigint",
 		"`gh_ost_dml_applied` bigint",
 		"`gh_ost_is_cutover` tinyint(1) DEFAULT '0'",
-		"`gh_ost_cutover_started` tinyint(1) DEFAULT '0'",
-		"`gh_ost_drain_gtid` text charset ascii",
+	}
+	if apl.migrationContext.IsMoveTablesMode() {
+		colDefs = append(colDefs,
+			"`gh_ost_cutover_started` tinyint(1) DEFAULT '0'",
+			"`gh_ost_drain_gtid` text charset ascii",
+		)
 	}
 	for _, col := range apl.migrationContext.UniqueKey.Columns.Columns() {
 		if col.MySQLType == "" {
@@ -976,7 +981,10 @@ func (apl *Applier) WriteCheckpoint(chk *Checkpoint) (int64, error) {
 	if err != nil {
 		return insertId, err
 	}
-	args := sqlutils.Args(chk.LastTrxCoords.String(), chk.Iteration, chk.RowsCopied, chk.DMLApplied, chk.IsCutover, chk.MoveTablesCutOverStarted, apl.checkpointDrainGTIDString(chk))
+	args := sqlutils.Args(chk.LastTrxCoords.String(), chk.Iteration, chk.RowsCopied, chk.DMLApplied, chk.IsCutover)
+	if apl.migrationContext.IsMoveTablesMode() {
+		args = append(args, chk.MoveTablesCutOverStarted, apl.checkpointDrainGTIDString(chk))
+	}
 	args = append(args, uniqueKeyArgs...)
 	res, err := apl.checkpointDB().Exec(query, args...)
 	if err != nil {
@@ -995,7 +1003,10 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 	var coordStr string
 	var drainGTIDStr string
 	var timestamp int64
-	ptrs := []interface{}{&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover, &chk.MoveTablesCutOverStarted, &drainGTIDStr}
+	ptrs := []interface{}{&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover}
+	if apl.migrationContext.IsMoveTablesMode() {
+		ptrs = append(ptrs, &chk.MoveTablesCutOverStarted, &drainGTIDStr)
+	}
 	ptrs = append(ptrs, chk.IterationRangeMin.ValuesPointers...)
 	ptrs = append(ptrs, chk.IterationRangeMax.ValuesPointers...)
 	err := row.Scan(ptrs...)

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -110,6 +110,27 @@ func NewApplier(migrationContext *base.MigrationContext) *Applier {
 	}
 }
 
+func (apl *Applier) checkpointDB() *gosql.DB {
+	if apl.migrationContext.IsMoveTablesMode() && apl.moveTablesTargetDB != nil {
+		return apl.moveTablesTargetDB
+	}
+	return apl.db
+}
+
+func (apl *Applier) checkpointDatabaseName() string {
+	if apl.migrationContext.IsMoveTablesMode() {
+		return apl.migrationContext.GetTargetDatabaseName()
+	}
+	return apl.migrationContext.DatabaseName
+}
+
+func (apl *Applier) checkpointDrainGTIDString(chk *Checkpoint) string {
+	if chk == nil || chk.DrainGTID == nil || chk.DrainGTID.IsEmpty() {
+		return ""
+	}
+	return chk.DrainGTID.String()
+}
+
 // compileMigrationKeyWarningRegex compiles a regex pattern that matches duplicate key warnings
 // for the migration's unique key. Duplicate warnings are formatted differently across MySQL versions,
 // hence the optional table name prefix. Metacharacters in table/index names are escaped to avoid
@@ -358,7 +379,7 @@ func (apl *Applier) prepareQueries() (err error) {
 	}
 	if apl.migrationContext.Checkpoint {
 		if apl.checkpointInsertQueryBuilder, err = sql.NewCheckpointQueryBuilder(
-			apl.migrationContext.DatabaseName,
+			apl.checkpointDatabaseName(),
 			apl.migrationContext.GetCheckpointTableName(),
 			&apl.migrationContext.UniqueKey.Columns,
 		); err != nil {
@@ -751,6 +772,8 @@ func (apl *Applier) CreateCheckpointTable() error {
 		"`gh_ost_rows_copied` bigint",
 		"`gh_ost_dml_applied` bigint",
 		"`gh_ost_is_cutover` tinyint(1) DEFAULT '0'",
+		"`gh_ost_cutover_started` tinyint(1) DEFAULT '0'",
+		"`gh_ost_drain_gtid` text charset ascii",
 	}
 	for _, col := range apl.migrationContext.UniqueKey.Columns.Columns() {
 		if col.MySQLType == "" {
@@ -768,12 +791,12 @@ func (apl *Applier) CreateCheckpointTable() error {
 	}
 
 	query := fmt.Sprintf("create /* gh-ost */ table %s.%s (\n %s\n)",
-		sql.EscapeName(apl.migrationContext.DatabaseName),
+		sql.EscapeName(apl.checkpointDatabaseName()),
 		sql.EscapeName(apl.migrationContext.GetCheckpointTableName()),
 		strings.Join(colDefs, ",\n "),
 	)
 	apl.migrationContext.Log.Infof("Created checkpoint table")
-	if _, err := sqlutils.ExecNoPrepare(apl.db, query); err != nil {
+	if _, err := sqlutils.ExecNoPrepare(apl.checkpointDB(), query); err != nil {
 		return err
 	}
 	return nil
@@ -782,14 +805,14 @@ func (apl *Applier) CreateCheckpointTable() error {
 // dropTable drops a given table on the applied host
 func (apl *Applier) dropTable(tableName string) error {
 	query := fmt.Sprintf(`drop /* gh-ost */ table if exists %s.%s`,
-		sql.EscapeName(apl.migrationContext.DatabaseName),
+		sql.EscapeName(apl.checkpointDatabaseName()),
 		sql.EscapeName(tableName),
 	)
 	apl.migrationContext.Log.Infof("Dropping table %s.%s",
-		sql.EscapeName(apl.migrationContext.DatabaseName),
+		sql.EscapeName(apl.checkpointDatabaseName()),
 		sql.EscapeName(tableName),
 	)
-	if _, err := sqlutils.ExecNoPrepare(apl.db, query); err != nil {
+	if _, err := sqlutils.ExecNoPrepare(apl.checkpointDB(), query); err != nil {
 		return err
 	}
 	apl.migrationContext.Log.Infof("Table dropped")
@@ -953,9 +976,9 @@ func (apl *Applier) WriteCheckpoint(chk *Checkpoint) (int64, error) {
 	if err != nil {
 		return insertId, err
 	}
-	args := sqlutils.Args(chk.LastTrxCoords.String(), chk.Iteration, chk.RowsCopied, chk.DMLApplied, chk.IsCutover)
+	args := sqlutils.Args(chk.LastTrxCoords.String(), chk.Iteration, chk.RowsCopied, chk.DMLApplied, chk.IsCutover, chk.MoveTablesCutOverStarted, apl.checkpointDrainGTIDString(chk))
 	args = append(args, uniqueKeyArgs...)
-	res, err := apl.db.Exec(query, args...)
+	res, err := apl.checkpointDB().Exec(query, args...)
 	if err != nil {
 		return insertId, err
 	}
@@ -963,15 +986,16 @@ func (apl *Applier) WriteCheckpoint(chk *Checkpoint) (int64, error) {
 }
 
 func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
-	row := apl.db.QueryRow(fmt.Sprintf(`select /* gh-ost */ * from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.migrationContext.DatabaseName), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
+	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ * from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
 	chk := &Checkpoint{
 		IterationRangeMin: sql.NewColumnValues(apl.migrationContext.UniqueKey.Columns.Len()),
 		IterationRangeMax: sql.NewColumnValues(apl.migrationContext.UniqueKey.Columns.Len()),
 	}
 
 	var coordStr string
+	var drainGTIDStr string
 	var timestamp int64
-	ptrs := []interface{}{&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover}
+	ptrs := []interface{}{&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover, &chk.MoveTablesCutOverStarted, &drainGTIDStr}
 	ptrs = append(ptrs, chk.IterationRangeMin.ValuesPointers...)
 	ptrs = append(ptrs, chk.IterationRangeMax.ValuesPointers...)
 	err := row.Scan(ptrs...)
@@ -988,12 +1012,49 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 			return nil, err
 		}
 		chk.LastTrxCoords = gtidCoords
+		if drainGTIDStr != "" {
+			drainGTID, err := mysql.NewGTIDBinlogCoordinates(drainGTIDStr)
+			if err != nil {
+				return nil, err
+			}
+			chk.DrainGTID = drainGTID
+		}
 	} else {
 		fileCoords, err := mysql.ParseFileBinlogCoordinates(coordStr)
 		if err != nil {
 			return nil, err
 		}
 		chk.LastTrxCoords = fileCoords
+	}
+	return chk, nil
+}
+
+func (apl *Applier) ReadMoveTablesCutOverCheckpoint() (*Checkpoint, error) {
+	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ gh_ost_chk_id, gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration, gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover, gh_ost_cutover_started, gh_ost_drain_gtid from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
+	chk := &Checkpoint{}
+	var coordStr, drainGTIDStr string
+	var timestamp int64
+	err := row.Scan(&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover, &chk.MoveTablesCutOverStarted, &drainGTIDStr)
+	if err != nil {
+		if errors.Is(err, gosql.ErrNoRows) {
+			return nil, ErrNoCheckpointFound
+		}
+		return nil, err
+	}
+	chk.Timestamp = time.Unix(timestamp, 0)
+	if coordStr != "" {
+		coords, err := mysql.NewGTIDBinlogCoordinates(coordStr)
+		if err != nil {
+			return nil, err
+		}
+		chk.LastTrxCoords = coords
+	}
+	if drainGTIDStr != "" {
+		drainGTID, err := mysql.NewGTIDBinlogCoordinates(drainGTIDStr)
+		if err != nil {
+			return nil, err
+		}
+		chk.DrainGTID = drainGTID
 	}
 	return chk, nil
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1001,12 +1001,8 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 	}
 
 	var coordStr string
-	var drainGTIDStr string
 	var timestamp int64
 	ptrs := []interface{}{&chk.Id, &timestamp, &coordStr, &chk.Iteration, &chk.RowsCopied, &chk.DMLApplied, &chk.IsCutover}
-	if apl.migrationContext.IsMoveTablesMode() {
-		ptrs = append(ptrs, &chk.MoveTablesCutOverStarted, &drainGTIDStr)
-	}
 	ptrs = append(ptrs, chk.IterationRangeMin.ValuesPointers...)
 	ptrs = append(ptrs, chk.IterationRangeMax.ValuesPointers...)
 	err := row.Scan(ptrs...)
@@ -1023,13 +1019,6 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 			return nil, err
 		}
 		chk.LastTrxCoords = gtidCoords
-		if drainGTIDStr != "" {
-			drainGTID, err := mysql.NewGTIDBinlogCoordinates(drainGTIDStr)
-			if err != nil {
-				return nil, err
-			}
-			chk.DrainGTID = drainGTID
-		}
 	} else {
 		fileCoords, err := mysql.ParseFileBinlogCoordinates(coordStr)
 		if err != nil {

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -1098,7 +1098,7 @@ func (apl *Applier) ReadLastCheckpoint() (*Checkpoint, error) {
 }
 
 func (apl *Applier) ReadMoveTablesCutOverCheckpoint() (*Checkpoint, error) {
-	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ gh_ost_chk_id, gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration, gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover, gh_ost_move_tables_cutover_started, gh_ost_move_tables_drain_gtid from %s.%s order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
+	row := apl.checkpointDB().QueryRow(fmt.Sprintf(`select /* gh-ost */ gh_ost_chk_id, gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration, gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover, gh_ost_move_tables_cutover_started, gh_ost_move_tables_drain_gtid from %s.%s where gh_ost_move_tables_cutover_started = 1 and gh_ost_move_tables_drain_gtid is not null and gh_ost_move_tables_drain_gtid != '' order by gh_ost_chk_id desc limit 1`, sql.EscapeName(apl.checkpointDatabaseName()), sql.EscapeName(apl.migrationContext.GetCheckpointTableName())))
 	chk := &Checkpoint{}
 	var coordStr, drainGTIDStr string
 	var timestamp int64
@@ -1111,11 +1111,19 @@ func (apl *Applier) ReadMoveTablesCutOverCheckpoint() (*Checkpoint, error) {
 	}
 	chk.Timestamp = time.Unix(timestamp, 0)
 	if coordStr != "" {
-		coords, err := mysql.NewGTIDBinlogCoordinates(coordStr)
-		if err != nil {
-			return nil, err
+		if apl.migrationContext.UseGTIDs {
+			coords, err := mysql.NewGTIDBinlogCoordinates(coordStr)
+			if err != nil {
+				return nil, err
+			}
+			chk.LastTrxCoords = coords
+		} else {
+			coords, err := mysql.ParseFileBinlogCoordinates(coordStr)
+			if err != nil {
+				return nil, err
+			}
+			chk.LastTrxCoords = coords
 		}
-		chk.LastTrxCoords = coords
 	}
 	if drainGTIDStr != "" {
 		drainGTID, err := mysql.NewGTIDBinlogCoordinates(drainGTIDStr)

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -125,10 +125,10 @@ func (apl *Applier) checkpointDatabaseName() string {
 }
 
 func (apl *Applier) checkpointDrainGTIDString(chk *Checkpoint) string {
-	if chk == nil || chk.DrainGTID == nil || chk.DrainGTID.IsEmpty() {
+	if chk == nil || chk.MoveTablesCutoverDrainGTID == nil || chk.MoveTablesCutoverDrainGTID.IsEmpty() {
 		return ""
 	}
-	return chk.DrainGTID.String()
+	return chk.MoveTablesCutoverDrainGTID.String()
 }
 
 // compileMigrationKeyWarningRegex compiles a regex pattern that matches duplicate key warnings
@@ -1054,7 +1054,7 @@ func (apl *Applier) ReadMoveTablesCutOverCheckpoint() (*Checkpoint, error) {
 		if err != nil {
 			return nil, err
 		}
-		chk.DrainGTID = drainGTID
+		chk.MoveTablesCutoverDrainGTID = drainGTID
 	}
 	return chk, nil
 }

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -125,10 +125,10 @@ func (apl *Applier) checkpointDatabaseName() string {
 }
 
 func (apl *Applier) checkpointDrainGTIDString(chk *Checkpoint) string {
-	if chk == nil || chk.MoveTablesCutoverDrainGTID == nil || chk.MoveTablesCutoverDrainGTID.IsEmpty() {
+	if chk == nil || chk.MoveTablesCutOverDrainGTID == nil || chk.MoveTablesCutOverDrainGTID.IsEmpty() {
 		return ""
 	}
-	return chk.MoveTablesCutoverDrainGTID.String()
+	return chk.MoveTablesCutOverDrainGTID.String()
 }
 
 // compileMigrationKeyWarningRegex compiles a regex pattern that matches duplicate key warnings
@@ -1054,7 +1054,7 @@ func (apl *Applier) ReadMoveTablesCutOverCheckpoint() (*Checkpoint, error) {
 		if err != nil {
 			return nil, err
 		}
-		chk.MoveTablesCutoverDrainGTID = drainGTID
+		chk.MoveTablesCutOverDrainGTID = drainGTID
 	}
 	return chk, nil
 }

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -1006,7 +1006,7 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	suite.Require().Equal(chk.DMLApplied, gotChk.DMLApplied)
 	suite.Require().Equal(chk.IsCutover, gotChk.IsCutover)
 	suite.Require().False(gotChk.MoveTablesCutOverStarted)
-	suite.Require().Nil(gotChk.DrainGTID)
+	suite.Require().Nil(gotChk.MoveTablesCutoverDrainGTID)
 }
 
 func (suite *ApplierTestSuite) TestPanicOnWarningsWithDuplicateKeyOnNonMigrationIndex() {

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -983,15 +983,13 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	coords := mysql.NewFileBinlogCoordinates("mysql-bin.000003", int64(219202907))
 
 	chk := &Checkpoint{
-		LastTrxCoords:            coords,
-		IterationRangeMin:        applier.migrationContext.MigrationRangeMinValues,
-		IterationRangeMax:        applier.migrationContext.MigrationRangeMaxValues,
-		Iteration:                2,
-		RowsCopied:               100000,
-		DMLApplied:               200000,
-		IsCutover:                true,
-		MoveTablesCutOverStarted: true,
-		DrainGTID:                coords,
+		LastTrxCoords:     coords,
+		IterationRangeMin: applier.migrationContext.MigrationRangeMinValues,
+		IterationRangeMax: applier.migrationContext.MigrationRangeMaxValues,
+		Iteration:         2,
+		RowsCopied:        100000,
+		DMLApplied:        200000,
+		IsCutover:         true,
 	}
 	id, err := applier.WriteCheckpoint(chk)
 	suite.Require().NoError(err)
@@ -1007,8 +1005,8 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	suite.Require().Equal(chk.RowsCopied, gotChk.RowsCopied)
 	suite.Require().Equal(chk.DMLApplied, gotChk.DMLApplied)
 	suite.Require().Equal(chk.IsCutover, gotChk.IsCutover)
-	suite.Require().Equal(chk.MoveTablesCutOverStarted, gotChk.MoveTablesCutOverStarted)
-	suite.Require().Equal(chk.DrainGTID.String(), gotChk.DrainGTID.String())
+	suite.Require().False(gotChk.MoveTablesCutOverStarted)
+	suite.Require().Nil(gotChk.DrainGTID)
 }
 
 func (suite *ApplierTestSuite) TestPanicOnWarningsWithDuplicateKeyOnNonMigrationIndex() {

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -1006,7 +1006,7 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	suite.Require().Equal(chk.DMLApplied, gotChk.DMLApplied)
 	suite.Require().Equal(chk.IsCutover, gotChk.IsCutover)
 	suite.Require().False(gotChk.MoveTablesCutOverStarted)
-	suite.Require().Nil(gotChk.MoveTablesCutoverDrainGTID)
+	suite.Require().Nil(gotChk.MoveTablesCutOverDrainGTID)
 }
 
 func (suite *ApplierTestSuite) TestPanicOnWarningsWithDuplicateKeyOnNonMigrationIndex() {

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -1009,6 +1009,94 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	suite.Require().Nil(gotChk.MoveTablesCutOverDrainGTID)
 }
 
+func (suite *ApplierTestSuite) TestWriteCheckpointMoveTables() {
+	ctx := context.Background()
+
+	var err error
+
+	_, err = suite.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id int not null, id2 char(4) CHARACTER SET utf8mb4, primary key(id, id2))", getTestTableName()))
+	suite.Require().NoError(err)
+
+	_, err = suite.db.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id, id2) VALUES (?,?), (?,?), (?,?)", getTestTableName()), 411, "君子懷德", 411, "小人懷土", 212, "君子不器")
+	suite.Require().NoError(err)
+
+	connectionConfig, err := getTestConnectionConfig(ctx, suite.mysqlContainer)
+	suite.Require().NoError(err)
+
+	migrationContext := newTestMigrationContext()
+	migrationContext.ApplierConnectionConfig = connectionConfig
+	migrationContext.InspectorConnectionConfig = connectionConfig
+	migrationContext.SetConnectionConfig("innodb")
+	migrationContext.UseGTIDs = true
+
+	migrationContext.OriginalTableColumns = sql.NewColumnList([]string{"id", "id2"})
+	migrationContext.SharedColumns = sql.NewColumnList([]string{"id", "id2"})
+	migrationContext.MappedSharedColumns = sql.NewColumnList([]string{"id", "id2"})
+	migrationContext.Checkpoint = true
+	migrationContext.MoveTables.TableNames = []string{testMysqlTableName}
+	migrationContext.MoveTables.TargetDatabase = testMysqlDatabase
+	migrationContext.MoveTables.ConnectionConfig = connectionConfig
+	migrationContext.UniqueKey = &sql.UniqueKey{
+		Name:             "PRIMARY",
+		NameInGhostTable: "PRIMARY",
+		Columns:          *sql.NewColumnList([]string{"id", "id2"}),
+	}
+
+	inspector := NewInspector(migrationContext)
+	suite.Require().NoError(inspector.InitDBConnections())
+
+	err = inspector.applyColumnTypes(testMysqlDatabase, testMysqlTableName, &migrationContext.UniqueKey.Columns)
+	suite.Require().NoError(err)
+
+	applier := NewApplier(migrationContext)
+
+	err = applier.InitDBConnections()
+	suite.Require().NoError(err)
+
+	err = applier.CreateCheckpointTable()
+	suite.Require().NoError(err)
+
+	err = applier.prepareQueries()
+	suite.Require().NoError(err)
+
+	err = applier.ReadMigrationRangeValues(inspector.db)
+	suite.Require().NoError(err)
+
+	coords, err := mysql.NewGTIDBinlogCoordinates("00000000-0000-0000-0000-000000000001:1-10")
+	suite.Require().NoError(err)
+	drainGTID, err := mysql.NewGTIDBinlogCoordinates("00000000-0000-0000-0000-000000000001:1-20")
+	suite.Require().NoError(err)
+
+	chk := &Checkpoint{
+		LastTrxCoords:              coords,
+		IterationRangeMin:          applier.migrationContext.MigrationRangeMinValues,
+		IterationRangeMax:          applier.migrationContext.MigrationRangeMaxValues,
+		Iteration:                  3,
+		RowsCopied:                 1000,
+		DMLApplied:                 2000,
+		IsCutover:                  false,
+		MoveTablesCutOverStarted:   true,
+		MoveTablesCutOverDrainGTID: drainGTID,
+	}
+	id, err := applier.WriteCheckpoint(chk)
+	suite.Require().NoError(err)
+	suite.Require().Equal(int64(1), id)
+
+	gotChk, err := applier.ReadLastCheckpoint()
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(chk.Iteration, gotChk.Iteration)
+	suite.Require().Equal(chk.LastTrxCoords.String(), gotChk.LastTrxCoords.String())
+	suite.Require().Equal(chk.IterationRangeMin.String(), gotChk.IterationRangeMin.String())
+	suite.Require().Equal(chk.IterationRangeMax.String(), gotChk.IterationRangeMax.String())
+	suite.Require().Equal(chk.RowsCopied, gotChk.RowsCopied)
+	suite.Require().Equal(chk.DMLApplied, gotChk.DMLApplied)
+	suite.Require().Equal(chk.IsCutover, gotChk.IsCutover)
+	suite.Require().True(gotChk.MoveTablesCutOverStarted)
+	suite.Require().NotNil(gotChk.MoveTablesCutOverDrainGTID)
+	suite.Require().Equal(drainGTID.String(), gotChk.MoveTablesCutOverDrainGTID.String())
+}
+
 func (suite *ApplierTestSuite) TestPanicOnWarningsWithDuplicateKeyOnNonMigrationIndex() {
 	ctx := context.Background()
 

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -983,13 +983,15 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	coords := mysql.NewFileBinlogCoordinates("mysql-bin.000003", int64(219202907))
 
 	chk := &Checkpoint{
-		LastTrxCoords:     coords,
-		IterationRangeMin: applier.migrationContext.MigrationRangeMinValues,
-		IterationRangeMax: applier.migrationContext.MigrationRangeMaxValues,
-		Iteration:         2,
-		RowsCopied:        100000,
-		DMLApplied:        200000,
-		IsCutover:         true,
+		LastTrxCoords:            coords,
+		IterationRangeMin:        applier.migrationContext.MigrationRangeMinValues,
+		IterationRangeMax:        applier.migrationContext.MigrationRangeMaxValues,
+		Iteration:                2,
+		RowsCopied:               100000,
+		DMLApplied:               200000,
+		IsCutover:                true,
+		MoveTablesCutOverStarted: true,
+		DrainGTID:                coords,
 	}
 	id, err := applier.WriteCheckpoint(chk)
 	suite.Require().NoError(err)
@@ -1005,6 +1007,8 @@ func (suite *ApplierTestSuite) TestWriteCheckpoint() {
 	suite.Require().Equal(chk.RowsCopied, gotChk.RowsCopied)
 	suite.Require().Equal(chk.DMLApplied, gotChk.DMLApplied)
 	suite.Require().Equal(chk.IsCutover, gotChk.IsCutover)
+	suite.Require().Equal(chk.MoveTablesCutOverStarted, gotChk.MoveTablesCutOverStarted)
+	suite.Require().Equal(chk.DrainGTID.String(), gotChk.DrainGTID.String())
 }
 
 func (suite *ApplierTestSuite) TestPanicOnWarningsWithDuplicateKeyOnNonMigrationIndex() {

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -1205,6 +1205,64 @@ func (suite *ApplierTestSuite) TestWriteCheckpointMoveTables() {
 	suite.Require().Equal(drainGTID.String(), gotChk.MoveTablesCutOverDrainGTID.String())
 }
 
+func (suite *ApplierTestSuite) TestReadMoveTablesCutOverCheckpointIgnoresRowCopyCheckpoints() {
+	ctx := context.Background()
+
+	var err error
+
+	_, err = suite.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id int not null primary key)", getTestTableName()))
+	suite.Require().NoError(err)
+
+	_, err = suite.db.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id) VALUES (1), (2), (3)", getTestTableName()))
+	suite.Require().NoError(err)
+
+	connectionConfig, err := getTestConnectionConfig(ctx, suite.mysqlContainer)
+	suite.Require().NoError(err)
+
+	migrationContext := newTestMigrationContext()
+	migrationContext.ApplierConnectionConfig = connectionConfig
+	migrationContext.InspectorConnectionConfig = connectionConfig
+	migrationContext.SetConnectionConfig("innodb")
+	migrationContext.Checkpoint = true
+	migrationContext.MoveTables.TableNames = []string{testMysqlTableName}
+	migrationContext.MoveTables.TargetDatabase = testMysqlDatabase
+	migrationContext.MoveTables.ConnectionConfig = connectionConfig
+	migrationContext.OriginalTableColumns = sql.NewColumnList([]string{"id"})
+	migrationContext.SharedColumns = sql.NewColumnList([]string{"id"})
+	migrationContext.MappedSharedColumns = sql.NewColumnList([]string{"id"})
+	migrationContext.UniqueKey = &sql.UniqueKey{
+		Name:             "PRIMARY",
+		NameInGhostTable: "PRIMARY",
+		Columns:          *sql.NewColumnList([]string{"id"}),
+	}
+
+	inspector := NewInspector(migrationContext)
+	suite.Require().NoError(inspector.InitDBConnections())
+	err = inspector.applyColumnTypes(testMysqlDatabase, testMysqlTableName, &migrationContext.UniqueKey.Columns)
+	suite.Require().NoError(err)
+
+	applier := NewApplier(migrationContext)
+	suite.Require().NoError(applier.InitDBConnections())
+	suite.Require().NoError(applier.CreateCheckpointTable())
+	suite.Require().NoError(applier.prepareQueries())
+	suite.Require().NoError(applier.ReadMigrationRangeValues(inspector.db))
+
+	coords := mysql.NewFileBinlogCoordinates("mysql-bin.000003", int64(1234))
+	chk := &Checkpoint{
+		LastTrxCoords:     coords,
+		IterationRangeMin: applier.migrationContext.MigrationRangeMinValues,
+		IterationRangeMax: applier.migrationContext.MigrationRangeMaxValues,
+		Iteration:         1,
+		RowsCopied:        3,
+		DMLApplied:        0,
+	}
+	_, err = applier.WriteCheckpoint(chk)
+	suite.Require().NoError(err)
+
+	_, err = applier.ReadMoveTablesCutOverCheckpoint()
+	suite.Require().ErrorIs(err, ErrNoCheckpointFound)
+}
+
 func (suite *ApplierTestSuite) TestPanicOnWarningsWithDuplicateKeyOnNonMigrationIndex() {
 	ctx := context.Background()
 

--- a/go/logic/checkpoint.go
+++ b/go/logic/checkpoint.go
@@ -24,9 +24,11 @@ type Checkpoint struct {
 	IterationRangeMin *sql.ColumnValues
 	// IterationRangeMax is the max shared key value
 	// for the chunk copier range.
-	IterationRangeMax *sql.ColumnValues
-	Iteration         int64
-	RowsCopied        int64
-	DMLApplied        int64
-	IsCutover         bool
+	IterationRangeMax        *sql.ColumnValues
+	Iteration                int64
+	RowsCopied               int64
+	DMLApplied               int64
+	IsCutover                bool
+	MoveTablesCutOverStarted bool
+	DrainGTID                mysql.BinlogCoordinates
 }

--- a/go/logic/checkpoint.go
+++ b/go/logic/checkpoint.go
@@ -30,5 +30,5 @@ type Checkpoint struct {
 	DMLApplied                 int64
 	IsCutover                  bool
 	MoveTablesCutOverStarted   bool
-	MoveTablesCutoverDrainGTID mysql.BinlogCoordinates
+	MoveTablesCutOverDrainGTID mysql.BinlogCoordinates
 }

--- a/go/logic/checkpoint.go
+++ b/go/logic/checkpoint.go
@@ -24,11 +24,11 @@ type Checkpoint struct {
 	IterationRangeMin *sql.ColumnValues
 	// IterationRangeMax is the max shared key value
 	// for the chunk copier range.
-	IterationRangeMax        *sql.ColumnValues
-	Iteration                int64
-	RowsCopied               int64
-	DMLApplied               int64
-	IsCutover                bool
-	MoveTablesCutOverStarted bool
-	DrainGTID                mysql.BinlogCoordinates
+	IterationRangeMax          *sql.ColumnValues
+	Iteration                  int64
+	RowsCopied                 int64
+	DMLApplied                 int64
+	IsCutover                  bool
+	MoveTablesCutOverStarted   bool
+	MoveTablesCutoverDrainGTID mysql.BinlogCoordinates
 }

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -990,7 +990,8 @@ func (mgtr *Migrator) MoveTables() (err error) {
 					_ = base.SendWithContext(mgtr.migrationContext.GetContext(), mgtr.migrationContext.PanicAbort, err)
 				}
 			}()
-			go mgtr.initiateStatus()
+			// Do not initiate status ticker in cutover resume path: inspector is not initialized,
+			// and we're only doing drain polling + hooks before exit (no row copy to monitor).
 			if err := mgtr.resumeMoveTablesCutOverFromCheckpoint(cutoverResumeCheckpoint); err != nil {
 				return err
 			}
@@ -1005,7 +1006,10 @@ func (mgtr *Migrator) MoveTables() (err error) {
 			}
 			return nil
 		}
-		mgtr.applier.Teardown()
+		// Do not teardown this preflight applier on the miss path. Its DB handles
+		// come from the shared connection cache keyed by migration UUID, and
+		// closing them here would poison the later inspector/applier init path
+		// with "sql: database is closed".
 		mgtr.applier = nil
 	}
 
@@ -1134,11 +1138,7 @@ func (mgtr *Migrator) MoveTables() (err error) {
 // NOT the standard cutOver() path: every internal call from cutOver() (throttle,
 // atomicCutOver, waitForEventsUpToLock, heartbeat-lag) was built on a
 // single-server assumption that no longer holds when the applier writes target
-// and the streamer reads source. Each is replaced or dropped here.
-//
-// Crash safety (persisting the drain GTID before T3) is #8210. Enriched hook
-// env vars (GH_OST_DRAIN_GTID, GH_OST_TARGET_*) are #8211. Target-side
-// throttling is #8212. None of those are wired here.
+// and the streamer reads source. Each is replaced or dropped here.s
 func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	if mgtr.migrationContext.Noop {
 		mgtr.migrationContext.Log.Debugf("Noop operation; not really moving tables")
@@ -1228,6 +1228,9 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 			return fmt.Errorf("failed to persist move-tables cutover checkpoint: %w", err)
 		}
 	}
+
+	// force a crash
+	panic("force crash between table rename and drain completion")
 
 	if err := mgtr.drainMoveTablesCutOver(drainGTID); err != nil {
 		return err
@@ -2268,6 +2271,17 @@ func (mgtr *Migrator) Checkpoint(ctx context.Context) (*Checkpoint, error) {
 		}
 		mgtr.applier.CurrentCoordinatesMutex.Lock()
 		if coords.SmallerThanOrEquals(mgtr.applier.CurrentCoordinates) {
+			id, err := mgtr.applier.WriteCheckpoint(chk)
+			chk.Id = id
+			mgtr.applier.CurrentCoordinatesMutex.Unlock()
+			return chk, err
+		}
+		// In move-tables mode we do not emit heartbeat rows into _ghc, so
+		// CurrentCoordinates may not advance while the system is otherwise idle.
+		// If there is no backlog in either queue, it is safe to treat the current
+		// streamer coordinates as applied for checkpointing purposes.
+		if mgtr.migrationContext.IsMoveTablesMode() && len(mgtr.applyEventsQueue) == 0 && (mgtr.eventsStreamer == nil || len(mgtr.eventsStreamer.eventsChannel) == 0) {
+			mgtr.applier.CurrentCoordinates = coords.Clone()
 			id, err := mgtr.applier.WriteCheckpoint(chk)
 			chk.Id = id
 			mgtr.applier.CurrentCoordinatesMutex.Unlock()

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -823,11 +823,11 @@ func (mgtr *Migrator) hydrateMoveTablesStateFromTarget() error {
 	return nil
 }
 
-func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogCoordinates, isCutover bool) (*Checkpoint, error) {
+func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogCoordinates, isCutover bool) error {
 	mgtr.applier.CurrentCoordinatesMutex.Lock()
 	if mgtr.applier.CurrentCoordinates == nil || mgtr.applier.CurrentCoordinates.IsEmpty() {
 		mgtr.applier.CurrentCoordinatesMutex.Unlock()
-		return nil, errors.New("current coordinates are empty, cannot checkpoint move-tables cutover")
+		return errors.New("current coordinates are empty, cannot checkpoint move-tables cutover")
 	}
 	safeCoords := mgtr.applier.CurrentCoordinates.Clone()
 	mgtr.applier.CurrentCoordinatesMutex.Unlock()
@@ -853,7 +853,7 @@ func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogC
 	mgtr.applier.LastIterationRangeMutex.Unlock()
 	id, err := mgtr.applier.WriteCheckpoint(chk)
 	chk.Id = id
-	return chk, err
+	return err
 }
 
 // moveTablesDrainCoordinateReached returns true when current is at-or-ahead of
@@ -958,7 +958,7 @@ func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) err
 		return err
 	}
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutOverDrainGTID, true); err != nil {
+		if err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutOverDrainGTID, true); err != nil {
 			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}
@@ -1279,7 +1279,7 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	}
 	mgtr.migrationContext.Log.Infof("T2: captured drain GTID: %s", drainGTID.DisplayString())
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID, false); err != nil {
+		if err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID, false); err != nil {
 			return fmt.Errorf("failed to persist move-tables cutover checkpoint: %w", err)
 		}
 	}
@@ -1288,7 +1288,7 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 		return err
 	}
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID, true); err != nil {
+		if err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID, true); err != nil {
 			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -804,6 +804,121 @@ func (mgtr *Migrator) prepareMoveTablesCopyState() {
 	mgtr.migrationContext.MappedSharedColumns = mgtr.migrationContext.OriginalTableColumns
 }
 
+func (mgtr *Migrator) hydrateMoveTablesStateFromTarget() error {
+	probeContext := base.NewMigrationContext()
+	probeContext.DatabaseName = mgtr.migrationContext.GetTargetDatabaseName()
+	targetInspector := &Inspector{db: mgtr.applier.moveTablesTargetDB, migrationContext: probeContext}
+
+	columns, virtualColumns, uniqueKeys, err := targetInspector.InspectTableColumnsAndUniqueKeys(mgtr.migrationContext.GetTargetTableName())
+	if err != nil {
+		return err
+	}
+
+	mgtr.migrationContext.OriginalTableColumns = columns
+	mgtr.migrationContext.OriginalTableVirtualColumns = virtualColumns
+	mgtr.migrationContext.OriginalTableUniqueKeys = uniqueKeys
+	mgtr.migrationContext.UniqueKey = targetInspector.selectUniqueKey(uniqueKeys)
+	mgtr.migrationContext.SharedColumns = columns
+	mgtr.migrationContext.MappedSharedColumns = columns
+	return nil
+}
+
+func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogCoordinates) (*Checkpoint, error) {
+	mgtr.applier.CurrentCoordinatesMutex.Lock()
+	if mgtr.applier.CurrentCoordinates == nil || mgtr.applier.CurrentCoordinates.IsEmpty() {
+		mgtr.applier.CurrentCoordinatesMutex.Unlock()
+		return nil, errors.New("current coordinates are empty, cannot checkpoint move-tables cutover")
+	}
+	safeCoords := mgtr.applier.CurrentCoordinates.Clone()
+	mgtr.applier.CurrentCoordinatesMutex.Unlock()
+
+	chk := &Checkpoint{
+		LastTrxCoords:            safeCoords,
+		IterationRangeMin:        sql.NewColumnValues(mgtr.migrationContext.UniqueKey.Len()),
+		IterationRangeMax:        sql.NewColumnValues(mgtr.migrationContext.UniqueKey.Len()),
+		Iteration:                mgtr.migrationContext.GetIteration(),
+		RowsCopied:               atomic.LoadInt64(&mgtr.migrationContext.TotalRowsCopied),
+		DMLApplied:               atomic.LoadInt64(&mgtr.migrationContext.TotalDMLEventsApplied),
+		MoveTablesCutOverStarted: true,
+		DrainGTID:                drainGTID,
+	}
+	mgtr.applier.LastIterationRangeMutex.Lock()
+	if mgtr.applier.LastIterationRangeMinValues != nil {
+		chk.IterationRangeMin = mgtr.applier.LastIterationRangeMinValues.Clone()
+	}
+	if mgtr.applier.LastIterationRangeMaxValues != nil {
+		chk.IterationRangeMax = mgtr.applier.LastIterationRangeMaxValues.Clone()
+	}
+	mgtr.applier.LastIterationRangeMutex.Unlock()
+	id, err := mgtr.applier.WriteCheckpoint(chk)
+	chk.Id = id
+	return chk, err
+}
+
+func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) error {
+	drainTimeout := time.Duration(mgtr.migrationContext.CutOverLockTimeoutSeconds) * time.Second
+	mgtr.migrationContext.Log.Infof("T3: draining applier to drain GTID (timeout %s, poll %s)",
+		drainTimeout, moveTablesCutOverDrainPollInterval)
+	drainCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancel()
+	ticker := time.NewTicker(moveTablesCutOverDrainPollInterval)
+	defer ticker.Stop()
+	for {
+		if err := mgtr.checkAbort(); err != nil {
+			return err
+		}
+		mgtr.applier.CurrentCoordinatesMutex.Lock()
+		applierCoords := mgtr.applier.CurrentCoordinates
+		mgtr.applier.CurrentCoordinatesMutex.Unlock()
+		applyBacklog := len(mgtr.applyEventsQueue)
+		streamerBacklog := 0
+		if mgtr.eventsStreamer != nil {
+			streamerBacklog = len(mgtr.eventsStreamer.eventsChannel)
+		}
+		if applierCoords != nil && !applierCoords.IsEmpty() && !applierCoords.SmallerThan(drainGTID) && applyBacklog == 0 && streamerBacklog == 0 {
+			mgtr.migrationContext.Log.Infof("T3: drain complete; applier caught up to drain GTID")
+			return nil
+		}
+		if applierCoords != nil && !applierCoords.IsEmpty() && !applierCoords.SmallerThan(drainGTID) {
+			mgtr.migrationContext.Log.Debugf("T3: drain GTID reached but backlog remains (apply=%d, streamer=%d)", applyBacklog, streamerBacklog)
+		} else {
+			mgtr.migrationContext.Log.Debugf("T3: applier still behind drain GTID, polling")
+		}
+		select {
+		case <-drainCtx.Done():
+			return fmt.Errorf("drain poll timed out after %s: applier did not catch up to drain GTID", drainTimeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) error {
+	if chk == nil || !chk.MoveTablesCutOverStarted || chk.DrainGTID == nil || chk.DrainGTID.IsEmpty() {
+		return errors.New("checkpoint does not contain move-tables cutover resume state")
+	}
+	if chk.LastTrxCoords != nil && !chk.LastTrxCoords.IsEmpty() {
+		mgtr.applier.CurrentCoordinatesMutex.Lock()
+		mgtr.applier.CurrentCoordinates = chk.LastTrxCoords.Clone()
+		mgtr.applier.CurrentCoordinatesMutex.Unlock()
+	}
+	mgtr.migrationContext.Log.Infof("Resuming move-tables cutover from checkpoint at coords=%+v drain_gtid=%s",
+		chk.LastTrxCoords, chk.DrainGTID.DisplayString())
+	if err := mgtr.drainMoveTablesCutOver(chk.DrainGTID); err != nil {
+		return err
+	}
+	if mgtr.migrationContext.Checkpoint {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.DrainGTID); err != nil {
+			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
+		}
+	}
+	atomic.StoreInt64(&mgtr.migrationContext.CutOverCompleteFlag, 1)
+	mgtr.migrationContext.Log.Debugf("T4: CutOverCompleteFlag set")
+	if err := mgtr.hooksExecutor.OnSuccess(false); err != nil {
+		return fmt.Errorf("on-success hook failed: %w", err)
+	}
+	return nil
+}
+
 func (mgtr *Migrator) MoveTables() (err error) {
 	mgtr.migrationContext.Log.Infof("Moving tables %v from %s to %s (%s)",
 		mgtr.migrationContext.MoveTables.TableNames,
@@ -832,6 +947,67 @@ func (mgtr *Migrator) MoveTables() (err error) {
 	// After this point, we'll need to teardown anything that's been started
 	// so we don't leave things hanging around
 	defer mgtr.teardown()
+
+	if mgtr.migrationContext.Checkpoint && mgtr.migrationContext.Resume {
+		mgtr.migrationContext.ApplierConnectionConfig = mgtr.migrationContext.MoveTables.ConnectionConfig
+		mgtr.applier = NewApplier(mgtr.migrationContext)
+		if err := mgtr.applier.InitDBConnections(); err != nil {
+			return err
+		}
+		cutoverResumeCheckpoint, err := mgtr.applier.ReadMoveTablesCutOverCheckpoint()
+		if err != nil && !errors.Is(err, ErrNoCheckpointFound) {
+			return err
+		}
+		if cutoverResumeCheckpoint != nil && cutoverResumeCheckpoint.MoveTablesCutOverStarted && cutoverResumeCheckpoint.DrainGTID != nil && !cutoverResumeCheckpoint.DrainGTID.IsEmpty() {
+			mgtr.migrationContext.InitialStreamerCoords = cutoverResumeCheckpoint.LastTrxCoords
+			mgtr.migrationContext.Iteration = cutoverResumeCheckpoint.Iteration
+			atomic.StoreInt64(&mgtr.migrationContext.TotalRowsCopied, cutoverResumeCheckpoint.RowsCopied)
+			atomic.StoreInt64(&mgtr.migrationContext.TotalDMLEventsApplied, cutoverResumeCheckpoint.DMLApplied)
+			if err := mgtr.hydrateMoveTablesStateFromTarget(); err != nil {
+				return fmt.Errorf("failed to hydrate move-tables resume state from target: %w", err)
+			}
+			if err := mgtr.createFlagFiles(); err != nil {
+				return err
+			}
+			if err := mgtr.initiateStreaming(); err != nil {
+				return err
+			}
+			if err := mgtr.applier.prepareQueries(); err != nil {
+				return err
+			}
+			if err := mgtr.hooksExecutor.OnValidated(); err != nil {
+				return err
+			}
+			if err := mgtr.initiateServer(); err != nil {
+				return err
+			}
+			defer mgtr.server.RemoveSocketFile()
+			if err := mgtr.addDMLEventsListener(); err != nil {
+				return err
+			}
+			go func() {
+				if err := mgtr.executeWriteFuncs(); err != nil {
+					_ = base.SendWithContext(mgtr.migrationContext.GetContext(), mgtr.migrationContext.PanicAbort, err)
+				}
+			}()
+			go mgtr.initiateStatus()
+			if err := mgtr.resumeMoveTablesCutOverFromCheckpoint(cutoverResumeCheckpoint); err != nil {
+				return err
+			}
+			if err := mgtr.finalCleanup(); err != nil {
+				return nil
+			}
+			mgtr.migrationContext.Log.Infof("Done moving tables %v from %s to %s (%s)",
+				mgtr.migrationContext.MoveTables.TableNames, sql.EscapeName(mgtr.migrationContext.DatabaseName),
+				sql.EscapeName(mgtr.migrationContext.GetTargetDatabaseName()), mgtr.migrationContext.MoveTables.TargetHost)
+			if err := mgtr.checkAbort(); err != nil {
+				return err
+			}
+			return nil
+		}
+		mgtr.applier.Teardown()
+		mgtr.applier = nil
+	}
 
 	if err := mgtr.initiateInspector(); err != nil {
 		return err
@@ -863,6 +1039,11 @@ func (mgtr *Migrator) MoveTables() (err error) {
 	// this function assumes that the unique key constraint has been set.
 	if err := mgtr.applier.prepareQueries(); err != nil {
 		return err
+	}
+	if mgtr.migrationContext.Checkpoint && !mgtr.migrationContext.Resume {
+		if err := mgtr.applier.CreateCheckpointTable(); err != nil {
+			mgtr.migrationContext.Log.Errorf("unable to create checkpoint table, see further error details")
+		}
 	}
 
 	// Validation complete! Run on-validated hook.
@@ -900,6 +1081,9 @@ func (mgtr *Migrator) MoveTables() (err error) {
 	go mgtr.iterateChunks()
 	mgtr.migrationContext.MarkRowCopyStartTime()
 	go mgtr.initiateStatus()
+	if mgtr.migrationContext.Checkpoint {
+		go mgtr.checkpointLoop()
+	}
 
 	mgtr.migrationContext.Log.Debugf("Operating until row copy is complete")
 	mgtr.consumeRowCopyComplete()
@@ -1025,46 +1209,18 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 		return fmt.Errorf("drain GTID parse failed: %w", err)
 	}
 	mgtr.migrationContext.Log.Infof("T2: captured drain GTID: %s", drainGTID.DisplayString())
+	if mgtr.migrationContext.Checkpoint {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID); err != nil {
+			return fmt.Errorf("failed to persist move-tables cutover checkpoint: %w", err)
+		}
+	}
 
-	// ----- T3: drain poll -----
-	// Wait until applier.CurrentCoordinates catches up to drainGTID. The drain
-	// is complete when the applier's coords are not strictly smaller than the
-	// drain target (i.e. the applier contains every GTID in drainGTID). Reads
-	// of CurrentCoordinates hold the mutex per applier.go:75. Per-iteration
-	// logging is Debug only to avoid spamming Info on a hot loop.
-	drainTimeout := time.Duration(mgtr.migrationContext.CutOverLockTimeoutSeconds) * time.Second
-	mgtr.migrationContext.Log.Infof("T3: draining applier to drain GTID (timeout %s, poll %s)",
-		drainTimeout, moveTablesCutOverDrainPollInterval)
-	drainCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
-	defer cancel()
-	ticker := time.NewTicker(moveTablesCutOverDrainPollInterval)
-	defer ticker.Stop()
-	for {
-		if err := mgtr.checkAbort(); err != nil {
-			return err
-		}
-		mgtr.applier.CurrentCoordinatesMutex.Lock()
-		applierCoords := mgtr.applier.CurrentCoordinates
-		mgtr.applier.CurrentCoordinatesMutex.Unlock()
-		applyBacklog := len(mgtr.applyEventsQueue)
-		streamerBacklog := 0
-		if mgtr.eventsStreamer != nil {
-			streamerBacklog = len(mgtr.eventsStreamer.eventsChannel)
-		}
-		if applierCoords != nil && !applierCoords.IsEmpty() && !applierCoords.SmallerThan(drainGTID) && applyBacklog == 0 && streamerBacklog == 0 {
-			mgtr.migrationContext.Log.Infof("T3: drain complete; applier caught up to drain GTID")
-			break
-		}
-		if applierCoords != nil && !applierCoords.IsEmpty() && !applierCoords.SmallerThan(drainGTID) {
-			mgtr.migrationContext.Log.Debugf("T3: drain GTID reached but backlog remains (apply=%d, streamer=%d)", applyBacklog, streamerBacklog)
-		} else {
-			mgtr.migrationContext.Log.Debugf("T3: applier still behind drain GTID, polling")
-		}
-		select {
-		case <-drainCtx.Done():
-			return fmt.Errorf("drain poll timed out after %s: applier did not catch up to drain GTID", drainTimeout)
-		case <-ticker.C:
-			// next iteration
+	if err := mgtr.drainMoveTablesCutOver(drainGTID); err != nil {
+		return err
+	}
+	if mgtr.migrationContext.Checkpoint {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID); err != nil {
+			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}
 
@@ -2273,9 +2429,17 @@ func (mgtr *Migrator) finalCleanup() error {
 	}
 
 	if mgtr.migrationContext.IsMoveTablesMode() {
+		if mgtr.migrationContext.Checkpoint {
+			if mgtr.migrationContext.OkToDropTable {
+				if err := mgtr.retryOperation(mgtr.applier.DropCheckpointTable); err != nil {
+					return err
+				}
+			} else if !mgtr.migrationContext.Noop {
+				mgtr.migrationContext.Log.Infof("Am not dropping checkpoint table without `--ok-to-drop-table`. To drop the checkpoint table, issue:")
+				mgtr.migrationContext.Log.Infof("-- drop table %s.%s", sql.EscapeName(mgtr.migrationContext.GetTargetDatabaseName()), sql.EscapeName(mgtr.migrationContext.GetCheckpointTableName()))
+			}
+		}
 		// for move-tables mode, we're done at this point
-		// TODO(zacharysierakowski): when we add the checkpoint table in for 1.6, make sure we cleanup
-		// the checkpoint table here first before returning (looks like that's a few lines below changelog table cleanup)
 		return nil
 	}
 

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1048,6 +1048,7 @@ func (mgtr *Migrator) MoveTables() (err error) {
 			if err := mgtr.addDMLEventsListener(); err != nil {
 				return err
 			}
+			mgtr.initiateThrottler()
 			go func() {
 				if err := mgtr.executeWriteFuncs(); err != nil {
 					_ = base.SendWithContext(mgtr.migrationContext.GetContext(), mgtr.migrationContext.PanicAbort, err)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1015,11 +1015,27 @@ func (mgtr *Migrator) MoveTables() (err error) {
 	if err := mgtr.checkAbort(); err != nil {
 		return err
 	}
+	mgtr.prepareMoveTablesCopyState()
 	if err := mgtr.initiateApplier(); err != nil {
 		return err
 	}
 	if err := mgtr.checkAbort(); err != nil {
 		return err
+	}
+	if mgtr.migrationContext.Checkpoint && mgtr.migrationContext.Resume {
+		lastCheckpoint, err := mgtr.applier.ReadLastCheckpoint()
+		if err != nil {
+			return mgtr.migrationContext.Log.Errorf("no checkpoint found, unable to resume: %+v", err)
+		}
+		mgtr.migrationContext.Log.Infof("Resuming move-tables from checkpoint coords=%+v range_min=%+v range_max=%+v iteration=%d",
+			lastCheckpoint.LastTrxCoords, lastCheckpoint.IterationRangeMin.String(), lastCheckpoint.IterationRangeMax.String(), lastCheckpoint.Iteration)
+
+		mgtr.migrationContext.MigrationIterationRangeMinValues = lastCheckpoint.IterationRangeMin
+		mgtr.migrationContext.MigrationIterationRangeMaxValues = lastCheckpoint.IterationRangeMax
+		mgtr.migrationContext.Iteration = lastCheckpoint.Iteration
+		atomic.StoreInt64(&mgtr.migrationContext.TotalRowsCopied, lastCheckpoint.RowsCopied)
+		atomic.StoreInt64(&mgtr.migrationContext.TotalDMLEventsApplied, lastCheckpoint.DMLApplied)
+		mgtr.migrationContext.InitialStreamerCoords = lastCheckpoint.LastTrxCoords
 	}
 	if err := mgtr.createFlagFiles(); err != nil {
 		return err
@@ -1033,8 +1049,6 @@ func (mgtr *Migrator) MoveTables() (err error) {
 	if err := mgtr.checkAbort(); err != nil {
 		return err
 	}
-
-	mgtr.prepareMoveTablesCopyState()
 
 	// this function assumes that the unique key constraint has been set.
 	if err := mgtr.applier.prepareQueries(); err != nil {
@@ -1993,13 +2007,20 @@ func (mgtr *Migrator) initiateApplier() error {
 	}
 
 	if mgtr.migrationContext.IsMoveTablesMode() {
-		createTableStatement, err := mgtr.inspector.showCreateTable(mgtr.migrationContext.MoveTables.TableNames[0])
-		if err != nil {
-			return fmt.Errorf("failed to fetch create table statement: %w", err)
-		}
-		if err := mgtr.applier.CreateTargetTable(createTableStatement); err != nil {
-			mgtr.migrationContext.Log.Errorf("unable to create target table, see further error details. Perhaps a previous migration failed without dropping the table? Bailing out")
-			return err
+		if !mgtr.migrationContext.Resume {
+			createTableStatement, err := mgtr.inspector.showCreateTable(mgtr.migrationContext.MoveTables.TableNames[0])
+			if err != nil {
+				return fmt.Errorf("failed to fetch create table statement: %w", err)
+			}
+			if err := mgtr.applier.CreateTargetTable(createTableStatement); err != nil {
+				mgtr.migrationContext.Log.Errorf("unable to create target table, see further error details. Perhaps a previous migration failed without dropping the table? Bailing out")
+				return err
+			}
+		} else {
+			mgtr.migrationContext.Log.Infof("Resuming move-tables; reusing existing target table %s.%s",
+				sql.EscapeName(mgtr.migrationContext.GetTargetDatabaseName()),
+				sql.EscapeName(mgtr.migrationContext.GetTargetTableName()),
+			)
 		}
 	} else {
 		if mgtr.migrationContext.Revert {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1198,7 +1198,7 @@ func (mgtr *Migrator) MoveTables() (err error) {
 // NOT the standard cutOver() path: every internal call from cutOver() (throttle,
 // atomicCutOver, waitForEventsUpToLock, heartbeat-lag) was built on a
 // single-server assumption that no longer holds when the applier writes target
-	// and the streamer reads source. Each is replaced or dropped here.
+// and the streamer reads source. Each is replaced or dropped here.
 func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	if mgtr.migrationContext.Noop {
 		mgtr.migrationContext.Log.Debugf("Noop operation; not really moving tables")

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -840,7 +840,7 @@ func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogC
 		RowsCopied:                 atomic.LoadInt64(&mgtr.migrationContext.TotalRowsCopied),
 		DMLApplied:                 atomic.LoadInt64(&mgtr.migrationContext.TotalDMLEventsApplied),
 		MoveTablesCutOverStarted:   true,
-		MoveTablesCutoverDrainGTID: drainGTID,
+		MoveTablesCutOverDrainGTID: drainGTID,
 	}
 	mgtr.applier.LastIterationRangeMutex.Lock()
 	if mgtr.applier.LastIterationRangeMinValues != nil {
@@ -893,7 +893,7 @@ func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) 
 }
 
 func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) error {
-	if chk == nil || !chk.MoveTablesCutOverStarted || chk.MoveTablesCutoverDrainGTID == nil || chk.MoveTablesCutoverDrainGTID.IsEmpty() {
+	if chk == nil || !chk.MoveTablesCutOverStarted || chk.MoveTablesCutOverDrainGTID == nil || chk.MoveTablesCutOverDrainGTID.IsEmpty() {
 		return errors.New("checkpoint does not contain move-tables cutover resume state")
 	}
 	if chk.LastTrxCoords != nil && !chk.LastTrxCoords.IsEmpty() {
@@ -902,12 +902,12 @@ func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) err
 		mgtr.applier.CurrentCoordinatesMutex.Unlock()
 	}
 	mgtr.migrationContext.Log.Infof("Resuming move-tables cutover from checkpoint at coords=%+v drain_gtid=%s",
-		chk.LastTrxCoords, chk.MoveTablesCutoverDrainGTID.DisplayString())
-	if err := mgtr.drainMoveTablesCutOver(chk.MoveTablesCutoverDrainGTID); err != nil {
+		chk.LastTrxCoords, chk.MoveTablesCutOverDrainGTID.DisplayString())
+	if err := mgtr.drainMoveTablesCutOver(chk.MoveTablesCutOverDrainGTID); err != nil {
 		return err
 	}
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutoverDrainGTID); err != nil {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutOverDrainGTID); err != nil {
 			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}
@@ -958,7 +958,7 @@ func (mgtr *Migrator) MoveTables() (err error) {
 		if err != nil && !errors.Is(err, ErrNoCheckpointFound) {
 			return err
 		}
-		if cutoverResumeCheckpoint != nil && cutoverResumeCheckpoint.MoveTablesCutOverStarted && cutoverResumeCheckpoint.MoveTablesCutoverDrainGTID != nil && !cutoverResumeCheckpoint.MoveTablesCutoverDrainGTID.IsEmpty() {
+		if cutoverResumeCheckpoint != nil && cutoverResumeCheckpoint.MoveTablesCutOverStarted && cutoverResumeCheckpoint.MoveTablesCutOverDrainGTID != nil && !cutoverResumeCheckpoint.MoveTablesCutOverDrainGTID.IsEmpty() {
 			mgtr.migrationContext.InitialStreamerCoords = cutoverResumeCheckpoint.LastTrxCoords
 			mgtr.migrationContext.Iteration = cutoverResumeCheckpoint.Iteration
 			atomic.StoreInt64(&mgtr.migrationContext.TotalRowsCopied, cutoverResumeCheckpoint.RowsCopied)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1189,7 +1189,7 @@ func (mgtr *Migrator) MoveTables() (err error) {
 // NOT the standard cutOver() path: every internal call from cutOver() (throttle,
 // atomicCutOver, waitForEventsUpToLock, heartbeat-lag) was built on a
 // single-server assumption that no longer holds when the applier writes target
-// and the streamer reads source. Each is replaced or dropped here.s
+	// and the streamer reads source. Each is replaced or dropped here.
 func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	if mgtr.migrationContext.Noop {
 		mgtr.migrationContext.Log.Debugf("Noop operation; not really moving tables")

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -100,8 +100,9 @@ type Migrator struct {
 	rowCopyCompleteFlag int64
 	// copyRowsQueue should not be buffered; if buffered some non-damaging but
 	//  excessive work happens at the end of the iteration as new copy-jobs arrive before realizing the copy is complete
-	copyRowsQueue    chan tableWriteFunc
-	applyEventsQueue chan *applyEventStruct
+	copyRowsQueue       chan tableWriteFunc
+	applyEventsQueue    chan *applyEventStruct
+	applyEventsInFlight int64
 
 	finishedMigrating int64
 }
@@ -923,21 +924,23 @@ func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) 
 				streamerCoords = mgtr.eventsStreamer.GetCurrentBinlogCoordinates()
 			}
 		}
-		// Normal completion path: applier reached drain and both queues are empty.
-		if drainReached && applyBacklog == 0 && streamerBacklog == 0 {
+		applyInFlight := atomic.LoadInt64(&mgtr.applyEventsInFlight)
+		// Normal completion path: applier reached drain, both queues are empty,
+		// and no apply handler is still running.
+		if drainReached && applyBacklog == 0 && streamerBacklog == 0 && applyInFlight == 0 {
 			mgtr.migrationContext.Log.Infof("T3: drain complete; applier caught up to drain GTID")
 			return nil
 		}
 		// Fallback for non-DML tail: GTID can advance due to unrelated/non-row events,
 		// so applier may stop moving while streamer has already crossed drain.
-		if moveTablesDrainProvenByStreamerProgress(drainGTID, streamerCoords, applyBacklog, streamerBacklog) {
+		if applyInFlight == 0 && moveTablesDrainProvenByStreamerProgress(drainGTID, streamerCoords, applyBacklog, streamerBacklog) {
 			mgtr.migrationContext.Log.Infof("T3: drain complete via streamer frontier (non-DML tail after T2)")
 			return nil
 		}
 		if drainReached {
-			mgtr.migrationContext.Log.Debugf("T3: drain GTID reached but backlog remains (apply=%d, streamer=%d)", applyBacklog, streamerBacklog)
+			mgtr.migrationContext.Log.Debugf("T3: drain GTID reached but backlog remains (apply=%d, streamer=%d, in_flight=%d)", applyBacklog, streamerBacklog, applyInFlight)
 		} else {
-			mgtr.migrationContext.Log.Debugf("T3: applier still behind drain GTID, polling (applier=%s drain=%s)", applierDisplay, drainGTID.DisplayString())
+			mgtr.migrationContext.Log.Debugf("T3: applier still behind drain GTID, polling (applier=%s drain=%s in_flight=%d)", applierDisplay, drainGTID.DisplayString(), applyInFlight)
 		}
 		select {
 		case <-drainCtx.Done():
@@ -945,8 +948,8 @@ func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) 
 			if streamerCoords != nil {
 				streamerDisplay = streamerCoords.DisplayString()
 			}
-			return fmt.Errorf("drain poll timed out after %s: applier did not catch up to drain GTID (applier=%s drain=%s streamer=%s apply_backlog=%d streamer_backlog=%d)",
-				drainTimeout, applierDisplay, drainGTID.DisplayString(), streamerDisplay, applyBacklog, streamerBacklog)
+			return fmt.Errorf("drain poll timed out after %s: applier did not catch up to drain GTID (applier=%s drain=%s streamer=%s apply_backlog=%d streamer_backlog=%d in_flight=%d)",
+				drainTimeout, applierDisplay, drainGTID.DisplayString(), streamerDisplay, applyBacklog, streamerBacklog, applyInFlight)
 		case <-ticker.C:
 		}
 	}
@@ -2251,6 +2254,9 @@ func (mgtr *Migrator) iterateChunks() error {
 }
 
 func (mgtr *Migrator) onApplyEventStruct(eventStruct *applyEventStruct) error {
+	atomic.AddInt64(&mgtr.applyEventsInFlight, 1)
+	defer atomic.AddInt64(&mgtr.applyEventsInFlight, -1)
+
 	handleNonDMLEventStruct := func(eventStruct *applyEventStruct) error {
 		if eventStruct.writeFunc != nil {
 			if err := mgtr.retryOperation(*eventStruct.writeFunc); err != nil {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -825,12 +825,21 @@ func (mgtr *Migrator) hydrateMoveTablesStateFromTarget() error {
 
 func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogCoordinates, isCutover bool) error {
 	mgtr.applier.CurrentCoordinatesMutex.Lock()
-	if mgtr.applier.CurrentCoordinates == nil || mgtr.applier.CurrentCoordinates.IsEmpty() {
-		mgtr.applier.CurrentCoordinatesMutex.Unlock()
-		return errors.New("current coordinates are empty, cannot checkpoint move-tables cutover")
-	}
-	safeCoords := mgtr.applier.CurrentCoordinates.Clone()
+	safeCoords := mgtr.applier.CurrentCoordinates
 	mgtr.applier.CurrentCoordinatesMutex.Unlock()
+
+	if safeCoords == nil || safeCoords.IsEmpty() {
+		// In move-tables mode CurrentCoordinates may never advance on a quiet source
+		// (no _ghc heartbeats, no DML). If there is no backlog, the streamer's
+		// frontier is a safe fallback for checkpointing.
+		if mgtr.eventsStreamer != nil && len(mgtr.applyEventsQueue) == 0 && len(mgtr.eventsStreamer.eventsChannel) == 0 {
+			safeCoords = mgtr.eventsStreamer.GetCurrentBinlogCoordinates()
+		}
+		if safeCoords == nil || safeCoords.IsEmpty() {
+			return errors.New("current coordinates are empty, cannot checkpoint move-tables cutover")
+		}
+	}
+	safeCoords = safeCoords.Clone()
 
 	chk := &Checkpoint{
 		LastTrxCoords:              safeCoords,

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -833,14 +833,14 @@ func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogC
 	mgtr.applier.CurrentCoordinatesMutex.Unlock()
 
 	chk := &Checkpoint{
-		LastTrxCoords:            safeCoords,
-		IterationRangeMin:        sql.NewColumnValues(mgtr.migrationContext.UniqueKey.Len()),
-		IterationRangeMax:        sql.NewColumnValues(mgtr.migrationContext.UniqueKey.Len()),
-		Iteration:                mgtr.migrationContext.GetIteration(),
-		RowsCopied:               atomic.LoadInt64(&mgtr.migrationContext.TotalRowsCopied),
-		DMLApplied:               atomic.LoadInt64(&mgtr.migrationContext.TotalDMLEventsApplied),
-		MoveTablesCutOverStarted: true,
-		DrainGTID:                drainGTID,
+		LastTrxCoords:              safeCoords,
+		IterationRangeMin:          sql.NewColumnValues(mgtr.migrationContext.UniqueKey.Len()),
+		IterationRangeMax:          sql.NewColumnValues(mgtr.migrationContext.UniqueKey.Len()),
+		Iteration:                  mgtr.migrationContext.GetIteration(),
+		RowsCopied:                 atomic.LoadInt64(&mgtr.migrationContext.TotalRowsCopied),
+		DMLApplied:                 atomic.LoadInt64(&mgtr.migrationContext.TotalDMLEventsApplied),
+		MoveTablesCutOverStarted:   true,
+		MoveTablesCutoverDrainGTID: drainGTID,
 	}
 	mgtr.applier.LastIterationRangeMutex.Lock()
 	if mgtr.applier.LastIterationRangeMinValues != nil {
@@ -893,7 +893,7 @@ func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) 
 }
 
 func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) error {
-	if chk == nil || !chk.MoveTablesCutOverStarted || chk.DrainGTID == nil || chk.DrainGTID.IsEmpty() {
+	if chk == nil || !chk.MoveTablesCutOverStarted || chk.MoveTablesCutoverDrainGTID == nil || chk.MoveTablesCutoverDrainGTID.IsEmpty() {
 		return errors.New("checkpoint does not contain move-tables cutover resume state")
 	}
 	if chk.LastTrxCoords != nil && !chk.LastTrxCoords.IsEmpty() {
@@ -902,12 +902,12 @@ func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) err
 		mgtr.applier.CurrentCoordinatesMutex.Unlock()
 	}
 	mgtr.migrationContext.Log.Infof("Resuming move-tables cutover from checkpoint at coords=%+v drain_gtid=%s",
-		chk.LastTrxCoords, chk.DrainGTID.DisplayString())
-	if err := mgtr.drainMoveTablesCutOver(chk.DrainGTID); err != nil {
+		chk.LastTrxCoords, chk.MoveTablesCutoverDrainGTID.DisplayString())
+	if err := mgtr.drainMoveTablesCutOver(chk.MoveTablesCutoverDrainGTID); err != nil {
 		return err
 	}
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.DrainGTID); err != nil {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutoverDrainGTID); err != nil {
 			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}
@@ -958,7 +958,7 @@ func (mgtr *Migrator) MoveTables() (err error) {
 		if err != nil && !errors.Is(err, ErrNoCheckpointFound) {
 			return err
 		}
-		if cutoverResumeCheckpoint != nil && cutoverResumeCheckpoint.MoveTablesCutOverStarted && cutoverResumeCheckpoint.DrainGTID != nil && !cutoverResumeCheckpoint.DrainGTID.IsEmpty() {
+		if cutoverResumeCheckpoint != nil && cutoverResumeCheckpoint.MoveTablesCutOverStarted && cutoverResumeCheckpoint.MoveTablesCutoverDrainGTID != nil && !cutoverResumeCheckpoint.MoveTablesCutoverDrainGTID.IsEmpty() {
 			mgtr.migrationContext.InitialStreamerCoords = cutoverResumeCheckpoint.LastTrxCoords
 			mgtr.migrationContext.Iteration = cutoverResumeCheckpoint.Iteration
 			atomic.StoreInt64(&mgtr.migrationContext.TotalRowsCopied, cutoverResumeCheckpoint.RowsCopied)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -823,7 +823,7 @@ func (mgtr *Migrator) hydrateMoveTablesStateFromTarget() error {
 	return nil
 }
 
-func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogCoordinates) (*Checkpoint, error) {
+func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogCoordinates, isCutover bool) (*Checkpoint, error) {
 	mgtr.applier.CurrentCoordinatesMutex.Lock()
 	if mgtr.applier.CurrentCoordinates == nil || mgtr.applier.CurrentCoordinates.IsEmpty() {
 		mgtr.applier.CurrentCoordinatesMutex.Unlock()
@@ -839,6 +839,7 @@ func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogC
 		Iteration:                  mgtr.migrationContext.GetIteration(),
 		RowsCopied:                 atomic.LoadInt64(&mgtr.migrationContext.TotalRowsCopied),
 		DMLApplied:                 atomic.LoadInt64(&mgtr.migrationContext.TotalDMLEventsApplied),
+		IsCutover:                  isCutover,
 		MoveTablesCutOverStarted:   true,
 		MoveTablesCutOverDrainGTID: drainGTID,
 	}
@@ -855,6 +856,32 @@ func (mgtr *Migrator) persistMoveTablesCutOverCheckpoint(drainGTID mysql.BinlogC
 	return chk, err
 }
 
+// moveTablesDrainCoordinateReached returns true when current is at-or-ahead of
+// drain within the same coordinate family. For GTID drains, current must also
+// be GTID-backed; mixed GTID/file-pos comparisons are treated as not reached.
+func moveTablesDrainCoordinateReached(current mysql.BinlogCoordinates, drain mysql.BinlogCoordinates) bool {
+	if current == nil || current.IsEmpty() || drain == nil || drain.IsEmpty() {
+		return false
+	}
+	switch drain.(type) {
+	case *mysql.GTIDBinlogCoordinates:
+		if _, ok := current.(*mysql.GTIDBinlogCoordinates); !ok {
+			return false
+		}
+	}
+	return !current.SmallerThan(drain)
+}
+
+// moveTablesDrainProvenByStreamerProgress is the non-DML-tail fallback used
+// in T3: if both queues are empty and the streamer has advanced to drain,
+// drain is considered complete even when applier coords did not move.
+func moveTablesDrainProvenByStreamerProgress(drain mysql.BinlogCoordinates, streamer mysql.BinlogCoordinates, applyBacklog int, streamerBacklog int) bool {
+	if applyBacklog != 0 || streamerBacklog != 0 {
+		return false
+	}
+	return moveTablesDrainCoordinateReached(streamer, drain)
+}
+
 func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) error {
 	drainTimeout := time.Duration(mgtr.migrationContext.CutOverLockTimeoutSeconds) * time.Second
 	mgtr.migrationContext.Log.Infof("T3: draining applier to drain GTID (timeout %s, poll %s)",
@@ -867,26 +894,50 @@ func (mgtr *Migrator) drainMoveTablesCutOver(drainGTID mysql.BinlogCoordinates) 
 		if err := mgtr.checkAbort(); err != nil {
 			return err
 		}
+		// Primary signal: applier's coordinate (advances when relevant apply work runs).
 		mgtr.applier.CurrentCoordinatesMutex.Lock()
 		applierCoords := mgtr.applier.CurrentCoordinates
 		mgtr.applier.CurrentCoordinatesMutex.Unlock()
+		drainReached := moveTablesDrainCoordinateReached(applierCoords, drainGTID)
+		// Backlogs gate completion: if either queue is non-empty, drain is not done.
 		applyBacklog := len(mgtr.applyEventsQueue)
 		streamerBacklog := 0
+		var streamerCoords mysql.BinlogCoordinates
+		applierDisplay := ""
+		if applierCoords != nil {
+			applierDisplay = applierCoords.DisplayString()
+		}
 		if mgtr.eventsStreamer != nil {
 			streamerBacklog = len(mgtr.eventsStreamer.eventsChannel)
+			if mgtr.eventsStreamer.binlogReader != nil {
+				// Secondary signal: streamer's latest source position.
+				streamerCoords = mgtr.eventsStreamer.GetCurrentBinlogCoordinates()
+			}
 		}
-		if applierCoords != nil && !applierCoords.IsEmpty() && !applierCoords.SmallerThan(drainGTID) && applyBacklog == 0 && streamerBacklog == 0 {
+		// Normal completion path: applier reached drain and both queues are empty.
+		if drainReached && applyBacklog == 0 && streamerBacklog == 0 {
 			mgtr.migrationContext.Log.Infof("T3: drain complete; applier caught up to drain GTID")
 			return nil
 		}
-		if applierCoords != nil && !applierCoords.IsEmpty() && !applierCoords.SmallerThan(drainGTID) {
+		// Fallback for non-DML tail: GTID can advance due to unrelated/non-row events,
+		// so applier may stop moving while streamer has already crossed drain.
+		if moveTablesDrainProvenByStreamerProgress(drainGTID, streamerCoords, applyBacklog, streamerBacklog) {
+			mgtr.migrationContext.Log.Infof("T3: drain complete via streamer frontier (non-DML tail after T2)")
+			return nil
+		}
+		if drainReached {
 			mgtr.migrationContext.Log.Debugf("T3: drain GTID reached but backlog remains (apply=%d, streamer=%d)", applyBacklog, streamerBacklog)
 		} else {
-			mgtr.migrationContext.Log.Debugf("T3: applier still behind drain GTID, polling")
+			mgtr.migrationContext.Log.Debugf("T3: applier still behind drain GTID, polling (applier=%s drain=%s)", applierDisplay, drainGTID.DisplayString())
 		}
 		select {
 		case <-drainCtx.Done():
-			return fmt.Errorf("drain poll timed out after %s: applier did not catch up to drain GTID", drainTimeout)
+			streamerDisplay := ""
+			if streamerCoords != nil {
+				streamerDisplay = streamerCoords.DisplayString()
+			}
+			return fmt.Errorf("drain poll timed out after %s: applier did not catch up to drain GTID (applier=%s drain=%s streamer=%s apply_backlog=%d streamer_backlog=%d)",
+				drainTimeout, applierDisplay, drainGTID.DisplayString(), streamerDisplay, applyBacklog, streamerBacklog)
 		case <-ticker.C:
 		}
 	}
@@ -907,7 +958,7 @@ func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) err
 		return err
 	}
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutOverDrainGTID); err != nil {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(chk.MoveTablesCutOverDrainGTID, true); err != nil {
 			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}
@@ -1144,6 +1195,7 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 		mgtr.migrationContext.Log.Debugf("Noop operation; not really moving tables")
 		return nil
 	}
+	defer atomic.StoreInt64(&mgtr.migrationContext.InCutOverCriticalSectionFlag, 0)
 
 	// ----- Postpone gate (precedes T0) -----
 	// Mirrors standard cutOver()'s sleepWhileTrue postpone structure but DROPS the
@@ -1176,6 +1228,9 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	}
 	atomic.StoreInt64(&mgtr.migrationContext.IsPostponingCutOver, 0)
 	mgtr.migrationContext.Log.Debugf("checking for cut-over postpone: complete")
+
+	// Disables throttling and background checkpoint loop
+	atomic.StoreInt64(&mgtr.migrationContext.InCutOverCriticalSectionFlag, 1)
 
 	// ----- T0: on-before-cut-over hook -----
 	// Non-zero hook exit aborts cutover BEFORE any source DDL fires.
@@ -1224,19 +1279,16 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	}
 	mgtr.migrationContext.Log.Infof("T2: captured drain GTID: %s", drainGTID.DisplayString())
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID); err != nil {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID, false); err != nil {
 			return fmt.Errorf("failed to persist move-tables cutover checkpoint: %w", err)
 		}
 	}
-
-	// force a crash
-	panic("force crash between table rename and drain completion")
 
 	if err := mgtr.drainMoveTablesCutOver(drainGTID); err != nil {
 		return err
 	}
 	if mgtr.migrationContext.Checkpoint {
-		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID); err != nil {
+		if _, err := mgtr.persistMoveTablesCutOverCheckpoint(drainGTID, true); err != nil {
 			mgtr.migrationContext.Log.Warningf("failed to checkpoint drained move-tables cutover: %+v", err)
 		}
 	}

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -995,7 +995,8 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	// No retry on the RENAME: it is not idempotent — a partial success leaves
 	// the table already renamed and a retry would fail. The operator re-runs
 	// the whole hook chain on failure.
-	pinnedConn, err := mgtr.inspector.db.Conn(context.Background())
+	cutOverCtx := mgtr.migrationContext.GetContext()
+	pinnedConn, err := mgtr.inspector.db.Conn(cutOverCtx)
 	if err != nil {
 		return fmt.Errorf("failed to pin connection for T1/T2: %w", err)
 	}
@@ -1008,7 +1009,7 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 		sql.EscapeName(sourceDB), sql.EscapeName(sourceTable),
 		sql.EscapeName(sourceDB), sql.EscapeName(delTable))
 	mgtr.migrationContext.Log.Infof("T1: renaming source table: %s", renameQuery)
-	if _, err := pinnedConn.ExecContext(context.Background(), renameQuery); err != nil {
+	if _, err := pinnedConn.ExecContext(cutOverCtx, renameQuery); err != nil {
 		return fmt.Errorf("RENAME failed: %w", err)
 	}
 
@@ -1016,7 +1017,7 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	// @@GLOBAL scope is explicit so the intent is unambiguous in the SQL itself.
 	// Design: https://github.com/github/gh-ost-tablemove-poc/blob/9dc6df75c4c88ff473906a497836c7518f5614ec/design/coop_cutover.md#32-correctness-verification-for-p4
 	var drainGTIDStr string
-	if err := pinnedConn.QueryRowContext(context.Background(), "select @@gtid_executed").Scan(&drainGTIDStr); err != nil {
+	if err := pinnedConn.QueryRowContext(cutOverCtx, "select @@global.gtid_executed").Scan(&drainGTIDStr); err != nil {
 		return fmt.Errorf("drain GTID capture failed: %w", err)
 	}
 	drainGTID, err := mysql.NewGTIDBinlogCoordinates(drainGTIDStr)

--- a/go/logic/migrator_move_tables_cutover_test.go
+++ b/go/logic/migrator_move_tables_cutover_test.go
@@ -151,7 +151,7 @@ func TestResumeMoveTablesCutOverFromCheckpointAlreadyDrained(t *testing.T) {
 	chk := &Checkpoint{
 		LastTrxCoords:              drainGTID,
 		MoveTablesCutOverStarted:   true,
-		MoveTablesCutoverDrainGTID: drainGTID,
+		MoveTablesCutOverDrainGTID: drainGTID,
 	}
 
 	require.Equal(t, int64(0), atomic.LoadInt64(&ctx.CutOverCompleteFlag), "pre-state: flag must be 0")

--- a/go/logic/migrator_move_tables_cutover_test.go
+++ b/go/logic/migrator_move_tables_cutover_test.go
@@ -131,6 +131,43 @@ func TestMoveTablesCutOver_PostponeGateFiresOnBeginPostponedOnce(t *testing.T) {
 		"post-state: hook failure must leave CutOverCompleteFlag unset")
 }
 
+// TestResumeMoveTablesCutOverFromCheckpointAlreadyDrained verifies the crash-
+// safe resume branch skips T1 entirely and proceeds directly to T5 when the
+// persisted checkpoint already shows a drain-satisfied position.
+func TestResumeMoveTablesCutOverFromCheckpointAlreadyDrained(t *testing.T) {
+	var calls []string
+	fakeHooks := &recordingHooks{name: "fake", calls: &calls}
+
+	ctx := base.NewMigrationContext()
+	ctx.Hooks = fakeHooks
+	ctx.Checkpoint = false
+
+	m := NewMigrator(ctx, "test")
+	m.applier = NewApplier(ctx)
+
+	drainGTID, err := mysql.NewGTIDBinlogCoordinates("11111111-1111-1111-1111-111111111111:1-10")
+	require.NoError(t, err)
+
+	chk := &Checkpoint{
+		LastTrxCoords:            drainGTID,
+		MoveTablesCutOverStarted: true,
+		DrainGTID:                drainGTID,
+	}
+
+	require.Equal(t, int64(0), atomic.LoadInt64(&ctx.CutOverCompleteFlag), "pre-state: flag must be 0")
+	require.Empty(t, calls, "pre-state: no hooks recorded")
+
+	require.NoError(t, m.resumeMoveTablesCutOverFromCheckpoint(chk))
+
+	require.Equal(t, int64(1), atomic.LoadInt64(&ctx.CutOverCompleteFlag),
+		"post-state: resume path must set CutOverCompleteFlag before exiting")
+	require.Equal(t, []string{"fake:OnSuccess"}, calls,
+		"post-state: resume path should jump directly to T5 without rerunning T0/T1")
+	if m.applier.CurrentCoordinates != nil {
+		require.Equal(t, drainGTID.String(), m.applier.CurrentCoordinates.String())
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Integration tests - real MySQL via testcontainers, exercise T1/T2/T3.
 //

--- a/go/logic/migrator_move_tables_cutover_test.go
+++ b/go/logic/migrator_move_tables_cutover_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -80,6 +81,21 @@ func TestMoveTablesCutOver_OnBeforeCutOverHookAbortsBeforeRename(t *testing.T) {
 		"post-state: T0 abort must leave CutOverCompleteFlag unset")
 	require.Equal(t, []string{"fake:OnBeforeCutOver"}, calls,
 		"post-state: only the failing T0 hook fires; no OnSuccess, no OnBeginPostponed")
+}
+
+type onSuccessCheckHooks struct {
+	*recordingHooks
+	onSuccessCheck func() error
+}
+
+func (h *onSuccessCheckHooks) OnSuccess(bool) error {
+	if err := h.record("OnSuccess"); err != nil {
+		return err
+	}
+	if h.onSuccessCheck != nil {
+		return h.onSuccessCheck()
+	}
+	return nil
 }
 
 // TestMoveTablesCutOver_PostponeGateFiresOnBeginPostponedOnce maps to the
@@ -237,7 +253,7 @@ func (s *MoveTablesCutOverSuite) containingDrainGTID() *mysql.GTIDBinlogCoordina
 // buildMigrator wires a Migrator with the test container's *sql.DB pinned to
 // inspector.db and a fresh Applier. initialCoords may be nil for the drain-
 // timeout case.
-func (s *MoveTablesCutOverSuite) buildMigrator(fakeHooks *recordingHooks, initialCoords mysql.BinlogCoordinates) (*Migrator, *base.MigrationContext) {
+func (s *MoveTablesCutOverSuite) buildMigrator(fakeHooks base.Hooks, initialCoords mysql.BinlogCoordinates) (*Migrator, *base.MigrationContext) {
 	ctx := context.Background()
 	connectionConfig, err := getTestConnectionConfig(ctx, s.mysqlContainer)
 	s.Require().NoError(err)
@@ -393,6 +409,98 @@ func (s *MoveTablesCutOverSuite) TestDrainWaitsForQueuedDML() {
 	}
 	s.Require().Equal([]string{"fake:OnBeforeCutOver"}, calls,
 		"post-state: only T0 fires before the drain loop times out")
+}
+
+// TestDrainWaitsForInFlightApplyEvent ensures T3 does not complete while an
+// apply handler is still running. The blocked handler simulates the last source
+// DML not yet landing on the target. If T3 exits early, OnSuccess observes the
+// target missing that row and fails immediately.
+func (s *MoveTablesCutOverSuite) TestDrainWaitsForInFlightApplyEvent() {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", testMysqlDatabaseOther))
+	s.Require().NoError(err)
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", getTestTableName()))
+	s.Require().NoError(err)
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", getTestOtherTableName()))
+	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		_, _ = s.db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+getTestOtherTableName())
+	})
+
+	drainGTID := s.containingDrainGTID()
+	const pendingID = 42
+	raceErr := errors.New("on-success observed target missing in-flight apply")
+
+	origPoll := moveTablesCutOverDrainPollInterval
+	moveTablesCutOverDrainPollInterval = 50 * time.Millisecond
+	s.T().Cleanup(func() {
+		moveTablesCutOverDrainPollInterval = origPoll
+	})
+
+	var calls []string
+	fakeHooks := &onSuccessCheckHooks{
+		recordingHooks: &recordingHooks{name: "fake", calls: &calls},
+		onSuccessCheck: func() error {
+			var count int
+			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE id = ?", getTestOtherTableName())
+			if err := s.db.QueryRowContext(context.Background(), query, pendingID).Scan(&count); err != nil {
+				return err
+			}
+			if count == 0 {
+				return raceErr
+			}
+			return nil
+		},
+	}
+	m, mc := s.buildMigrator(fakeHooks, drainGTID)
+	mc.CutOverLockTimeoutSeconds = 1
+	m.applier.CurrentCoordinatesMutex.Lock()
+	m.applier.CurrentCoordinates = drainGTID
+	m.applier.CurrentCoordinatesMutex.Unlock()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	releaseApply := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	s.T().Cleanup(releaseApply)
+	blockApply := tableWriteFunc(func() error {
+		startedOnce.Do(func() {
+			close(started)
+		})
+		<-release
+		_, err := s.db.ExecContext(context.Background(), fmt.Sprintf("INSERT INTO %s VALUES (?)", getTestOtherTableName()), pendingID)
+		return err
+	})
+	go func() {
+		<-started
+		time.Sleep(200 * time.Millisecond)
+		releaseApply()
+	}()
+	go func() {
+		_ = m.onApplyEventStruct(newApplyEventStructByFunc(&blockApply))
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		s.Require().FailNow("blocked apply event never started")
+	}
+
+	s.Require().Equal(int64(0), atomic.LoadInt64(&mc.CutOverCompleteFlag), "pre-state: flag must be 0")
+	err = m.moveTablesCutOver()
+	s.Require().NoError(err)
+
+	var count int
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE id = ?", getTestOtherTableName())
+	s.Require().NoError(s.db.QueryRowContext(context.Background(), query, pendingID).Scan(&count))
+	s.Require().Equal(1, count, "post-state: target must contain the pending row by the time cutover succeeds")
+	s.Require().Equal([]string{"fake:OnBeforeCutOver", "fake:OnSuccess"}, calls,
+		"post-state: cutover should only reach OnSuccess after the target row is present")
 }
 
 func TestMoveTablesCutOver(t *testing.T) {

--- a/go/logic/migrator_move_tables_cutover_test.go
+++ b/go/logic/migrator_move_tables_cutover_test.go
@@ -149,9 +149,9 @@ func TestResumeMoveTablesCutOverFromCheckpointAlreadyDrained(t *testing.T) {
 	require.NoError(t, err)
 
 	chk := &Checkpoint{
-		LastTrxCoords:            drainGTID,
-		MoveTablesCutOverStarted: true,
-		DrainGTID:                drainGTID,
+		LastTrxCoords:              drainGTID,
+		MoveTablesCutOverStarted:   true,
+		MoveTablesCutoverDrainGTID: drainGTID,
 	}
 
 	require.Equal(t, int64(0), atomic.LoadInt64(&ctx.CutOverCompleteFlag), "pre-state: flag must be 0")

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -120,11 +120,12 @@ func BuildEqualsPreparedComparison(columns []string) (result string, err error) 
 
 // It holds the prepared query statement so it doesn't need to be recreated every time.
 type CheckpointInsertQueryBuilder struct {
-	uniqueKeyColumns  *ColumnList
-	preparedStatement string
+	uniqueKeyColumns                *ColumnList
+	preparedStatement               string
+	includeMoveTablesCutOverColumns bool
 }
 
-func NewCheckpointQueryBuilder(databaseName, tableName string, uniqueKeyColumns *ColumnList) (*CheckpointInsertQueryBuilder, error) {
+func NewCheckpointQueryBuilder(databaseName, tableName string, uniqueKeyColumns *ColumnList, includeMoveTablesCutOverColumns bool) (*CheckpointInsertQueryBuilder, error) {
 	if uniqueKeyColumns.Len() == 0 {
 		return nil, fmt.Errorf("got 0 columns in BuildSetCheckpointInsertQuery")
 	}
@@ -139,28 +140,49 @@ func NewCheckpointQueryBuilder(databaseName, tableName string, uniqueKeyColumns 
 	}
 	databaseName = EscapeName(databaseName)
 	tableName = EscapeName(tableName)
-	stmt := fmt.Sprintf(`
-		insert /* gh-ost */
-		into %s.%s
-			(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
-			 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
-			 gh_ost_cutover_started, gh_ost_drain_gtid,
-  			 %s, %s)
-		values
-			(unix_timestamp(now()), ?, ?,
-			 ?, ?, ?,
-			 ?, ?,
-			 %s, %s)`,
-		databaseName, tableName,
-		strings.Join(minUniqueColNames, ", "),
-		strings.Join(maxUniqueColNames, ", "),
-		strings.Join(values, ", "),
-		strings.Join(values, ", "),
-	)
+	stmt := ""
+	if includeMoveTablesCutOverColumns {
+		stmt = fmt.Sprintf(`
+			insert /* gh-ost */
+			into %s.%s
+				(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
+				 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+				 gh_ost_cutover_started, gh_ost_drain_gtid,
+				 %s, %s)
+			values
+				(unix_timestamp(now()), ?, ?,
+				 ?, ?, ?,
+				 ?, ?,
+				 %s, %s)`,
+			databaseName, tableName,
+			strings.Join(minUniqueColNames, ", "),
+			strings.Join(maxUniqueColNames, ", "),
+			strings.Join(values, ", "),
+			strings.Join(values, ", "),
+		)
+	} else {
+		stmt = fmt.Sprintf(`
+			insert /* gh-ost */
+			into %s.%s
+				(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
+				 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+				 %s, %s)
+			values
+				(unix_timestamp(now()), ?, ?,
+				 ?, ?, ?,
+				 %s, %s)`,
+			databaseName, tableName,
+			strings.Join(minUniqueColNames, ", "),
+			strings.Join(maxUniqueColNames, ", "),
+			strings.Join(values, ", "),
+			strings.Join(values, ", "),
+		)
+	}
 
 	b := &CheckpointInsertQueryBuilder{
-		uniqueKeyColumns:  uniqueKeyColumns,
-		preparedStatement: stmt,
+		uniqueKeyColumns:                uniqueKeyColumns,
+		preparedStatement:               stmt,
+		includeMoveTablesCutOverColumns: includeMoveTablesCutOverColumns,
 	}
 	return b, nil
 }

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -141,7 +141,7 @@ func NewCheckpointQueryBuilder(databaseName, tableName string, uniqueKeyColumns 
 	databaseName = EscapeName(databaseName)
 	tableName = EscapeName(tableName)
 	b := &CheckpointInsertQueryBuilder{
-		uniqueKeyColumns:                uniqueKeyColumns,
+		uniqueKeyColumns: uniqueKeyColumns,
 		preparedStatement: func() string {
 			if includeMoveTablesCutOverColumns {
 				return fmt.Sprintf(`

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -144,10 +144,12 @@ func NewCheckpointQueryBuilder(databaseName, tableName string, uniqueKeyColumns 
 		into %s.%s
 			(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
 			 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+			 gh_ost_cutover_started, gh_ost_drain_gtid,
   			 %s, %s)
 		values
 			(unix_timestamp(now()), ?, ?,
 			 ?, ?, ?,
+			 ?, ?,
 			 %s, %s)`,
 		databaseName, tableName,
 		strings.Join(minUniqueColNames, ", "),

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -140,48 +140,47 @@ func NewCheckpointQueryBuilder(databaseName, tableName string, uniqueKeyColumns 
 	}
 	databaseName = EscapeName(databaseName)
 	tableName = EscapeName(tableName)
-	stmt := ""
-	if includeMoveTablesCutOverColumns {
-		stmt = fmt.Sprintf(`
-			insert /* gh-ost */
-			into %s.%s
-				(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
-				 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
-				 gh_ost_cutover_started, gh_ost_drain_gtid,
-				 %s, %s)
-			values
-				(unix_timestamp(now()), ?, ?,
-				 ?, ?, ?,
-				 ?, ?,
-				 %s, %s)`,
-			databaseName, tableName,
-			strings.Join(minUniqueColNames, ", "),
-			strings.Join(maxUniqueColNames, ", "),
-			strings.Join(values, ", "),
-			strings.Join(values, ", "),
-		)
-	} else {
-		stmt = fmt.Sprintf(`
-			insert /* gh-ost */
-			into %s.%s
-				(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
-				 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
-				 %s, %s)
-			values
-				(unix_timestamp(now()), ?, ?,
-				 ?, ?, ?,
-				 %s, %s)`,
-			databaseName, tableName,
-			strings.Join(minUniqueColNames, ", "),
-			strings.Join(maxUniqueColNames, ", "),
-			strings.Join(values, ", "),
-			strings.Join(values, ", "),
-		)
-	}
-
 	b := &CheckpointInsertQueryBuilder{
 		uniqueKeyColumns:                uniqueKeyColumns,
-		preparedStatement:               stmt,
+		preparedStatement: func() string {
+			if includeMoveTablesCutOverColumns {
+				return fmt.Sprintf(`
+					insert /* gh-ost */
+					into %s.%s
+						(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
+						 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+						 gh_ost_move_tables_cutover_started, gh_ost_move_tables_drain_gtid,
+						 %s, %s)
+					values
+						(unix_timestamp(now()), ?, ?,
+						 ?, ?, ?,
+						 ?, ?,
+						 %s, %s)`,
+					databaseName, tableName,
+					strings.Join(minUniqueColNames, ", "),
+					strings.Join(maxUniqueColNames, ", "),
+					strings.Join(values, ", "),
+					strings.Join(values, ", "),
+				)
+			}
+
+			return fmt.Sprintf(`
+				insert /* gh-ost */
+				into %s.%s
+					(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
+					 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+					 %s, %s)
+				values
+					(unix_timestamp(now()), ?, ?,
+					 ?, ?, ?,
+					 %s, %s)`,
+				databaseName, tableName,
+				strings.Join(minUniqueColNames, ", "),
+				strings.Join(maxUniqueColNames, ", "),
+				strings.Join(values, ", "),
+				strings.Join(values, ", "),
+			)
+		}(),
 		includeMoveTablesCutOverColumns: includeMoveTablesCutOverColumns,
 	}
 	return b, nil

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -1355,11 +1355,13 @@ func TestCheckpointQueryBuilder(t *testing.T) {
 		insert /* gh-ost */ into mydb._tbl_ghk
 		(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
 		 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+		 gh_ost_cutover_started, gh_ost_drain_gtid,
 		 name_min, position_min, my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长_min,
 		 name_max, position_max, my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长_max)
 		values
 		(unix_timestamp(now()), ?, ?,
 			 ?, ?, ?,
+			 ?, ?,
 			 ?, ?, ?,
 			 ?, ?, ?)
     `

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -1380,7 +1380,7 @@ func TestMoveTablesCheckpointQueryBuilder(t *testing.T) {
 		insert /* gh-ost */ into mydb._tbl_ghk
 		(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
 		 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
-		 gh_ost_cutover_started, gh_ost_drain_gtid,
+		 gh_ost_move_tables_cutover_started, gh_ost_move_tables_drain_gtid,
 		 name_min, position_min, my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长_min,
 		 name_max, position_max, my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长_max)
 		values

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -1347,7 +1347,32 @@ func TestCheckpointQueryBuilder(t *testing.T) {
 	tableName := "_tbl_ghk"
 	valueArgs := []interface{}{"mona", "mascot", int8(-17), "anothername", "anotherposition", int8(-2)}
 	uniqueKeyColumns := NewColumnList([]string{"name", "position", "my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长很长很长"})
-	builder, err := NewCheckpointQueryBuilder(databaseName, tableName, uniqueKeyColumns)
+	builder, err := NewCheckpointQueryBuilder(databaseName, tableName, uniqueKeyColumns, false)
+	require.NoError(t, err)
+	query, uniqueKeyArgs, err := builder.BuildQuery(valueArgs)
+	require.NoError(t, err)
+	expected := `
+		insert /* gh-ost */ into mydb._tbl_ghk
+		(gh_ost_chk_timestamp, gh_ost_chk_coords, gh_ost_chk_iteration,
+		 gh_ost_rows_copied, gh_ost_dml_applied, gh_ost_is_cutover,
+		 name_min, position_min, my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长_min,
+		 name_max, position_max, my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长_max)
+		values
+		(unix_timestamp(now()), ?, ?,
+			 ?, ?, ?,
+			 ?, ?, ?,
+			 ?, ?, ?)
+    `
+	require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+	require.Equal(t, []interface{}{"mona", "mascot", int8(-17), "anothername", "anotherposition", int8(-2)}, uniqueKeyArgs)
+}
+
+func TestMoveTablesCheckpointQueryBuilder(t *testing.T) {
+	databaseName := "mydb"
+	tableName := "_tbl_ghk"
+	valueArgs := []interface{}{"mona", "mascot", int8(-17), "anothername", "anotherposition", int8(-2)}
+	uniqueKeyColumns := NewColumnList([]string{"name", "position", "my_very_long_column_that_is_64_utf8_characters_long_很长很长很长很长很长很长"})
+	builder, err := NewCheckpointQueryBuilder(databaseName, tableName, uniqueKeyColumns, true)
 	require.NoError(t, err)
 	query, uniqueKeyArgs, err := builder.BuildQuery(valueArgs)
 	require.NoError(t, err)

--- a/script/move-tables/README.md
+++ b/script/move-tables/README.md
@@ -24,7 +24,7 @@ script/build --cli
 
 Run gh-ost to move tables:
 ```bash
-./script/build --cli; ./bin/gh-ost --move-tables=gh_ost_test --host=localhost --port=3307 --user root --password opensesame --database=gh_ost_test_db --target-host=localhost --target-port=3309 --target-user root --target-password opensesame --target-database=gh_ost_test_db --postpone-cut-over-flag-file=/tmp/ghost-move-tables.postpone.flag --execute --verbose
+./script/build --cli; ./bin/gh-ost --move-tables=gh_ost_test --host=localhost --port=3307 --user root --password opensesame --database=gh_ost_test_db --target-host=localhost --target-port=3309 --target-user root --target-password opensesame --target-database=gh_ost_test_db --postpone-cut-over-flag-file=/tmp/ghost-move-tables.postpone.flag --execute --verbose --checkpoint --checkpoint-seconds 10
 ```
 
 Note: replicas in this local topology are configured with `read_only=ON` and

--- a/script/move-tables/README.md
+++ b/script/move-tables/README.md
@@ -31,3 +31,30 @@ Note: replicas in this local topology are configured with `read_only=ON` and
 `super_read_only=ON`. If you point `--host` at `mysql-source-replica` (3308),
 the cutover `RENAME TABLE` step will fail by design. Use source primary (3307)
 as the inspected host when you want cutover to rename on source.
+
+Start continuous inserts against the source.
+```bash
+script/move-tables/insert-source-primary-loop
+```
+
+Check the target - it should have the initial data from the source and should be receiving the new data.
+```bash
+script/move-tables/mysql-target-primary -D gh_ost_test_db -e "SELECT * FROM gh_ost_test;"
+```
+
+Remove the cutover flag file.
+```bash
+rm /tmp/ghost-move-tables.postpone.flag
+```
+
+You'll see the continous inserts will stop because of the table rename.
+
+Check the source - table has been renamed.
+```bash
+script/move-tables/mysql-source-primary -D gh_ost_test_db -e "SELECT * FROM _gh_ost_test_del;"
+```
+
+Check the target has the same set of data.
+```bash
+script/move-tables/mysql-target-primary -D gh_ost_test_db -e "SELECT * FROM gh_ost_test;"
+```

--- a/script/move-tables/README.md
+++ b/script/move-tables/README.md
@@ -47,7 +47,7 @@ Remove the cutover flag file.
 rm /tmp/ghost-move-tables.postpone.flag
 ```
 
-You'll see the continous inserts will stop because of the table rename.
+You'll see the continuous inserts will stop because of the table rename.
 
 Check the source - table has been renamed.
 ```bash

--- a/script/move-tables/insert-source-primary-loop
+++ b/script/move-tables/insert-source-primary-loop
@@ -3,28 +3,45 @@ set -euo pipefail
 
 # Continuously insert new rows into gh_ost_test on source primary.
 # Usage:
-#   script/move-tables/insert-source-primary-loop [start_column1] [sleep_seconds]
+#   script/move-tables/insert-source-primary-loop [start_column1] [sleep_seconds] [rows_per_batch]
 # Example:
-#   script/move-tables/insert-source-primary-loop 100000 0.2
+#   script/move-tables/insert-source-primary-loop 100000 0.2 1
+# Fast example:
+#   script/move-tables/insert-source-primary-loop 100000 0 50
 
 start_i="${1:-100000}"
 delay="${2:-0.2}"
+rows_per_batch="${3:-1}"
 i="$start_i"
 
 echo "Starting continuous inserts on source primary. Press Ctrl+C to stop."
-echo "start_column1=$start_i sleep_seconds=$delay"
+echo "start_column1=$start_i sleep_seconds=$delay rows_per_batch=$rows_per_batch"
 
 trap 'echo; echo "Stopped."; exit 0' INT TERM
 
 while true; do
   ts="$(date +%s)"
+  values=""
+  batch_start="$i"
+
+  for ((n=0; n<rows_per_batch; n++)); do
+    current_i=$((i + n))
+    row="($current_i, $((current_i % 65535)), $((current_i % 16777215)), $((current_i % 255)), $ts, $((ts + 1)))"
+    if [[ -n "$values" ]]; then
+      values+=" , "
+    fi
+    values+="$row"
+  done
 
   script/move-tables/mysql-source-primary -D gh_ost_test_db -e "
     INSERT INTO gh_ost_test (column1, column2, column3, column4, column5, column6)
-    VALUES ($i, $((i % 65535)), $((i % 16777215)), $((i % 255)), $ts, $((ts + 1)));
+    VALUES $values;
   "
 
-  echo "inserted row: column1=$i ts=$ts"
-  i=$((i + 1))
-  sleep "$delay"
+  i=$((i + rows_per_batch))
+  echo "inserted rows: column1=${batch_start}..$((i - 1)) ts=$ts"
+
+  if [[ "$delay" != "0" && "$delay" != "0.0" ]]; then
+    sleep "$delay"
+  fi
 done

--- a/script/move-tables/teardown
+++ b/script/move-tables/teardown
@@ -18,3 +18,7 @@ docker stop mysql-source-replica mysql-source-primary mysql-target-replica mysql
 
 echo "Removing containers..."
 docker rm -f mysql-source-replica mysql-source-primary mysql-target-replica mysql-target-primary 2>/dev/null || true
+
+echo "Cleaning up Docker resources..."
+docker system prune -f
+docker volume prune -f


### PR DESCRIPTION
closes https://github.com/github/database-infrastructure/issues/8210

## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue (internal): https://github.com/github/database-infrastructure/issues/8210
Related issue (public): https://github.com/github/gh-ost/issues/1681

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR updates move-tables mode to be crash-resume safe. It manages the `checkpoint` table life, and a backgrounded checkpoint process as well as introduces new checkpoint data specifically for the move-tables cutover. Per the [docs on crash safe resume across cutover](https://github.com/github/gh-ost-tablemove-poc/blob/design-docs/design/move_table_mode.md#16-crash-safe-resume-across-cutover), we now store that the move-tables cutover has started (a bool) and the move-tables cutover drain GTID. We use these two attributes for `--move-tables --resume` to pickup if the process failed mid-cutover. It's safe for failure between T1-T3 (the rename and the drain) and also safe for failure post drain, pre hook call (between T3-T5). I simple `--resume` will pick back up in the cutover protocol and ensure the rename isn't re-run, the drain is complete, and the complete hook is fired. 

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.


### Demo

https://github.com/user-attachments/assets/943ef4fc-5c0d-4f94-b243-f4801a3e6e36


