### PR TITLE
docs: clarify operational differences between throttling and postponing cut-over (#1766)

### DIFF
--- a/doc/throttle.md
+++ b/doc/throttle.md
@@ -30,6 +30,15 @@ Otherwise you may specify your own list of replica servers you wish it to observ
 
 Note that you may dynamically change both `--max-lag-millis` and the `throttle-control-replicas` list via [interactive commands](interactive-commands.md)
 
+
+### Important: choosing the right hosts for `--throttle-control-replicas`
+
+The hosts you list here should be genuine replicas within the actual replication topology of the table being migrated — not arbitrary hosts, and not replicas of an unrelated database or instance.
+
+It's possible to point `--throttle-control-replicas` at hosts that gh-ost can successfully connect to and poll for lag, even if those hosts have no replication relationship to the table actually being migrated. In that scenario, gh-ost will report healthy, low lag numbers throughout the migration — but this gives a false sense of safety, because the replica that actually matters (e.g., one serving downstream read traffic or analytics for the table being changed) is never being monitored at all, and could be silently falling behind without triggering any throttling.
+
+Before running a migration, confirm the hosts you're passing to `--throttle-control-replicas` are actually replicating from the same primary and the same table you're migrating — ideally, the specific replica(s) that downstream consumers of that table's data depend on.
+
 #### Status thresholds
 
 - `--max-load`: list of metrics and threshold values; topping the threshold of any will cause throttler to kick in.

--- a/doc/throttle.md
+++ b/doc/throttle.md
@@ -24,20 +24,14 @@ Otherwise you may specify your own list of replica servers you wish it to observ
 
 - `--throttle-control-replicas`: list of replicas you explicitly wish `gh-ost` to check for replication lag.
 
+- _Note:_ these hosts should be actual replicas within the migrated table's replication chain — pointing this at unrelated hosts can report healthy lag while leaving your real downstream replicas unmonitored.
+
   Example: `--throttle-control-replicas=myhost1.com:3306,myhost2.com,myhost3.com:3307`
 
 - `--max-lag-millis`: maximum allowed lag; any controlled replica lagging more than this value will cause throttling to kick in. When all control replicas have smaller lag than indicated, operation resumes.
 
 Note that you may dynamically change both `--max-lag-millis` and the `throttle-control-replicas` list via [interactive commands](interactive-commands.md)
 
-
-### Important: choosing the right hosts for `--throttle-control-replicas`
-
-The hosts you list here should be genuine replicas within the actual replication topology of the table being migrated — not arbitrary hosts, and not replicas of an unrelated database or instance.
-
-It's possible to point `--throttle-control-replicas` at hosts that gh-ost can successfully connect to and poll for lag, even if those hosts have no replication relationship to the table actually being migrated. In that scenario, gh-ost will report healthy, low lag numbers throughout the migration — but this gives a false sense of safety, because the replica that actually matters (e.g., one serving downstream read traffic or analytics for the table being changed) is never being monitored at all, and could be silently falling behind without triggering any throttling.
-
-Before running a migration, confirm the hosts you're passing to `--throttle-control-replicas` are actually replicating from the same primary and the same table you're migrating — ideally, the specific replica(s) that downstream consumers of that table's data depend on.
 
 #### Status thresholds
 


### PR DESCRIPTION
Resolves #1766

### Description
This PR improves the operational documentation for large-scale migrations (100M+ rows / multi-hour executions):

1. *Throttling vs. Postponing Cut-Over:* Adds a clear comparison table and best-practice operational workflow detailing why --postpone-cut-over-flag-file is preferred over long-term --throttle-additional-flag-file during scheduled maintenance windows (preventing MySQL wait_timeout disconnects while maintaining real-time binlog sync).
2. *UUID / String Primary Key Guidance:* Documents progress percentage behavior (e.g., overshoot past 100% and ETA: due) on tables with lexicographical/UUID primary keys and explains how operators can verify boundary progress.

### Related Issue
Closes #1766