### PR TITLE
Set drain-gtid when resuming in move-tables mode

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -980,6 +980,7 @@ func (mgtr *Migrator) resumeMoveTablesCutOverFromCheckpoint(chk *Checkpoint) err
 	}
 	atomic.StoreInt64(&mgtr.migrationContext.CutOverCompleteFlag, 1)
 	mgtr.migrationContext.Log.Debugf("T4: CutOverCompleteFlag set")
+	mgtr.migrationContext.MoveTables.DrainGTID = chk.MoveTablesCutOverDrainGTID
 	if err := mgtr.hooksExecutor.OnSuccess(false); err != nil {
 		return fmt.Errorf("on-success hook failed: %w", err)
 	}


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/gh-ost/issues/1681
Related issue (internal): https://github.com/github/database-infrastructure/issues/8261

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR sets the drain-GTID when resuming gh-ost in move-tables mode.
The value is forwarded to the gh-ost hook scripts.

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
