### PR TITLE
fix: strip trailing semicolon from ALTER statement options

### DIFF
--- a/go/sql/parser.go
+++ b/go/sql/parser.go
@@ -150,6 +150,11 @@ func (atp *AlterTableParser) ParseAlterStatement(alterStatement string) (err err
 			break
 		}
 	}
+	// Strip any trailing statement terminator. A trailing semicolon would
+	// otherwise be carried into alterStatementOptions and, when the options are
+	// spliced into a larger statement (e.g. appending ", ALGORITHM=INSTANT"),
+	// break it into two statements under multiStatements=true.
+	atp.alterStatementOptions = strings.TrimRight(atp.alterStatementOptions, "; \t\r\n")
 	for _, alterToken := range atp.tokenizeAlterStatement(atp.alterStatementOptions) {
 		alterToken = atp.sanitizeQuotesFromAlterStatement(alterToken)
 		atp.parseAlterToken(alterToken)

--- a/go/sql/parser_test.go
+++ b/go/sql/parser_test.go
@@ -26,6 +26,27 @@ func TestParseAlterStatement(t *testing.T) {
 	require.False(t, parser.IsAutoIncrementDefined())
 }
 
+func TestParseAlterStatementTrailingSemicolon(t *testing.T) {
+	statements := []string{
+		"add column t int;",
+		"add column t int ;",
+		"add column t int;  \t\r\n",
+		"ADD KEY idx_username (`username`);",
+	}
+	expected := []string{
+		"add column t int",
+		"add column t int",
+		"add column t int",
+		"ADD KEY idx_username (`username`)",
+	}
+	for i, statement := range statements {
+		parser := NewAlterTableParser()
+		err := parser.ParseAlterStatement(statement)
+		require.NoError(t, err)
+		require.Equal(t, expected[i], parser.alterStatementOptions)
+	}
+}
+
 func TestParseAlterStatementrivialRename(t *testing.T) {
 	statement := "add column t int, change ts ts timestamp, engine=innodb"
 	parser := NewAlterTableParser()


### PR DESCRIPTION
A trailing semicolon in the ALTER statement was carried into alterStatementOptions by the greedy (.*$) capture and never trimmed. When those options are spliced into a larger statement (e.g. appending ", ALGORITHM=INSTANT" in generateInstantDDLQuery) the semicolon lands mid-statement. With multiStatements=true on the applier connection this turns one INSTANT DDL into two statements, silently degrading to a native online DDL and, on error, falling back to the full copy.

Trim the trailing terminator once in ParseAlterStatement so the options stay a clean fragment.