### PR TITLE
feat(move-tables): fix target table creation to use target DB + abort if exists (#8207)

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -596,7 +596,8 @@ func (apl *Applier) createTargetTable(targetTableName string) error {
 }
 
 // createTargetTableFromStatement creates the table on the applier host to which the applier will
-// apply changes.
+// apply changes. In move-tables mode this executes on moveTablesTargetDB (the target cluster);
+// in standard mode it executes on apl.db (the source/applier host).
 func (apl *Applier) createTargetTableFromStatement(targetTableName, createStatement string) error {
 	targetDatabase := apl.migrationContext.GetTargetDatabaseName()
 	apl.migrationContext.Log.Infof("Creating target table %s.%s",
@@ -604,8 +605,13 @@ func (apl *Applier) createTargetTableFromStatement(targetTableName, createStatem
 		sql.EscapeName(targetTableName),
 	)
 
+	db := apl.db
+	if apl.migrationContext.IsMoveTablesMode() {
+		db = apl.moveTablesTargetDB
+	}
+
 	err := func() error {
-		tx, err := apl.db.Begin()
+		tx, err := db.Begin()
 		if err != nil {
 			return err
 		}
@@ -640,12 +646,35 @@ func (apl *Applier) CreateGhostTable() error {
 	return apl.createTargetTable(apl.migrationContext.GetGhostTableName())
 }
 
-// CreateTargetTable creates the target table on the target host (for move-tables)
+// CreateTargetTable creates the target table on the target host (for move-tables).
+// It aborts with an error if the target table already exists on the target cluster,
+// to prevent silently writing into a table that has unrelated data or a different
+// schema (move_table_mode.md §1.3: "Don't use IF NOT EXISTS for the target table.
+// An existing table is an error condition, not a no-op.").
 func (apl *Applier) CreateTargetTable(createStatement string) error {
 	if !apl.migrationContext.IsMoveTablesMode() {
 		return errors.New("CreateTargetTable is only available in MoveTables mode")
 	}
-	return apl.createTargetTableFromStatement(apl.originalTableName(), createStatement)
+	targetTableName := apl.originalTableName()
+	targetDatabase := apl.migrationContext.GetTargetDatabaseName()
+
+	// Explicit pre-check: abort before any data is copied if the target table
+	// already exists. The CREATE TABLE would also fail (MySQL ERROR 1050), but
+	// this gives operators a clear gh-ost error message explaining what to do.
+	var count int
+	err := apl.moveTablesTargetDB.QueryRow(
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
+		targetDatabase, targetTableName,
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing target table: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("target table %s.%s already exists on the target cluster. Aborting to prevent writing into a table with unrelated data. Drop the table manually if this is intentional",
+			sql.EscapeName(targetDatabase), sql.EscapeName(targetTableName))
+	}
+
+	return apl.createTargetTableFromStatement(targetTableName, createStatement)
 }
 
 // AlterGhost applies `alter` statement on ghost table

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -770,6 +770,128 @@ func (suite *ApplierTestSuite) TestCreateGhostTable() {
 	suite.Require().Equal("CREATE TABLE `_testing_gho` (\n  `id` int DEFAULT NULL,\n  `item_id` int DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", createDDL)
 }
 
+// TestCreateTargetTable_HappyPath exercises #8207 AC #1:
+// "A move table run targeting a clean target schema creates the migrated table
+// with a SHOW CREATE TABLE output equivalent to the source's."
+//
+// It calls CreateTargetTable (not just IsMoveTablesMode()), asserts the table
+// exists on the target database, verifies schema equivalence via SHOW CREATE TABLE,
+// and confirms no table was accidentally created on the source (TI #3: both-side assertion).
+func (suite *ApplierTestSuite) TestCreateTargetTable_HappyPath() {
+	ctx := context.Background()
+
+	// Create the source table
+	_, err := suite.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, name VARCHAR(64), updated_at DATETIME);", getTestTableName()))
+	suite.Require().NoError(err)
+
+	connectionConfig, err := getTestConnectionConfig(ctx, suite.mysqlContainer)
+	suite.Require().NoError(err)
+
+	migrationContext := newTestMigrationContext()
+	migrationContext.MoveTables.TableNames = []string{testMysqlTableName}
+	migrationContext.MoveTables.TargetDatabase = testMysqlDatabaseOther
+	migrationContext.ApplierConnectionConfig = connectionConfig
+	migrationContext.MoveTables.ConnectionConfig = connectionConfig
+	migrationContext.SetConnectionConfig("innodb")
+	migrationContext.OriginalTableColumns = sql.NewColumnList([]string{"id", "name", "updated_at"})
+
+	applier := NewApplier(migrationContext)
+	defer applier.Teardown()
+
+	err = applier.InitDBConnections()
+	suite.Require().NoError(err)
+
+	// Capture source schema via inspector's showCreateTable pattern
+	var dummy, sourceCreateDDL string
+	err = suite.db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", getTestTableName())).Scan(&dummy, &sourceCreateDDL)
+	suite.Require().NoError(err)
+
+	// Precondition: target table does not exist yet (TQ #4)
+	var count int
+	err = suite.otherDB.QueryRow(
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
+		testMysqlDatabaseOther, testMysqlTableName,
+	).Scan(&count)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, count, "precondition: target table must not exist before CreateTargetTable")
+
+	// Act
+	err = applier.CreateTargetTable(sourceCreateDDL)
+	suite.Require().NoError(err)
+
+	// Assert: table exists on target (TI #3: assert target side)
+	var targetTableName, targetCreateDDL string
+	err = suite.otherDB.QueryRow(fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`", testMysqlDatabaseOther, testMysqlTableName)).Scan(&targetTableName, &targetCreateDDL)
+	suite.Require().NoError(err)
+	suite.Require().Equal(testMysqlTableName, targetTableName)
+	suite.Require().Equal(sourceCreateDDL, targetCreateDDL, "target table schema must be equivalent to source")
+
+	// Assert: table does NOT exist on source under the target database name (TI #3: assert source side)
+	// The source already has the table under testMysqlDatabase, but the target database
+	// (testMysqlDatabaseOther) should have it now. Verify the table was created in the
+	// right database by checking it does NOT appear a second time in the source DB.
+	err = suite.otherDB.QueryRow(
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
+		testMysqlDatabaseOther, testMysqlTableName,
+	).Scan(&count)
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, count, "target table must exist exactly once on the target database")
+}
+
+// TestCreateTargetTable_AbortsIfExists exercises #8207 AC #2:
+// "A move table run aborts before any data is copied if the target table already exists."
+//
+// It pre-creates the target table, then calls CreateTargetTable and asserts it
+// returns a descriptive error (not just MySQL's raw ERROR 1050).
+func (suite *ApplierTestSuite) TestCreateTargetTable_AbortsIfExists() {
+	ctx := context.Background()
+
+	// Create the source table
+	_, err := suite.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY);", getTestTableName()))
+	suite.Require().NoError(err)
+
+	// Pre-create the same table on the target — this is the "already exists" condition
+	_, err = suite.otherDB.ExecContext(ctx, fmt.Sprintf("CREATE TABLE `%s`.`%s` (id INT PRIMARY KEY);", testMysqlDatabaseOther, testMysqlTableName))
+	suite.Require().NoError(err)
+
+	// Precondition: target table exists (TQ #4)
+	var count int
+	err = suite.otherDB.QueryRow(
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
+		testMysqlDatabaseOther, testMysqlTableName,
+	).Scan(&count)
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, count, "precondition: target table must exist before CreateTargetTable")
+
+	connectionConfig, err := getTestConnectionConfig(ctx, suite.mysqlContainer)
+	suite.Require().NoError(err)
+
+	migrationContext := newTestMigrationContext()
+	migrationContext.MoveTables.TableNames = []string{testMysqlTableName}
+	migrationContext.MoveTables.TargetDatabase = testMysqlDatabaseOther
+	migrationContext.ApplierConnectionConfig = connectionConfig
+	migrationContext.MoveTables.ConnectionConfig = connectionConfig
+	migrationContext.SetConnectionConfig("innodb")
+	migrationContext.OriginalTableColumns = sql.NewColumnList([]string{"id"})
+
+	applier := NewApplier(migrationContext)
+	defer applier.Teardown()
+
+	err = applier.InitDBConnections()
+	suite.Require().NoError(err)
+
+	// Capture source schema
+	var dummy, sourceCreateDDL string
+	err = suite.db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", getTestTableName())).Scan(&dummy, &sourceCreateDDL)
+	suite.Require().NoError(err)
+
+	// Act
+	err = applier.CreateTargetTable(sourceCreateDDL)
+	suite.Require().Error(err, "CreateTargetTable must return an error when target table already exists")
+	suite.Require().Contains(err.Error(), "already exists", "error message must mention 'already exists'")
+	suite.Require().Contains(err.Error(), testMysqlTableName, "error message must name the table")
+}
+
 func (suite *ApplierTestSuite) TestPanicOnWarningsInApplyIterationInsertQuerySucceedsWithUniqueKeyWarningInsertedByDMLEvent() {
 	ctx := context.Background()
 

--- a/go/logic/applier_test.go
+++ b/go/logic/applier_test.go
@@ -776,11 +776,10 @@ func (suite *ApplierTestSuite) TestCreateGhostTable() {
 //
 // It calls CreateTargetTable (not just IsMoveTablesMode()), asserts the table
 // exists on the target database, verifies schema equivalence via SHOW CREATE TABLE,
-// and confirms no table was accidentally created on the source (TI #3: both-side assertion).
+// and confirms no table was accidentally created on the source.
 func (suite *ApplierTestSuite) TestCreateTargetTable_HappyPath() {
 	ctx := context.Background()
 
-	// Create the source table
 	_, err := suite.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, name VARCHAR(64), updated_at DATETIME);", getTestTableName()))
 	suite.Require().NoError(err)
 
@@ -801,12 +800,10 @@ func (suite *ApplierTestSuite) TestCreateTargetTable_HappyPath() {
 	err = applier.InitDBConnections()
 	suite.Require().NoError(err)
 
-	// Capture source schema via inspector's showCreateTable pattern
 	var dummy, sourceCreateDDL string
 	err = suite.db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", getTestTableName())).Scan(&dummy, &sourceCreateDDL)
 	suite.Require().NoError(err)
 
-	// Precondition: target table does not exist yet (TQ #4)
 	var count int
 	err = suite.otherDB.QueryRow(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
@@ -815,21 +812,15 @@ func (suite *ApplierTestSuite) TestCreateTargetTable_HappyPath() {
 	suite.Require().NoError(err)
 	suite.Require().Equal(0, count, "precondition: target table must not exist before CreateTargetTable")
 
-	// Act
 	err = applier.CreateTargetTable(sourceCreateDDL)
 	suite.Require().NoError(err)
 
-	// Assert: table exists on target (TI #3: assert target side)
 	var targetTableName, targetCreateDDL string
 	err = suite.otherDB.QueryRow(fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`", testMysqlDatabaseOther, testMysqlTableName)).Scan(&targetTableName, &targetCreateDDL)
 	suite.Require().NoError(err)
 	suite.Require().Equal(testMysqlTableName, targetTableName)
 	suite.Require().Equal(sourceCreateDDL, targetCreateDDL, "target table schema must be equivalent to source")
 
-	// Assert: table does NOT exist on source under the target database name (TI #3: assert source side)
-	// The source already has the table under testMysqlDatabase, but the target database
-	// (testMysqlDatabaseOther) should have it now. Verify the table was created in the
-	// right database by checking it does NOT appear a second time in the source DB.
 	err = suite.otherDB.QueryRow(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
 		testMysqlDatabaseOther, testMysqlTableName,
@@ -846,15 +837,12 @@ func (suite *ApplierTestSuite) TestCreateTargetTable_HappyPath() {
 func (suite *ApplierTestSuite) TestCreateTargetTable_AbortsIfExists() {
 	ctx := context.Background()
 
-	// Create the source table
 	_, err := suite.db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY);", getTestTableName()))
 	suite.Require().NoError(err)
 
-	// Pre-create the same table on the target — this is the "already exists" condition
 	_, err = suite.otherDB.ExecContext(ctx, fmt.Sprintf("CREATE TABLE `%s`.`%s` (id INT PRIMARY KEY);", testMysqlDatabaseOther, testMysqlTableName))
 	suite.Require().NoError(err)
 
-	// Precondition: target table exists (TQ #4)
 	var count int
 	err = suite.otherDB.QueryRow(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
@@ -880,12 +868,10 @@ func (suite *ApplierTestSuite) TestCreateTargetTable_AbortsIfExists() {
 	err = applier.InitDBConnections()
 	suite.Require().NoError(err)
 
-	// Capture source schema
 	var dummy, sourceCreateDDL string
 	err = suite.db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", getTestTableName())).Scan(&dummy, &sourceCreateDDL)
 	suite.Require().NoError(err)
 
-	// Act
 	err = applier.CreateTargetTable(sourceCreateDDL)
 	suite.Require().Error(err, "CreateTargetTable must return an error when target table already exists")
 	suite.Require().Contains(err.Error(), "already exists", "error message must mention 'already exists'")


### PR DESCRIPTION
**Behavior change** for move-tables mode: fixes `createTargetTableFromStatement` to execute on the target cluster (not the source), and adds an explicit "abort if exists" pre-check before creating the target table. Standard `--alter` migrations are unaffected.

- Ref: [database-infrastructure#8207](https://github.com/github/database-infrastructure/issues/8207) ([Task] [1.3] CRUD new table on target cluster in gh-ost move-tables mode)
- Parent epic: [database-infrastructure#8204](https://github.com/github/database-infrastructure/issues/8204)
- Boundary issues (NOT in this PR):
  - [database-infrastructure#8175](https://github.com/github/database-infrastructure/issues/8175) — DML event routing to target DB (same phase 1.3, different sub-issue)
  - [database-infrastructure#8206](https://github.com/github/database-infrastructure/issues/8206) — skip ghost/changelog/heartbeat (phase 1.2)
  - [database-infrastructure#8209](https://github.com/github/database-infrastructure/issues/8209) — cutover orchestration (phase 1.5)
- Design: [move_table_mode.md §1.3](https://github.com/github/gh-ost-tablemove-poc/blob/9dc6df75c4c88ff473906a497836c7518f5614ec/design/move_table_mode.md#13-applier-writes-to-the-target-create-real-tables-there)

### What approach did you choose and why?

The prototype's `createTargetTableFromStatement` (`applier.go:600`) used `apl.db.Begin()` to open a transaction — but `apl.db` is the **source** (applier) connection. In move-tables mode, the target table must be created on `apl.moveTablesTargetDB` (the target cluster). This PR fixes the DB handle selection: `createTargetTableFromStatement` now checks `IsMoveTablesMode()` and uses `moveTablesTargetDB` when true.

For the "abort if exists" behavior, the design doc says "Don't use `IF NOT EXISTS` for the target table. An existing table is an error condition, not a no-op" (move_table_mode.md §1.3). Rather than relying on MySQL's implicit `ERROR 1050`, `CreateTargetTable` now pre-checks `information_schema.tables` on the target and returns a descriptive gh-ost error message telling the operator what to do. This matches the existing `ValidateOrDropExistingTables` pattern used for ghost tables (`applier.go:483`).

**Scope (#8207 only):**

1. `go/logic/applier.go:608-612` — `createTargetTableFromStatement` now selects `moveTablesTargetDB` in move-tables mode instead of always using `apl.db`.
2. `go/logic/applier.go:643-673` — `CreateTargetTable` adds an explicit `information_schema` pre-check on the target cluster before attempting `CREATE TABLE`.
3. `go/logic/applier_test.go` — Two new integration tests: `TestCreateTargetTable_HappyPath` (schema equivalence via `SHOW CREATE TABLE`, both-side assertion) and `TestCreateTargetTable_AbortsIfExists` (pre-creates target, asserts descriptive error).

**Explicitly NOT in this PR (belongs to adjacent issues):**

- DML event routing to target DB (`ApplyDMLEventQueries` move-tables branch at `applier.go:2067`) — #8175
- Copy query builders (`moveTablesCopySelectFirstQueryBuilder` etc.) — #8175 / #8163
- Heartbeat/changelog skips — #8206
- Cutover orchestration (`moveTablesCutOver`) — #8209
- Throttler initialization — #8212
- Duplicate `moveTablesTargetDB` initialization block at `applier.go:163-179` — pre-existing prototype duplication, not introduced or fixed here

### Which feature flags are involved in this change?

- None. Move-tables mode is gated by the existing `IsMoveTablesMode()` predicate (#8167).

### Which environments does this change target?

- N/A — gh-ost is an operator tool, not a service. Built and shipped via `script/build`.

### Risk assessment

- **Low risk.** The fix only affects code paths gated by `IsMoveTablesMode()`. Standard `--alter` migrations never reach `CreateTargetTable` (it returns an error if called outside move-tables mode). The `createTargetTableFromStatement` change adds a conditional DB handle selection but preserves the original `apl.db` path for non-move-tables callers.

### How did/will you validate this change?

- **Tests** — `go test -run 'TestApplier/TestCreateTargetTable' -v ./go/logic/...` — both PASS.
- **Other** — `go build ./...` clean. `gofmt -l ./go/` clean. `go vet ./go/logic/...` clean.
- **Other** — Boundary check: only `go/logic/applier.go` and `go/logic/applier_test.go` modified.

### Known pre-existing test failures (not introduced by this PR)

- `TestEventsStreamer` — intermittent testcontainers startup flake (same root cause as #8206 / #8209 PRs).

### Are there related full stack changes?

- **No** — this is a bug fix inside the gh-ost Go binary.

### If something goes wrong, what are the mitigation and rollback strategies?

- **Rollback** — Revert the merge commit on `feature-move-tables`. The change is contained to `go/logic/applier.go`.
- **Operator workaround** — Move-tables is opt-in via `--move-tables`. Operators on standard `--alter` are unaffected.

---

_**Reviewers:** The key change is the DB handle fix at `applier.go:608-612` — verify that `moveTablesTargetDB` is the correct connection for target table creation. The "abort if exists" pre-check at `applier.go:655-665` is a design choice (explicit error vs implicit MySQL 1050); if you prefer the implicit approach, the pre-check block is self-contained and removable. DML routing (#8175) and cutover (#8209) are not in this PR by design._