### PR TITLE
docs: correct spelling

### DIFF
--- a/doc/coding-ghost.md
+++ b/doc/coding-ghost.md
@@ -16,7 +16,7 @@ If additional steps are needed, please add them into this workflow so that the w
 
 ## `golang-ci` linter
 
-To enfore best-practices, Pull Requests are automatically linted by [`golang-ci`](https://golangci-lint.run/). The linter config is located at [`.golangci.yml`](https://github.com/github/gh-ost/blob/master/.golangci.yml) and the `golangci-lint` GitHub Action is located at [`.github/workflows/golangci-lint.yml`](https://github.com/github/gh-ost/blob/master/.github/workflows/golangci-lint.yml).
+To enforce best-practices, Pull Requests are automatically linted by [`golang-ci`](https://golangci-lint.run/). The linter config is located at [`.golangci.yml`](https://github.com/github/gh-ost/blob/master/.golangci.yml) and the `golangci-lint` GitHub Action is located at [`.github/workflows/golangci-lint.yml`](https://github.com/github/gh-ost/blob/master/.github/workflows/golangci-lint.yml).
 
 To run the `golang-ci` linters locally _(recommended before push)_, use `script/lint`.
 


### PR DESCRIPTION
### Description

Fix typo in `doc/coding-ghost.md:19`: `enfore` ==> `enforce`
