### PR TITLE
Handle context cancellation while waiting for ghost table migration

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -267,6 +267,22 @@ func (mgtr *Migrator) consumeRowCopyComplete() {
 	}()
 }
 
+// waitForGhostTableMigrated blocks until the ghost table has been migrated, or
+// until the migration context is cancelled by an abort. The only sender on
+// ghostTableMigrated publishes via base.SendWithContext, which stops sending
+// once the context is cancelled, so waiting on the channel alone would block
+// forever after an abort.
+func (mgtr *Migrator) waitForGhostTableMigrated() error {
+	select {
+	case <-mgtr.ghostTableMigrated:
+		mgtr.migrationContext.Log.Debugf("ghost table migrated")
+		return nil
+	case <-mgtr.migrationContext.GetContext().Done():
+		// Abort cancelled the context
+		return mgtr.checkAbort()
+	}
+}
+
 func (mgtr *Migrator) canStopStreaming() bool {
 	return atomic.LoadInt64(&mgtr.migrationContext.CutOverCompleteFlag) != 0
 }
@@ -554,8 +570,9 @@ func (mgtr *Migrator) Migrate() (err error) {
 	initialLag, _ := mgtr.inspector.getReplicationLag()
 	if !mgtr.migrationContext.Resume {
 		mgtr.migrationContext.Log.Infof("Waiting for ghost table to be migrated. Current lag is %+v", initialLag)
-		<-mgtr.ghostTableMigrated
-		mgtr.migrationContext.Log.Debugf("ghost table migrated")
+		if err := mgtr.waitForGhostTableMigrated(); err != nil {
+			return err
+		}
 	}
 	// Yay! We now know the Ghost and Changelog tables are good to examine!
 	// When running on replica, this means the replica has those tables. When running

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -1566,6 +1566,63 @@ func TestAbort_DuringInspection(t *testing.T) {
 	}
 }
 
+func TestAbort_DuringGhostTableWait(t *testing.T) {
+	migrationContext := base.NewMigrationContext()
+	migrator := NewMigrator(migrationContext, "1.0.0")
+
+	// Start listenOnPanicAbort
+	go migrator.listenOnPanicAbort()
+
+	// Give listenOnPanicAbort time to start
+	time.Sleep(20 * time.Millisecond)
+
+	// Simulate an abort raised while Migrate() waits for the ghost table
+	testErr := errors.New("ghost table wait aborted")
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		select {
+		case migrationContext.PanicAbort <- testErr:
+		case <-migrationContext.GetContext().Done():
+		}
+	}()
+
+	// Nothing sends on ghostTableMigrated, mirroring an abort that cancels the
+	// context before the changelog event arrives: the real sender publishes via
+	// base.SendWithContext, which stops sending once the context is cancelled.
+	// Waiting on the channel alone would block here forever.
+	done := make(chan error, 1)
+	go func() {
+		done <- migrator.waitForGhostTableMigrated()
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Expected an error once the abort cancelled the context")
+		}
+		if err.Error() != "ghost table wait aborted" {
+			t.Errorf("Expected 'ghost table wait aborted', got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Expected waitForGhostTableMigrated to return after the abort cancelled the context")
+	}
+}
+
+func TestWaitForGhostTableMigrated(t *testing.T) {
+	migrationContext := base.NewMigrationContext()
+	migrator := NewMigrator(migrationContext, "1.0.0")
+
+	// ghostTableMigrated is unbuffered, so the send must be async
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		migrator.ghostTableMigrated <- true
+	}()
+
+	if err := migrator.waitForGhostTableMigrated(); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
 func TestAbort_DuringStreaming(t *testing.T) {
 	migrationContext := base.NewMigrationContext()
 	migrator := NewMigrator(migrationContext, "1.0.0")


### PR DESCRIPTION
### Description

`Migrate()` blocks on an unbuffered receive from `ghostTableMigrated` while waiting for the ghost table to be created:

```go
mgtr.migrationContext.Log.Infof("Waiting for ghost table to be migrated. Current lag is %+v", initialLag)
<-mgtr.ghostTableMigrated
```

The only sender is `onChangelogStateEvent()`, which publishes via `base.SendWithContext()`. If the migration aborts during this window, `abort()` cancels the migration context, so `SendWithContext()` takes its `ctx.Done()` branch and returns *without ever sending*. Nothing else writes to the channel, so `Migrate()` blocks forever:

- `Migrate()` never returns, so its deferred `teardown()` never runs
- `finishedMigrating` is therefore never set
- the status and throttler tickers exit on `finishedMigrating` rather than on the context, so they keep looping

The result is a process that has already decided to abort but stays alive indefinitely, logging a frozen status line, until it is killed externally. This is the same type of deadlock, and the same fix, as #1677 applied to `consumeRowCopyComplete()` — `ghostTableMigrated` is its remaining sibling.

### Change

Extract the wait into `waitForGhostTableMigrated()` and select on the migration context alongside the channel, returning `checkAbort()` so the original abort error is surfaced rather than a bare context error. The extraction mirrors `consumeRowCopyComplete()` and makes the behaviour testable without a database.

`TestAbort_DuringGhostTableWait` follows the existing `TestAbort_*` convention and blocks until its timeout (i.e. fails) without this change; `TestWaitForGhostTableMigrated` covers the normal path.

### Possibly related

Not claiming these are fixed by this change — their root causes aren't established, and this only addresses hangs caused by an abort cancelling the context during the wait — but they are reports of hanging at this exact point, so noting them for reference: #884, #380. #1735 concerns the same `ghostTableMigrated` channel in a different scenario.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.

On `script/cibuild`: formatting, build, and all unit tests pass. The three testcontainers-based suites (`TestApplier`, `TestMigrator`, `TestEventsStreamer`) cannot run in my environment — no rootless Docker provider — and fail identically on unmodified `master`, so they are unaffected by this change and left to CI.
