### PR TITLE
Move-tables post-migration cleanup

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -226,6 +226,7 @@ type MigrationContext struct {
 	UserCommandedUnpostponeFlag            int64
 	CutOverCompleteFlag                    int64
 	InCutOverCriticalSectionFlag           int64
+	MoveTablesSourceRenamedFlag            int64
 	PanicAbort                             chan error
 
 	// Context for cancellation signaling across all goroutines

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -198,15 +198,6 @@ func (apl *Applier) InitDBConnections() (err error) {
 			return err
 		}
 	}
-	if apl.moveTablesConnectionConfig != nil {
-		moveTablesURI := apl.moveTablesConnectionConfig.GetDBUri(apl.migrationContext.GetTargetDatabaseName()) + "&multiStatements=true"
-		if apl.moveTablesTargetDB, _, err = mysql.GetDB(apl.migrationContext.Uuid, moveTablesURI); err != nil {
-			return err
-		}
-		if _, err := base.ValidateConnection(apl.moveTablesTargetDB, apl.moveTablesConnectionConfig, apl.migrationContext, apl.name); err != nil {
-			return err
-		}
-	}
 	apl.migrationContext.Log.Infof("Applier initiated on %+v, version %+v", apl.connectionConfig.ImpliedKey, apl.migrationContext.ApplierMySQLVersion)
 	return nil
 }

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -959,6 +959,10 @@ func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) err
 	if chk == nil || !chk.MoveTablesCutOverStarted || chk.MoveTablesCutOverDrainGTID == nil || chk.MoveTablesCutOverDrainGTID.IsEmpty() {
 		return errors.New("checkpoint does not contain move-tables cutover resume state")
 	}
+	// The checkpoint proves the source RENAME already happened in a prior run, so
+	// `__del` exists on the source. Mark it so a failed resume emits the rollback
+	// hint.
+	atomic.StoreInt64(&mgtr.migrationContext.MoveTablesSourceRenamedFlag, 1)
 	if chk.LastTrxCoords != nil && !chk.LastTrxCoords.IsEmpty() {
 		mgtr.applier.CurrentCoordinatesMutex.Lock()
 		mgtr.applier.CurrentCoordinates = chk.LastTrxCoords.Clone()
@@ -1010,6 +1014,17 @@ func (mgtr *Migrator) MoveTables() (err error) {
 	// After this point, we'll need to teardown anything that's been started
 	// so we don't leave things hanging around
 	defer mgtr.teardown()
+
+	// If the run fails after the source RENAME, the source `__del` table is the
+	// rollback handle. Emit a clear rollback hint on any error return once the
+	// rename has happened. finalCleanup errors are
+	// swallowed below (they return nil), so this never fires on a successful
+	// cutover whose only failure was post-success cleanup.
+	defer func() {
+		if err != nil && atomic.LoadInt64(&mgtr.migrationContext.MoveTablesSourceRenamedFlag) > 0 {
+			mgtr.logMoveTablesRollbackHint()
+		}
+	}()
 
 	if mgtr.migrationContext.Checkpoint && mgtr.migrationContext.Resume {
 		mgtr.migrationContext.ApplierConnectionConfig = mgtr.migrationContext.MoveTables.ConnectionConfig
@@ -1278,6 +1293,10 @@ func (mgtr *Migrator) moveTablesCutOver() (err error) {
 	if _, err := pinnedConn.ExecContext(cutOverCtx, renameQuery); err != nil {
 		return fmt.Errorf("RENAME failed: %w", err)
 	}
+	// The source `__del` table now exists and is the rollback handle. Mark the
+	// rename as done so any later failure emits the rollback hint (and never
+	// drops `__del`).
+	atomic.StoreInt64(&mgtr.migrationContext.MoveTablesSourceRenamedFlag, 1)
 
 	// ----- T2: capture @@gtid_executed on the SAME connection as T1 -----
 	// @@GLOBAL scope is explicit so the intent is unambiguous in the SQL itself.
@@ -2507,36 +2526,28 @@ func (mgtr *Migrator) executeDMLWriteFuncs() error {
 func (mgtr *Migrator) finalCleanup() error {
 	atomic.StoreInt64(&mgtr.migrationContext.CleanupImminentFlag, 1)
 
-	mgtr.migrationContext.Log.Infof("Writing changelog state: %+v", Migrated)
-	if _, err := mgtr.applier.WriteChangelogState(string(Migrated)); err != nil {
-		return err
-	}
+	if !mgtr.migrationContext.IsMoveTablesMode() {
+		mgtr.migrationContext.Log.Infof("Writing changelog state: %+v", Migrated)
+		if _, err := mgtr.applier.WriteChangelogState(string(Migrated)); err != nil {
+			return err
+		}
 
-	if mgtr.migrationContext.Noop {
-		if createTableStatement, err := mgtr.inspector.showCreateTable(mgtr.migrationContext.GetGhostTableName()); err == nil {
-			mgtr.migrationContext.Log.Infof("New table structure follows")
-			fmt.Println(createTableStatement)
-		} else if !mgtr.migrationContext.IsMoveTablesMode() {
-			mgtr.migrationContext.Log.Errore(fmt.Errorf("error showing create table: %w", err))
+		if mgtr.migrationContext.Noop {
+			if createTableStatement, err := mgtr.inspector.showCreateTable(mgtr.migrationContext.GetGhostTableName()); err == nil {
+				mgtr.migrationContext.Log.Infof("New table structure follows")
+				fmt.Println(createTableStatement)
+			} else {
+				mgtr.migrationContext.Log.Errore(fmt.Errorf("error showing create table: %w", err))
+			}
 		}
 	}
+
 	if err := mgtr.eventsStreamer.Close(); err != nil {
 		mgtr.migrationContext.Log.Errore(err)
 	}
 
 	if mgtr.migrationContext.IsMoveTablesMode() {
-		if mgtr.migrationContext.Checkpoint {
-			if mgtr.migrationContext.OkToDropTable {
-				if err := mgtr.retryOperation(mgtr.applier.DropCheckpointTable); err != nil {
-					return err
-				}
-			} else if !mgtr.migrationContext.Noop {
-				mgtr.migrationContext.Log.Infof("Am not dropping checkpoint table without `--ok-to-drop-table`. To drop the checkpoint table, issue:")
-				mgtr.migrationContext.Log.Infof("-- drop table %s.%s", sql.EscapeName(mgtr.migrationContext.GetTargetDatabaseName()), sql.EscapeName(mgtr.migrationContext.GetCheckpointTableName()))
-			}
-		}
-		// for move-tables mode, we're done at this point
-		return nil
+		return mgtr.moveTablesFinalCleanup()
 	}
 
 	if err := mgtr.retryOperation(mgtr.applier.DropChangelogTable); err != nil {
@@ -2564,6 +2575,71 @@ func (mgtr *Migrator) finalCleanup() error {
 	}
 
 	return nil
+}
+
+// moveTablesFinalCleanup handles artifact cleanup after a successful move-tables
+// run. A successful run leaves two artifacts behind:
+// the source `__del` table (the post-cutover rollback handle) and the target
+// checkpoint table. There are no `_ghc`/`__gho` tables in move-tables mode.
+//
+// This runs only on the success path; on failure `__del` is never dropped and
+// survives as the rollback handle (see logMoveTablesRollbackHint).
+func (mgtr *Migrator) moveTablesFinalCleanup() error {
+	sourceDatabaseName := mgtr.migrationContext.DatabaseName
+	delTableName := mgtr.migrationContext.GetOldTableName()
+	targetDatabaseName := mgtr.migrationContext.GetTargetDatabaseName()
+	checkpointTableName := mgtr.migrationContext.GetCheckpointTableName()
+
+	if mgtr.migrationContext.OkToDropTable {
+		// The source `__del` rollback handle only exists after a real cutover,
+		// never in Noop runs. The streamer owns the live source connection in
+		// both the normal and cutover-resume paths (its `db` handle uses the
+		// source config and Close() above only closed the binlog reader), so the
+		// source-side drop goes through it.
+		if !mgtr.migrationContext.Noop {
+			if err := mgtr.retryOperation(mgtr.eventsStreamer.DropSourceOldTable); err != nil {
+				return err
+			}
+		}
+		if mgtr.migrationContext.Checkpoint {
+			if err := mgtr.retryOperation(mgtr.applier.DropCheckpointTable); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if mgtr.migrationContext.Noop {
+		return nil
+	}
+
+	// --ok-to-drop-table not set: log the artifacts left behind and the exact
+	// commands to drop them.
+	mgtr.migrationContext.Log.Infof("Am not dropping move-tables artifacts without `--ok-to-drop-table`. The following are left behind:")
+	mgtr.migrationContext.Log.Infof("- source rollback handle %s.%s. To drop it, issue:", sql.EscapeName(sourceDatabaseName), sql.EscapeName(delTableName))
+	mgtr.migrationContext.Log.Infof("-- drop table %s.%s", sql.EscapeName(sourceDatabaseName), sql.EscapeName(delTableName))
+	if mgtr.migrationContext.Checkpoint {
+		mgtr.migrationContext.Log.Infof("- target checkpoint table %s.%s. To drop it, issue:", sql.EscapeName(targetDatabaseName), sql.EscapeName(checkpointTableName))
+		mgtr.migrationContext.Log.Infof("-- drop table %s.%s", sql.EscapeName(targetDatabaseName), sql.EscapeName(checkpointTableName))
+	}
+	return nil
+}
+
+// logMoveTablesRollbackHint prints a clear rollback hint after a failed
+// move-tables run in which the source RENAME already happened. The source
+// `__del` table is intentionally left in place as the rollback handle
+// and the operator rolls the source back by renaming
+// `__del` to the original table name. We do NOT drop `__del` on a failure path.
+func (mgtr *Migrator) logMoveTablesRollbackHint() {
+	sourceDatabaseName := mgtr.migrationContext.DatabaseName
+	originalTableName := mgtr.migrationContext.OriginalTableName
+	delTableName := mgtr.migrationContext.GetOldTableName()
+	mgtr.migrationContext.Log.Infof("move-tables run failed after the source rename; leaving %s.%s in place as the rollback handle.",
+		sql.EscapeName(sourceDatabaseName), sql.EscapeName(delTableName))
+	mgtr.migrationContext.Log.Infof("To roll back the source table, issue:")
+	mgtr.migrationContext.Log.Infof("-- rename table %s.%s to %s.%s",
+		sql.EscapeName(sourceDatabaseName), sql.EscapeName(delTableName),
+		sql.EscapeName(sourceDatabaseName), sql.EscapeName(originalTableName))
 }
 
 func (mgtr *Migrator) teardown() {

--- a/go/logic/migrator_move_tables_cleanup_test.go
+++ b/go/logic/migrator_move_tables_cleanup_test.go
@@ -1,0 +1,71 @@
+package logic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/github/gh-ost/go/base"
+)
+
+// capturingLogger records Infof messages so tests can assert on the operator
+// commands emitted by the move-tables cleanup path. It embeds base.Logger so it
+// only needs to override the one method the tests care about.
+type capturingLogger struct {
+	base.Logger
+	infofs []string
+}
+
+func (l *capturingLogger) Infof(format string, args ...interface{}) {
+	l.infofs = append(l.infofs, fmt.Sprintf(format, args...))
+}
+
+func (l *capturingLogger) has(substr string) bool {
+	for _, line := range l.infofs {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func newCleanupTestMigrator() (*Migrator, *capturingLogger) {
+	logger := &capturingLogger{Logger: base.NewDefaultLogger()}
+	mc := base.NewMigrationContext()
+	mc.Log = logger
+	mc.DatabaseName = "source_db"
+	mc.OriginalTableName = "t"
+	mc.MoveTables.TableNames = []string{"t"}
+	mc.MoveTables.TargetDatabase = "target_db"
+	return NewMigrator(mc, "test"), logger
+}
+
+// TestMoveTablesFinalCleanup_EmitsOperatorCommands verifies that without
+// --ok-to-drop-table, cleanup drops nothing and instead logs the exact
+// `drop table` commands for the source rollback handle and the target
+// checkpoint table. The applier/streamer are nil, so any real drop would panic.
+func TestMoveTablesFinalCleanup_EmitsOperatorCommands(t *testing.T) {
+	m, logger := newCleanupTestMigrator()
+	m.migrationContext.OkToDropTable = false
+	m.migrationContext.Checkpoint = true
+
+	require.NoError(t, m.moveTablesFinalCleanup())
+
+	require.True(t, logger.has("-- drop table `source_db`.`_t_del`"),
+		"must emit the command to drop the source rollback handle")
+	require.True(t, logger.has("-- drop table `target_db`.`_t_ghk`"),
+		"must emit the command to drop the target checkpoint table")
+}
+
+// TestLogMoveTablesRollbackHint_EmitsRenameCommand verifies the failure-path
+// hint emits the exact rename command to roll the source table back.
+func TestLogMoveTablesRollbackHint_EmitsRenameCommand(t *testing.T) {
+	m, logger := newCleanupTestMigrator()
+
+	m.logMoveTablesRollbackHint()
+
+	require.True(t, logger.has("-- rename table `source_db`.`_t_del` to `source_db`.`t`"),
+		"must emit the rename command to roll the source table back")
+}

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/binlog"
 	"github.com/github/gh-ost/go/mysql"
+	"github.com/github/gh-ost/go/sql"
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/openark/golib/sqlutils"
@@ -237,6 +238,32 @@ func (es *EventsStreamer) Close() (err error) {
 	err = es.binlogReader.Close()
 	es.migrationContext.Log.Infof("Closed streamer connection. err=%+v", err)
 	return err
+}
+
+// DropSourceOldTable drops the source "__del" table in move-tables mode. The
+// __del table is the post-cutover rollback handle on the source cluster; it is
+// only dropped after a successful run when --ok-to-drop-table is set.
+// The applier's dropTable targets the move-tables target cluster,
+// so the source-side drop is owned by the streamer: its `db`
+// handle uses InspectorConnectionConfig (the source) and stays open in both the
+// normal and the cutover-resume paths (Close() only closes the binlog reader,
+// not `db`).
+func (es *EventsStreamer) DropSourceOldTable() error {
+	databaseName := es.migrationContext.DatabaseName
+	tableName := es.migrationContext.GetOldTableName()
+	query := fmt.Sprintf(`drop /* gh-ost */ table if exists %s.%s`,
+		sql.EscapeName(databaseName),
+		sql.EscapeName(tableName),
+	)
+	es.migrationContext.Log.Infof("Dropping source table %s.%s",
+		sql.EscapeName(databaseName),
+		sql.EscapeName(tableName),
+	)
+	if _, err := sqlutils.ExecNoPrepare(es.db, query); err != nil {
+		return err
+	}
+	es.migrationContext.Log.Infof("Source table dropped")
+	return nil
 }
 
 func (es *EventsStreamer) Teardown() {


### PR DESCRIPTION
closes https://github.com/github/database-infrastructure/issues/8213

## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/gh-ost/issues/0123456789

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR fixes up some move-table post-run cleanup logic. It follows the design doc and meets the requirements:

- When --ok-to-drop-table is set, drop _<table>_del on source and drop the checkpoint table on target after on-success.
- When --ok-to-drop-table is not set, log the artifacts left behind and the exact commands to drop them.
- On failure, leave _<table>_del in place — it is the rollback handle.

### Demo showing those three things


https://github.com/user-attachments/assets/1923720d-047c-4fda-9067-515e162b0c63


> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
