### PR TITLE
Enable throttler in move-tables mode

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -2177,11 +2177,7 @@ func (mgtr *Migrator) executeWriteFuncs() error {
 			return nil
 		}
 
-		if !mgtr.migrationContext.IsMoveTablesMode() {
-			// disable throttling in move-tables mode for now
-			// https://github.com/github/database-infrastructure/issues/8212
-			mgtr.throttler.throttle(nil)
-		}
+		mgtr.throttler.throttle(nil)
 
 		// We give higher priority to event processing, then secondary priority to
 		// rowcopy


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue (internal): https://github.com/github/database-infrastructure/issues/8212
Related issue (public): https://github.com/github/gh-ost/issues/1681

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR enables throttling in move-tables mode.
The code was conditionally turned off at the beginning of development.

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
