### PR TITLE
Small fixes in move-tables config initialization

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -983,8 +983,14 @@ func (mctx *MigrationContext) ApplyCredentials() {
 			Hostname: mctx.MoveTables.TargetHost,
 			Port:     mctx.MoveTables.TargetPort,
 		})
-		mctx.MoveTables.ConnectionConfig.User = mctx.MoveTables.TargetUser
-		mctx.MoveTables.ConnectionConfig.Password = mctx.MoveTables.TargetPass
+		if mctx.MoveTables.TargetUser != "" {
+			// Override
+			mctx.MoveTables.ConnectionConfig.User = mctx.MoveTables.TargetUser
+		}
+		if mctx.MoveTables.TargetPass != "" {
+			// Override
+			mctx.MoveTables.ConnectionConfig.Password = mctx.MoveTables.TargetPass
+		}
 	}
 }
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -383,13 +383,6 @@ func main() {
 			// For now, we only support moving a single table at a time.
 			log.Fatal("--move-tables currently supports only a single table")
 		}
-
-		if migrationContext.MoveTables.TargetUser == "" {
-			migrationContext.MoveTables.TargetUser = migrationContext.CliUser
-		}
-		if migrationContext.MoveTables.TargetPass == "" {
-			migrationContext.MoveTables.TargetPass = migrationContext.CliPassword
-		}
 		if migrationContext.MoveTables.TargetDatabase == "" {
 			migrationContext.MoveTables.TargetDatabase = migrationContext.DatabaseName
 		}

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -197,11 +197,11 @@ func buildMigrationLockName(db, table string) string {
 // preventing two gh-ost processes from migrating the same table concurrently
 // on the same MySQL server.
 func (apl *Applier) AcquireMigrationLock(ctx context.Context) error {
-	lockName := buildMigrationLockName(apl.migrationContext.DatabaseName, apl.originalTableName())
+	lockName := buildMigrationLockName(apl.migrationContext.GetTargetDatabaseName(), apl.originalTableName())
 
 	// Use a dedicated *sql.DB so the pinned connection does not consume a
 	// slot in apl.db's small pool (mysql.MaxDBPoolConnections).
-	lockURI := apl.connectionConfig.GetDBUri(apl.migrationContext.DatabaseName)
+	lockURI := apl.connectionConfig.GetDBUri(apl.migrationContext.GetTargetDatabaseName())
 	lockDB, err := gosql.Open("mysql", lockURI)
 	if err != nil {
 		return fmt.Errorf("failed to open migration lock DB: %w", err)


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/gh-ost/issues/1681

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR fixes the credential loading for move-tables mode. It only uses the `--target-user` and `--target-password` if not empty. Otherwise it re-uses the same credentials as for the source connection.

It also fixes the lock database connection, using the target database instead of the source database name. These can differ in move-tables mode.
